### PR TITLE
feat: Add spread analysis to simulator results

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -323,6 +323,13 @@
       </div>
     </div>
 
+    <!-- Spread analysis -->
+    <div class="bg-white rounded-xl border border-gray-200 p-5">
+      <h3 class="font-semibold text-gray-700 mb-1 text-sm">Minimum Spread Analysis</h3>
+      <p class="text-xs text-gray-400 mb-3">Based on simulator RTE and degradation cost.</p>
+      <div id="spread-analysis-sim" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
+    </div>
+
     <!-- Charts -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div class="bg-gray-50 rounded-xl border border-gray-200 p-4">
@@ -960,7 +967,7 @@ function renderTips(tips) {
 // ══════════════════════════════════════════════════════════════════
 // SPREAD ANALYSIS
 // ══════════════════════════════════════════════════════════════════
-function renderSpreadAnalysis(bc, opts, prices) {
+function renderSpreadAnalysis(bc, opts, prices, targetId) {
   const rte    = bc.round_trip_efficiency || 0.9;
   const sqrtRte= Math.sqrt(rte);
   const degrad = opts.degradation_cost_per_kwh || 0.03;
@@ -973,7 +980,7 @@ function renderSpreadAnalysis(bc, opts, prices) {
   const deltaMin= rteLoss + degLoss;
   const profitable = spread >= deltaMin;
 
-  const el = document.getElementById('spread-analysis');
+  const el = document.getElementById(targetId || 'spread-analysis');
   el.innerHTML = `
     <div class="space-y-2 text-sm">
       <div class="kv-row"><span class="kv-label">Forecast price range</span>
@@ -1493,6 +1500,13 @@ function runSimulator() {
           <td class="border border-gray-200 px-2 py-1 font-medium ${ok?'text-green-700':'text-red-700'}">${ok?'✓ YES':'✗ NO'}</td>`;
         wbody.appendChild(tr2);
       });
+
+      renderSpreadAnalysis(
+        { round_trip_efficiency: p.rte, max_soc_kwh: p.maxSocKwh },
+        { degradation_cost_per_kwh: p.degradation },
+        price,
+        'spread-analysis-sim'
+      );
 
       document.getElementById('sim-results').classList.remove('hidden');
     } catch(e) {


### PR DESCRIPTION
## Description

This PR adds a "Minimum Spread Analysis" section to the simulator results display. The spread analysis now renders in the simulation results panel, showing the same profitability metrics (forecast price range, RTE loss, degradation loss, minimum spread, and profitability status) that were previously only available in the main analysis section.

### Changes Made

1. **UI Enhancement**: Added a new "Minimum Spread Analysis" card in the simulator results section that displays spread analysis based on the simulator's RTE and degradation cost parameters.

2. **Function Refactoring**: Modified `renderSpreadAnalysis()` to accept an optional `targetId` parameter, allowing the function to render to different DOM elements. This enables reuse of the same analysis logic for both the main analysis and simulator results.

3. **Simulator Integration**: After running a simulation, the spread analysis is now automatically rendered to the new `spread-analysis-sim` container using the simulator's specific RTE and degradation cost values.

## Type of change

- [x] `feat:` New feature (minor version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Documentation updated (HTML structure added)
- [x] Change is straightforward and self-contained

## Test Plan

The spread analysis rendering can be verified by:
1. Running a simulation with custom RTE and degradation cost parameters
2. Confirming the "Minimum Spread Analysis" section appears in the results
3. Verifying the displayed metrics match the simulator inputs and expected calculations