### PR TITLE
fix: oscillation filter incorrectly removes charge blocks with 15-min…

### DIFF
--- a/custom_components/battery_controller/optimizer.py
+++ b/custom_components/battery_controller/optimizer.py
@@ -907,10 +907,19 @@ def _filter_oscillations(
             + to_export_kw * feed_in_forecast[timestep]
         ) / total_kw
 
-    # Lookahead window: use first step duration as representative interval.
-    # The first step may be shorter (partial interval), making the window
-    # slightly larger in step count — this is conservative and safe.
-    ref_step_h = step_durations_hours[0] if step_durations_hours else 0.25
+    # Lookahead window: use the full interval step (index 1), not the partial
+    # first step (index 0).  The first step is artificially shortened to align
+    # with the current price-period boundary (e.g. 1 minute when running just
+    # before a 15-min tick).  Using it would inflate lookahead_steps by up to
+    # 15× for quarter-hour data (round(2.0 / 0.017) = 120 instead of 8),
+    # causing the filter to scan the entire 36-h horizon and pair charge steps
+    # with distant, unrelated discharge steps — incorrectly suppressing whole
+    # charge blocks.
+    ref_step_h = (
+        step_durations_hours[1]
+        if len(step_durations_hours) > 1
+        else (step_durations_hours[0] if step_durations_hours else 0.25)
+    )
     lookahead_steps = max(1, round(oscillation_window_hours / ref_step_h))
 
     # Iterative scan: repeat until convergence so that suppressing one step
@@ -922,29 +931,49 @@ def _filter_oscillations(
         i = 0
         while i < len(filtered_mode) - 1:
             if filtered_mode[i] == ACTION_CHARGING:
-                # Look ahead for quick discharge
+                # Look ahead for a discharge within the oscillation window.
+                # Evaluate ALL discharges in the window: only suppress the
+                # charge if every discharge found is unprofitable.  Stopping
+                # at the *nearest* discharge was wrong for quarter-hour data:
+                # the DP can produce a complex schedule where a small
+                # intermediate discharge (low spread) precedes the main
+                # discharge (high spread).  Breaking on the first discharge
+                # caused the charge to be removed even though a profitable
+                # pairing existed slightly further in the window.
+                charge_cost = get_charge_cost(i, max(filtered_power[i], 0.0))
+                has_discharge_in_window = False
+                has_profitable_discharge = False
                 for j in range(i + 1, min(i + lookahead_steps + 1, len(filtered_mode))):
                     if filtered_mode[j] == ACTION_DISCHARGING:
-                        charge_cost = get_charge_cost(i, max(filtered_power[i], 0.0))
+                        has_discharge_in_window = True
                         discharge_price = get_discharge_value(j, abs(filtered_power[j]))
                         effective_spread = discharge_price - charge_cost / rte
-                        if effective_spread < min_arbitrage_spread:
-                            filtered_power[i] = 0.0
-                            filtered_mode[i] = ACTION_IDLE
-                            changed = True
-                        break
+                        if effective_spread >= min_arbitrage_spread:
+                            has_profitable_discharge = True
+                            break
+                if has_discharge_in_window and not has_profitable_discharge:
+                    filtered_power[i] = 0.0
+                    filtered_mode[i] = ACTION_IDLE
+                    changed = True
             elif filtered_mode[i] == ACTION_DISCHARGING:
-                # Look ahead for quick charge
+                # Look ahead for a charge within the oscillation window.
+                # Same logic: suppress only if every charge in the window
+                # would make this discharge unprofitable.
+                discharge_price = get_discharge_value(i, abs(filtered_power[i]))
+                has_charge_in_window = False
+                has_profitable_charge = False
                 for j in range(i + 1, min(i + lookahead_steps + 1, len(filtered_mode))):
                     if filtered_mode[j] == ACTION_CHARGING:
-                        discharge_price = get_discharge_value(i, abs(filtered_power[i]))
+                        has_charge_in_window = True
                         charge_cost = get_charge_cost(j, max(filtered_power[j], 0.0))
                         effective_spread = discharge_price - charge_cost / rte
-                        if effective_spread < min_arbitrage_spread:
-                            filtered_power[i] = 0.0
-                            filtered_mode[i] = ACTION_IDLE
-                            changed = True
-                        break
+                        if effective_spread >= min_arbitrage_spread:
+                            has_profitable_charge = True
+                            break
+                if has_charge_in_window and not has_profitable_charge:
+                    filtered_power[i] = 0.0
+                    filtered_mode[i] = ACTION_IDLE
+                    changed = True
             i += 1
 
     return _rebuild_schedule(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -785,6 +785,134 @@ class TestOscillationPrevention:
         assert soc[1] == 5.0
 
 
+class TestQuarterHourOscillationFilter:
+    """Regression tests for oscillation filter with quarter-hour price data.
+
+    Bug: with 15-min price data, step_durations_hours[0] can be very short
+    (e.g. 1 min when the optimizer runs just before a price boundary).  Using
+    it as ref_step_h inflated lookahead_steps up to 120, causing the filter to
+    scan the entire 36-h horizon and incorrectly pair charge steps with distant
+    unrelated discharges — removing profitable charge blocks so only single
+    15-min slots survived.
+
+    Additionally, the filter only evaluated the *nearest* discharge in the
+    window.  An intermediate low-spread discharge would wrongly suppress a
+    charge whose actual profitable match was slightly further in the window.
+    """
+
+    def test_charge_block_preserved_with_short_first_step(self):
+        """Charge block must not be removed when first step is very short (1 min).
+
+        Simulates the optimizer running 1 minute before a price boundary.
+        Before the fix, lookahead_steps = round(2.0 / 0.017) = 120 which
+        covered the entire 96-step horizon, causing charge blocks to be
+        paired with distant, low-spread discharges and incorrectly removed.
+        """
+        from custom_components.battery_controller.optimizer import _filter_oscillations
+
+        n = 16
+        # Steps 0-3: cheap (4 ct), steps 4-7: idle, steps 8-15: expensive (25 ct)
+        prices = [0.04] * 4 + [0.14] * 4 + [0.25] * 8
+        power = [3.0] * 4 + [0.0] * 4 + [-3.0] * 8
+        mode = ["charging"] * 4 + ["idle"] * 4 + ["discharging"] * 8
+
+        # First step is 1 minute (= 0.017 h); rest are full 15-min steps
+        step_durations = [1 / 60] + [0.25] * (n - 1)
+
+        filtered_power, filtered_mode, _ = _filter_oscillations(
+            power_schedule_kw=power,
+            mode_schedule=mode,
+            initial_soc_kwh=2.0,
+            price_forecast=prices,
+            min_price_spread=0.05,
+            degradation_cost_per_kwh=0.03,
+            rte=0.9,
+            step_durations_hours=step_durations,
+            min_soc_kwh=1.0,
+            max_soc_kwh=10.0,
+        )
+
+        # Profitable charge steps (spread = 25 - 4/0.9 ≈ 20.6 ct >> threshold)
+        # must not be suppressed regardless of the short first step.
+        assert filtered_mode[0] == "charging", "charge step 0 wrongly suppressed"
+        assert filtered_mode[1] == "charging", "charge step 1 wrongly suppressed"
+        assert filtered_mode[2] == "charging", "charge step 2 wrongly suppressed"
+        assert filtered_mode[3] == "charging", "charge step 3 wrongly suppressed"
+
+    def test_charge_block_preserved_with_intermediate_low_spread_discharge(self):
+        """Charge block must survive when an intermediate nearby discharge has low spread.
+
+        Before the fix the filter broke on the *first* discharge found.  An
+        intermediate discharge at a small spread caused the charge to be
+        removed, even though a profitable discharge appeared a few steps later
+        within the same lookahead window.
+        """
+        from custom_components.battery_controller.optimizer import _filter_oscillations
+
+        n = 16
+        # Step 0: charge at 4 ct
+        # Step 2: small discharge at 7 ct (spread 7-4/0.9 ≈ 2.6 ct < threshold)
+        # Step 8: big discharge at 25 ct (spread 25-4/0.9 ≈ 20.6 ct >> threshold)
+        prices = [0.04, 0.04, 0.07, 0.04, 0.04, 0.04, 0.04, 0.04, 0.25] + [0.25] * 7
+        power = [3.0, 3.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0] + [-3.0] * 8
+        mode = (
+            ["charging", "charging", "discharging"] + ["idle"] * 5 + ["discharging"] * 8
+        )
+        step_durations = [0.25] * n
+
+        filtered_power, filtered_mode, _ = _filter_oscillations(
+            power_schedule_kw=power,
+            mode_schedule=mode,
+            initial_soc_kwh=2.0,
+            price_forecast=prices,
+            min_price_spread=0.05,
+            degradation_cost_per_kwh=0.03,
+            rte=0.9,
+            step_durations_hours=step_durations,
+            min_soc_kwh=1.0,
+            max_soc_kwh=10.0,
+        )
+
+        # The charge steps 0 and 1 have a profitable discharge at step 8
+        # (spread ≈ 20.6 ct >> 11.6 ct threshold). They must be kept even
+        # though the nearest discharge at step 2 has an insufficient spread.
+        assert filtered_mode[0] == "charging", (
+            "charge step 0 wrongly suppressed by intermediate low-spread discharge"
+        )
+        assert filtered_mode[1] == "charging", (
+            "charge step 1 wrongly suppressed by intermediate low-spread discharge"
+        )
+
+    def test_true_oscillation_still_removed(self):
+        """Rapid charge→discharge with no profitable match must still be suppressed."""
+        from custom_components.battery_controller.optimizer import _filter_oscillations
+
+        n = 8
+        # All discharges have very small spread vs the charges → true oscillation
+        prices = [0.04, 0.05, 0.04, 0.05, 0.04, 0.05, 0.04, 0.05]
+        power = [3.0, -1.0, 3.0, -1.0, 3.0, -1.0, 3.0, -1.0]
+        mode = ["charging", "discharging"] * 4
+        step_durations = [0.25] * n
+
+        filtered_power, filtered_mode, _ = _filter_oscillations(
+            power_schedule_kw=power,
+            mode_schedule=mode,
+            initial_soc_kwh=5.0,
+            price_forecast=prices,
+            min_price_spread=0.05,
+            degradation_cost_per_kwh=0.03,
+            rte=0.9,
+            step_durations_hours=step_durations,
+            min_soc_kwh=1.0,
+            max_soc_kwh=10.0,
+        )
+
+        charge_count = sum(1 for m in filtered_mode if m == "charging")
+        assert charge_count == 0, (
+            f"True oscillations should be suppressed, but {charge_count} charge steps remain"
+        )
+
+
 class TestMicroCycleFilter:
     """Tests for micro-cycle post-processing."""
 


### PR DESCRIPTION
Two bugs in _filter_oscillations caused isolated single-slot charge/discharge with quarter-hour price data while hourly data worked correctly:

1. ref_step_h used step_durations_hours[0] (the partial first step) instead of the full interval step. When the optimizer runs 1-2 min before a price boundary, this inflated lookahead_steps from 8 to ~120, covering the entire 36-h horizon instead of the intended 2-h window.

2. The filter broke on the *nearest* discharge found in the window. An intermediate discharge with a low spread caused the preceding charge to be removed, even when a profitable discharge existed slightly further in the same window.

Fix 1: use step_durations_hours[1] as ref_step_h (the representative full interval), keeping lookahead_steps at 8 steps for 15-min data.

Fix 2: scan all discharges (charges) within the window; only suppress a charge (discharge) step if no profitable pairing exists anywhere in the window. True rapid oscillations with no profitable match are still correctly removed.

Adds three regression tests covering both scenarios.


## Description

<!-- Briefly describe what this PR does and why -->

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

<!-- Add relevant screenshots or log output -->