### PR TITLE
Optimizer improvements: continuous forward pass, SoC resolution, efficiency corrections

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -10,7 +10,7 @@ battery_controller/
 │   ├── forecast_models.py    # PV model, consumption pattern, historical price model
 │   ├── battery_model.py      # Physics: RTE split, SoC limits, power constraints
 │   ├── config_flow.py        # Setup + options flow (sections with collapsed panels)
-│   ├── const.py              # SOC_RESOLUTION_WH=100Wh, POWER_STEP_W=500W, config keys
+│   ├── const.py              # SOC_RESOLUTION_WH=10Wh, POWER_STEP_W=100W, config keys
 │   ├── sensor.py / number.py / select.py / switch.py / binary_sensor.py
 │   ├── helpers.py            # Price extraction (Nordpool/ENTSO-E/generic formats)
 │   ├── manifest.json         # domain, version, requirements: [aiohttp]
@@ -25,7 +25,7 @@ battery_controller/
 3. **OptimizationCoordinator** (15 min) — runs DP optimizer + zero-grid controller; depends on (2)
 
 ## Core algorithm (optimizer.py)
-- State space: time steps × SoC states (100 Wh resolution) × power actions (500 W steps)
+- State space: time steps × SoC states (10 Wh resolution) × power actions (100 W steps)
 - Backward pass: `V[t][s] = min(step_cost + V[t+1][s'])` for all actions
 - Forward pass: execute `best_action[t][current_soc_state]`
 - Terminal condition: `V[T][s] = -(soc_kwh × feed_in_price_T)` — prevents horizon-end discharge

--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -83,7 +83,7 @@ n_soc_states = round((max_soc_wh - min_soc_wh) / soc_resolution_wh) + 1
 soc_states[i] = min_soc_wh + i × soc_resolution_wh
 ```
 
-- **`SOC_RESOLUTION_WH`** (default: 25 Wh) is the only grid constant; the power step is derived from it.
+- **`SOC_RESOLUTION_WH`** (default: 10 Wh) is the only grid constant; the power step is derived from it.
 - SoC boundaries are rounded to the nearest Wh to prevent floating-point comparison errors (e.g. `212.0 < 212.00000000000003`).
 
 ### 3.2 Power Action Grid
@@ -91,8 +91,8 @@ soc_states[i] = min_soc_wh + i × soc_resolution_wh
 The power step uses `POWER_STEP_W` as a practical minimum to prevent unprofitable trickle actions at near-marginal prices. The aligned step ensures the smallest action crosses at least one SoC state:
 
 ```
-aligned_step_w   = soc_resolution_wh / full_step_hours   (e.g. 25 Wh / 1 h = 25 W)
-power_step_w     = max(POWER_STEP_W, aligned_step_w)      (e.g. max(100, 25) = 100 W)
+aligned_step_w   = soc_resolution_wh / full_step_hours   (e.g. 10 Wh / 1 h = 10 W)
+power_step_w     = max(POWER_STEP_W, aligned_step_w)      (e.g. max(100, 10) = 100 W)
 charge_actions   = [max_charge_w, ..., 2×step, step, 0]   (highest-first)
 discharge_actions = [-step, -2×step, ..., -max_discharge_w] (lowest-first)
 actions = discharge_actions + charge_actions
@@ -279,28 +279,24 @@ After the backward pass, `V[0][s]` gives the optimal total cost from now to the 
 
 ## 7. Forward Pass (Schedule Extraction)
 
-Starting from the current SoC (`current_soc_wh` → nearest discrete state), the forward pass traces the optimal trajectory:
+The forward pass re-evaluates the V-table at the actual continuous SoC instead of snapping to the nearest discrete state and following the policy table. At each step it enumerates the same action set as the backward pass (including boundary actions) and picks the minimum-cost action:
 
 ```python
-current_soc = nearest_soc_state(current_soc_kwh)
+current_soc = current_soc_kwh * 1000  # continuous, not snapped
 
 for t in range(N):
-    s_idx = nearest_soc_idx(current_soc)
-    a = policy[t][s_idx]
-    record a as power_schedule_kw[t]
+    soc_idx = nearest_soc_idx(current_soc)
+    best_action, best_new_soc = argmin over all actions a:
+        step_cost(t, current_soc, a) + V[t+1][nearest_soc_idx(new_soc_after(a))]
 
-    if a > 0:   # charging
-        current_soc += a × dt × sqrt(RTE)
-        mode = "charging"
-    elif a < 0: # discharging
-        current_soc -= |a| × dt / sqrt(RTE)
-        mode = "discharging"
-    else:       # idle (passive DC PV if applicable)
-        current_soc += passive_dc_pv_charge
-        mode = "idle"
-
+    record best_action as power_schedule_kw[t]
+    current_soc = best_new_soc
     soc_schedule_kwh[t+1] = current_soc / 1000
 ```
+
+The sub-resolution skip still applies: non-zero actions that do not cross a SoC state boundary are skipped. Boundary actions (exact drain-to-min / fill-to-max) are also evaluated as in the backward pass.
+
+This eliminates the SoC discretisation error that accumulates when the policy for a neighbouring discrete state differs from the optimal action at the true SoC.
 
 This gives:
 - `power_schedule_kw[t]` — battery power at each step (positive = charge)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Home Assistant custom integration that optimizes home battery charge/discharge s
   - `forecast_models.py` — PV and consumption forecasting + historical price model
   - `battery_model.py` — battery physics (RTE split as √RTE per direction)
   - `config_flow.py` — setup + options flow with `section()` helpers
-  - `const.py` — SOC_RESOLUTION_WH=25, POWER_STEP_W=100 (boundary actions handle residual capacity), all config keys
+  - `const.py` — SOC_RESOLUTION_WH=10, POWER_STEP_W=100 (boundary actions handle residual capacity), all config keys
 - `tests/` — pytest with `pytest-homeassistant-custom-component` + syrupy snapshots
 
 ## HA Conventions

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -150,7 +150,7 @@ DEFAULT_CONTROL_MODE = "hybrid"
 # to near the feed-in price, making charging appear break-even and preventing
 # the optimizer from finding profitable charge/discharge cycles.
 # 25 Wh ensures ~6× margin between charging cost and discharge revenue per state.
-SOC_RESOLUTION_WH = 25.0  # Minimum SoC state size in Wh
+SOC_RESOLUTION_WH = 10.0  # Minimum SoC state size in Wh
 POWER_STEP_W = 100  # Minimum practical power action granularity in W
 
 # DC-to-AC conversion efficiency (excess DC PV through inverter to AC bus)

--- a/custom_components/battery_controller/optimizer.py
+++ b/custom_components/battery_controller/optimizer.py
@@ -711,37 +711,133 @@ def optimize_battery_schedule(
     mode_schedule = []
     soc_schedule_kwh = [current_soc_kwh]
 
-    current_soc = float(soc_states[current_soc_idx])
+    # Forward pass: V-table re-evaluation from actual continuous SoC.
+    # Instead of snapping to the nearest discrete state and following the policy
+    # table, we keep the real SoC and at each step enumerate the same action set
+    # as the backward pass (including boundary actions), evaluating
+    # step_cost + V[t+1][new_soc_idx] directly. This eliminates the SoC
+    # discretisation error that accumulates when the policy for a neighbouring
+    # discrete state differs from the optimal action at the true SoC.
+    current_soc = current_soc_kwh * 1000.0  # continuous, not snapped
 
     for t in range(n_steps):
         time_step_hours = step_durations_hours[t]
-        soc_idx = _find_nearest_soc_idx(current_soc, soc_states)
-        action_w = policy[t][soc_idx]
+        grid_price = price_forecast[t]
+        feed_in_price = feed_in_forecast[t] if t < len(feed_in_forecast) else grid_price
+        pv_w = pv_forecast[t] * 1000 if t < len(pv_forecast) else 0
         pv_dc_w = pv_dc_forecast[t] * 1000 if t < len(pv_dc_forecast) else 0.0
+        consumption_w = (
+            consumption_forecast[t] * 1000 if t < len(consumption_forecast) else 0
+        )
 
-        power_kw = action_w / 1000
-        power_schedule_kw.append(power_kw)
+        soc_idx = _find_nearest_soc_idx(current_soc, soc_states)
+        max_chg_w = battery_config.max_charge_at_soc(current_soc / 1000) * 1000
+        max_dis_w = battery_config.max_discharge_at_soc(current_soc / 1000) * 1000
 
-        if action_w > 0:
+        best_cost = INF
+        best_action = 0.0
+        best_new_soc = current_soc
+
+        for action_w in actions:
+            if action_w > 0:
+                if action_w > max_chg_w:
+                    continue
+                new_soc_wh = current_soc + action_w * time_step_hours * charge_eff
+                if new_soc_wh > max_soc_wh:
+                    continue
+            elif action_w < 0:
+                if -action_w > max_dis_w:
+                    continue
+                new_soc_wh = (
+                    current_soc - abs(action_w) * time_step_hours / discharge_eff
+                )
+                if new_soc_wh < min_soc_wh:
+                    continue
+            else:
+                if battery_config.pv_dc_coupled and pv_dc_w > 0:
+                    dc_eff = battery_config.pv_dc_efficiency
+                    headroom_wh = max(0.0, float(max_soc_wh) - current_soc)
+                    passive_wh = min(pv_dc_w * dc_eff * time_step_hours, headroom_wh)
+                    new_soc_wh = current_soc + passive_wh
+                else:
+                    new_soc_wh = current_soc
+
+            new_soc_idx = _find_nearest_soc_idx(new_soc_wh, soc_states)
+            if action_w != 0 and new_soc_idx == soc_idx:
+                continue
+
+            step_cost = calculate_step_cost(
+                time_step_hours=time_step_hours,
+                soc_wh=current_soc,
+                action_w=action_w,
+                grid_price=grid_price,
+                feed_in_price=feed_in_price,
+                pv_production_w=pv_w,
+                consumption_w=consumption_w,
+                rte=battery_config.round_trip_efficiency,
+                degradation_cost_per_kwh=degradation_cost_per_kwh,
+                battery_config=battery_config,
+                pv_dc_production_w=pv_dc_w,
+            )
+            total_cost = step_cost + V[t + 1][new_soc_idx]
+            if total_cost < best_cost:
+                best_cost = total_cost
+                best_action = action_w
+                best_new_soc = new_soc_wh
+
+        # Boundary actions: exact power to drain to min or fill to max SoC
+        if current_soc > min_soc_wh:
+            drain_w = (current_soc - min_soc_wh) * discharge_eff / time_step_hours
+            if 0 < drain_w <= max_dis_w:
+                step_cost = calculate_step_cost(
+                    time_step_hours=time_step_hours,
+                    soc_wh=current_soc,
+                    action_w=-drain_w,
+                    grid_price=grid_price,
+                    feed_in_price=feed_in_price,
+                    pv_production_w=pv_w,
+                    consumption_w=consumption_w,
+                    rte=battery_config.round_trip_efficiency,
+                    degradation_cost_per_kwh=degradation_cost_per_kwh,
+                    battery_config=battery_config,
+                    pv_dc_production_w=pv_dc_w,
+                )
+                total_cost = step_cost + V[t + 1][0]
+                if total_cost < best_cost:
+                    best_cost = total_cost
+                    best_action = -drain_w
+                    best_new_soc = float(min_soc_wh)
+
+        if current_soc < max_soc_wh:
+            fill_w = (max_soc_wh - current_soc) / (time_step_hours * charge_eff)
+            if 0 < fill_w <= max_chg_w:
+                step_cost = calculate_step_cost(
+                    time_step_hours=time_step_hours,
+                    soc_wh=current_soc,
+                    action_w=fill_w,
+                    grid_price=grid_price,
+                    feed_in_price=feed_in_price,
+                    pv_production_w=pv_w,
+                    consumption_w=consumption_w,
+                    rte=battery_config.round_trip_efficiency,
+                    degradation_cost_per_kwh=degradation_cost_per_kwh,
+                    battery_config=battery_config,
+                    pv_dc_production_w=pv_dc_w,
+                )
+                total_cost = step_cost + V[t + 1][n_soc_states - 1]
+                if total_cost < best_cost:
+                    best_cost = total_cost
+                    best_action = fill_w
+                    best_new_soc = float(max_soc_wh)
+
+        power_schedule_kw.append(best_action / 1000)
+        if best_action > 0:
             mode_schedule.append(ACTION_CHARGING)
-            current_soc = min(
-                current_soc + action_w * time_step_hours * charge_eff, float(max_soc_wh)
-            )
-        elif action_w < 0:
+        elif best_action < 0:
             mode_schedule.append(ACTION_DISCHARGING)
-            current_soc = max(
-                current_soc - abs(action_w) * time_step_hours / discharge_eff,
-                float(min_soc_wh),
-            )
         else:
-            # Idle: account for passive DC PV charging in forward pass
-            if battery_config.pv_dc_coupled and pv_dc_w > 0:
-                dc_eff = battery_config.pv_dc_efficiency
-                headroom_wh = max(0.0, float(max_soc_wh) - current_soc)
-                passive_wh = min(pv_dc_w * dc_eff * time_step_hours, headroom_wh)
-                current_soc = current_soc + passive_wh
             mode_schedule.append(ACTION_IDLE)
-
+        current_soc = best_new_soc
         soc_schedule_kwh.append(current_soc / 1000)
 
     # Oscillation filter window: at least 2 h, but scale with battery size so

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -4,7 +4,7 @@
 // ════════════════════════════════════════════════════════════════════
 
 // ── Constants (mirroring Python const.py) ──────────────────────────
-const SOC_RES_WH             = 25.0;
+const SOC_RES_WH             = 10.0;
 const POWER_STEP_W           = 100;
 const DC_TO_AC_EFF           = 0.96;
 const MIN_PV_SURPLUS_KW      = 0.05;
@@ -230,36 +230,108 @@ function runDP(cfg, currentSocKwh, priceFc, feedInFc, pvFc, consumFc,
   return { V, policy, socStates, socResWh, powerStepW, stepDurations, minSocWh, maxSocWh, terminalPrice, nSteps };
 }
 
-function forwardPass(dpResult, cfg, currentSocKwh, pvDcFc, chargeEffOverride, dischargeEffOverride) {
-  const { policy, socStates, stepDurations, minSocWh, maxSocWh, nSteps } = dpResult;
+function forwardPass(dpResult, cfg, currentSocKwh, pvDcFc, inputs, chargeEffOverride, dischargeEffOverride) {
+  const { V, socStates, stepDurations, minSocWh, maxSocWh, nSteps, powerStepW } = dpResult;
+  const { priceFc, feedInFc, pvFc, consumFc, degradCost } = inputs;
   const sqrtRte      = Math.sqrt(cfg.rte);
   const chargeEff    = chargeEffOverride    ?? sqrtRte;
   const dischargeEff = dischargeEffOverride ?? sqrtRte;
-  let curSocWh = currentSocKwh * 1000;
+  const nSocStates   = socStates.length;
+  const INF          = Infinity;
+
+  const maxChargeW    = Math.round(cfg.maxChargeKw    * 1000);
+  const maxDischargeW = Math.round(cfg.maxDischargeKw * 1000);
+  const chargeSteps    = Math.floor(maxChargeW    / powerStepW);
+  const dischargeSteps = Math.floor(maxDischargeW / powerStepW);
+  const actions = [];
+  for (let i = dischargeSteps; i >= 1; i--) actions.push(-i * powerStepW);
+  for (let i = chargeSteps;    i >= 0; i--) actions.push( i * powerStepW);
+
+  let curSocWh = currentSocKwh * 1000;  // continuous, not snapped
   const powerKw = [], modes = [], socKwh = [currentSocKwh];
 
   for (let t = 0; t < nSteps; t++) {
-    const stepH   = stepDurations[t];
-    const sIdx    = findNearestSocIdx(curSocWh, socStates);
-    const actionW = policy[t][sIdx];
-    const pvDcW   = pvDcFc && t < pvDcFc.length ? pvDcFc[t] * 1000 : 0;
+    const stepH      = stepDurations[t];
+    const gridPrice  = priceFc[t] ?? 0;
+    const feedIn     = feedInFc && t < feedInFc.length ? feedInFc[t] : gridPrice;
+    const pvW        = pvFc  && t < pvFc.length  ? pvFc[t]  * 1000 : 0;
+    const pvDcW      = pvDcFc && t < pvDcFc.length ? pvDcFc[t] * 1000 : 0;
+    const consumW    = consumFc && t < consumFc.length ? consumFc[t] * 1000 : 0;
 
-    powerKw.push(-actionW / 1000);
-    if (actionW > 0) {
-      modes.push('charging');
-      curSocWh = Math.min(curSocWh + actionW * stepH * chargeEff, maxSocWh);
-    } else if (actionW < 0) {
-      modes.push('discharging');
-      curSocWh = Math.max(curSocWh - Math.abs(actionW) * stepH / dischargeEff, minSocWh);
-    } else {
-      if (cfg.pvDcCoupled && pvDcW > 0) {
-        const dcEff      = cfg.pvDcEfficiency;
-        const headroomWh = Math.max(0, maxSocWh - curSocWh);
-        const passiveWh  = Math.min(pvDcW * dcEff * stepH, headroomWh);
-        curSocWh += passiveWh;
+    const sIdx = findNearestSocIdx(curSocWh, socStates);
+    const maxChgW = cfg.highSocChargeThresholdPct && cfg.highSocMaxChargeKw &&
+      (curSocWh / (cfg.capacityKwh * 10) >= cfg.highSocChargeThresholdPct)
+        ? cfg.highSocMaxChargeKw * 1000 : maxChargeW;
+    const maxDisW = cfg.lowSocDischargeThresholdPct && cfg.lowSocMaxDischargeKw &&
+      (curSocWh / (cfg.capacityKwh * 10) <= cfg.lowSocDischargeThresholdPct)
+        ? cfg.lowSocMaxDischargeKw * 1000 : maxDischargeW;
+
+    let bestCost = INF, bestAction = 0, bestNewSoc = curSocWh;
+
+    for (const actionW of actions) {
+      let newSocWh;
+      if (actionW > 0) {
+        if (actionW > maxChgW) continue;
+        newSocWh = curSocWh + actionW * stepH * chargeEff;
+        if (newSocWh > maxSocWh) continue;
+      } else if (actionW < 0) {
+        if (-actionW > maxDisW) continue;
+        newSocWh = curSocWh - Math.abs(actionW) * stepH / dischargeEff;
+        if (newSocWh < minSocWh) continue;
+      } else {
+        if (cfg.pvDcCoupled && pvDcW > 0) {
+          const dcEff      = cfg.pvDcEfficiency;
+          const headroomWh = Math.max(0, maxSocWh - curSocWh);
+          const passiveWh  = Math.min(pvDcW * dcEff * stepH, headroomWh);
+          newSocWh = curSocWh + passiveWh;
+        } else {
+          newSocWh = curSocWh;
+        }
       }
-      modes.push('idle');
+
+      const newSocIdx = findNearestSocIdx(newSocWh, socStates);
+      if (actionW !== 0 && newSocIdx === sIdx) continue;
+
+      const stepCost = calculateStepCost(
+        stepH, curSocWh, actionW, gridPrice, feedIn,
+        pvW, consumW, cfg.rte, degradCost,
+        cfg.pvDcCoupled, pvDcW, cfg.pvDcEfficiency, cfg.maxGridPowerKw, maxSocWh
+      );
+      const totalCost = stepCost + V[t + 1][newSocIdx];
+      if (totalCost < bestCost) { bestCost = totalCost; bestAction = actionW; bestNewSoc = newSocWh; }
     }
+
+    // Boundary actions: exact power to drain to min or fill to max SoC
+    if (curSocWh > minSocWh) {
+      const drainW = (curSocWh - minSocWh) * dischargeEff / stepH;
+      if (drainW > 0 && drainW <= maxDisW) {
+        const stepCost = calculateStepCost(
+          stepH, curSocWh, -drainW, gridPrice, feedIn,
+          pvW, consumW, cfg.rte, degradCost,
+          cfg.pvDcCoupled, pvDcW, cfg.pvDcEfficiency, cfg.maxGridPowerKw, maxSocWh
+        );
+        const totalCost = stepCost + V[t + 1][0];
+        if (totalCost < bestCost) { bestCost = totalCost; bestAction = -drainW; bestNewSoc = minSocWh; }
+      }
+    }
+    if (curSocWh < maxSocWh) {
+      const fillW = (maxSocWh - curSocWh) / (stepH * chargeEff);
+      if (fillW > 0 && fillW <= maxChgW) {
+        const stepCost = calculateStepCost(
+          stepH, curSocWh, fillW, gridPrice, feedIn,
+          pvW, consumW, cfg.rte, degradCost,
+          cfg.pvDcCoupled, pvDcW, cfg.pvDcEfficiency, cfg.maxGridPowerKw, maxSocWh
+        );
+        const totalCost = stepCost + V[t + 1][nSocStates - 1];
+        if (totalCost < bestCost) { bestCost = totalCost; bestAction = fillW; bestNewSoc = maxSocWh; }
+      }
+    }
+
+    powerKw.push(-bestAction / 1000);
+    if (bestAction > 0) modes.push('charging');
+    else if (bestAction < 0) modes.push('discharging');
+    else modes.push('idle');
+    curSocWh = bestNewSoc;
     socKwh.push(curSocWh / 1000);
   }
   return { powerKw, modes, socKwh };
@@ -513,7 +585,7 @@ function runOptimizer(cfg, currentSocKwh, inputs) {
 
   const dp = runDP(cfg, currentSocKwh, priceFc, feedInFc, pvFc, consumFc,
                    stepDurations, degradCost, minPriceSpread, pvDcFc, terminalShadowPrice, chargeEffOverride, dischargeEffOverride);
-  let { powerKw, modes } = forwardPass(dp, cfg, currentSocKwh, pvDcFc, chargeEffOverride, dischargeEffOverride);
+  let { powerKw, modes } = forwardPass(dp, cfg, currentSocKwh, pvDcFc, inputs, chargeEffOverride, dischargeEffOverride);
 
   // Post-processing filters (matching optimizer.py)
   const oscResult = filterOscillations(

--- a/simulate/simulate_diagnostics.py
+++ b/simulate/simulate_diagnostics.py
@@ -199,7 +199,7 @@ def extract_inputs(diag: dict) -> tuple:
 # Inline DP optimizer (copy from optimizer.py, no HA imports)
 # ---------------------------------------------------------------------------
 
-SOC_RESOLUTION_WH = 25.0
+SOC_RESOLUTION_WH = 10.0
 POWER_STEP_W = 100
 MIN_CYCLE_KWH = 0.2
 POWER_IDLE_THRESHOLD_KW = 0.001
@@ -492,7 +492,7 @@ def run_dp(
 
 
 def forward_pass(
-    policy,
+    V,
     soc_states,
     current_soc_kwh,
     step_durations_hours,
@@ -501,51 +501,158 @@ def forward_pass(
     n_steps,
     battery_config,
     pv_dc_forecast,
+    price_forecast,
+    feed_in_forecast,
+    pv_forecast,
+    consumption_forecast,
+    degradation_cost_per_kwh,
+    power_step_w,
     charge_eff_override=None,
     discharge_eff_override=None,
 ):
-    """Execute the forward pass to get the schedule."""
+    """Execute the forward pass via V-table re-evaluation at the actual continuous SoC."""
     sqrt_rte = math.sqrt(battery_config.round_trip_efficiency)
     charge_eff = charge_eff_override if charge_eff_override is not None else sqrt_rte
     discharge_eff = (
         discharge_eff_override if discharge_eff_override is not None else sqrt_rte
     )
-    current_soc = float(
-        soc_states[_find_nearest_soc_idx(int(current_soc_kwh * 1000), soc_states)]
-    )
+    n_soc_states = len(soc_states)
+
+    max_charge_w = battery_config.max_charge_power_kw * 1000
+    max_discharge_w = battery_config.max_discharge_power_kw * 1000
+    charge_steps = int(max_charge_w / power_step_w)
+    discharge_steps = int(max_discharge_w / power_step_w)
+    charge_actions = [float(i * power_step_w) for i in range(charge_steps, -1, -1)]
+    discharge_actions = [
+        float(-i * power_step_w) for i in range(discharge_steps, 0, -1)
+    ]
+    actions = discharge_actions + charge_actions
+
+    INF = float("inf")
+    current_soc = current_soc_kwh * 1000.0  # continuous, not snapped
 
     power_schedule_kw = []
     mode_schedule = []
-    soc_schedule_kwh = [current_soc_kwh]  # Start with exact SoC
+    soc_schedule_kwh = [current_soc_kwh]
 
     for t in range(n_steps):
         time_step_hours = step_durations_hours[t]
-        soc_idx = _find_nearest_soc_idx(current_soc, soc_states)
-        action_w = policy[t][soc_idx]
+        grid_price = price_forecast[t] if t < len(price_forecast) else 0.0
+        feed_in_price = feed_in_forecast[t] if t < len(feed_in_forecast) else grid_price
+        pv_w = pv_forecast[t] * 1000 if t < len(pv_forecast) else 0.0
         pv_dc_w = pv_dc_forecast[t] * 1000 if t < len(pv_dc_forecast) else 0.0
+        consumption_w = (
+            consumption_forecast[t] * 1000 if t < len(consumption_forecast) else 0.0
+        )
 
-        power_kw = action_w / 1000
-        power_schedule_kw.append(power_kw)
+        soc_idx = _find_nearest_soc_idx(current_soc, soc_states)
+        max_chg_w = battery_config.max_charge_at_soc(current_soc / 1000) * 1000
+        max_dis_w = battery_config.max_discharge_at_soc(current_soc / 1000) * 1000
 
-        if action_w > 0:
+        best_cost = INF
+        best_action = 0.0
+        best_new_soc = current_soc
+
+        for action_w in actions:
+            if action_w > 0:
+                if action_w > max_chg_w:
+                    continue
+                new_soc_wh = current_soc + action_w * time_step_hours * charge_eff
+                if new_soc_wh > max_soc_wh:
+                    continue
+            elif action_w < 0:
+                if -action_w > max_dis_w:
+                    continue
+                new_soc_wh = (
+                    current_soc - abs(action_w) * time_step_hours / discharge_eff
+                )
+                if new_soc_wh < min_soc_wh:
+                    continue
+            else:
+                if battery_config.pv_dc_coupled and pv_dc_w > 0:
+                    dc_eff = battery_config.pv_dc_efficiency
+                    headroom_wh = max(0.0, float(max_soc_wh) - current_soc)
+                    passive_wh = min(pv_dc_w * dc_eff * time_step_hours, headroom_wh)
+                    new_soc_wh = current_soc + passive_wh
+                else:
+                    new_soc_wh = current_soc
+
+            new_soc_idx = _find_nearest_soc_idx(new_soc_wh, soc_states)
+            if action_w != 0 and new_soc_idx == soc_idx:
+                continue
+
+            step_cost = calculate_step_cost(
+                time_step_hours=time_step_hours,
+                soc_wh=current_soc,
+                action_w=action_w,
+                grid_price=grid_price,
+                feed_in_price=feed_in_price,
+                pv_production_w=pv_w,
+                consumption_w=consumption_w,
+                rte=battery_config.round_trip_efficiency,
+                degradation_cost_per_kwh=degradation_cost_per_kwh,
+                battery_config=battery_config,
+                pv_dc_production_w=pv_dc_w,
+            )
+            total_cost = step_cost + V[t + 1][new_soc_idx]
+            if total_cost < best_cost:
+                best_cost = total_cost
+                best_action = action_w
+                best_new_soc = new_soc_wh
+
+        # Boundary actions: exact power to drain to min or fill to max SoC
+        if current_soc > min_soc_wh:
+            drain_w = (current_soc - min_soc_wh) * discharge_eff / time_step_hours
+            if 0 < drain_w <= max_dis_w:
+                step_cost = calculate_step_cost(
+                    time_step_hours=time_step_hours,
+                    soc_wh=current_soc,
+                    action_w=-drain_w,
+                    grid_price=grid_price,
+                    feed_in_price=feed_in_price,
+                    pv_production_w=pv_w,
+                    consumption_w=consumption_w,
+                    rte=battery_config.round_trip_efficiency,
+                    degradation_cost_per_kwh=degradation_cost_per_kwh,
+                    battery_config=battery_config,
+                    pv_dc_production_w=pv_dc_w,
+                )
+                total_cost = step_cost + V[t + 1][0]
+                if total_cost < best_cost:
+                    best_cost = total_cost
+                    best_action = -drain_w
+                    best_new_soc = float(min_soc_wh)
+
+        if current_soc < max_soc_wh:
+            fill_w = (max_soc_wh - current_soc) / (time_step_hours * charge_eff)
+            if 0 < fill_w <= max_chg_w:
+                step_cost = calculate_step_cost(
+                    time_step_hours=time_step_hours,
+                    soc_wh=current_soc,
+                    action_w=fill_w,
+                    grid_price=grid_price,
+                    feed_in_price=feed_in_price,
+                    pv_production_w=pv_w,
+                    consumption_w=consumption_w,
+                    rte=battery_config.round_trip_efficiency,
+                    degradation_cost_per_kwh=degradation_cost_per_kwh,
+                    battery_config=battery_config,
+                    pv_dc_production_w=pv_dc_w,
+                )
+                total_cost = step_cost + V[t + 1][n_soc_states - 1]
+                if total_cost < best_cost:
+                    best_cost = total_cost
+                    best_action = fill_w
+                    best_new_soc = float(max_soc_wh)
+
+        power_schedule_kw.append(best_action / 1000)
+        if best_action > 0:
             mode_schedule.append("charging")
-            current_soc = min(
-                current_soc + action_w * time_step_hours * charge_eff, float(max_soc_wh)
-            )
-        elif action_w < 0:
+        elif best_action < 0:
             mode_schedule.append("discharging")
-            current_soc = max(
-                current_soc - abs(action_w) * time_step_hours / discharge_eff,
-                float(min_soc_wh),
-            )
         else:
-            if battery_config.pv_dc_coupled and pv_dc_w > 0:
-                dc_eff = battery_config.pv_dc_efficiency
-                headroom_wh = max(0.0, float(max_soc_wh) - current_soc)
-                passive_wh = min(pv_dc_w * dc_eff * time_step_hours, headroom_wh)
-                current_soc = current_soc + passive_wh
             mode_schedule.append("idle")
-
+        current_soc = best_new_soc
         soc_schedule_kwh.append(current_soc / 1000)
 
     return power_schedule_kw, mode_schedule, soc_schedule_kwh
@@ -1087,7 +1194,7 @@ def main():
 
     # Forward pass
     power_schedule_kw, mode_schedule, soc_schedule_kwh = forward_pass(
-        policy=policy,
+        V=V,
         soc_states=soc_states,
         current_soc_kwh=current_soc_kwh,
         step_durations_hours=step_durations_hours,
@@ -1096,6 +1203,12 @@ def main():
         n_steps=n_steps,
         battery_config=battery,
         pv_dc_forecast=pv_dc_forecast,
+        price_forecast=price_forecast,
+        feed_in_forecast=feed_in_forecast,
+        pv_forecast=pv_forecast,
+        consumption_forecast=consumption_forecast,
+        degradation_cost_per_kwh=degradation_cost,
+        power_step_w=power_step_w,
         charge_eff_override=charge_eff_override,
         discharge_eff_override=discharge_eff_override,
     )


### PR DESCRIPTION
## Summary

- **Continuous forward pass**: replaced policy-table lookup (snap to nearest discrete SoC → follow `policy[t][soc_idx]`) with V-table re-evaluation at the actual continuous SoC. Eliminates discretisation error that accumulates when the nearest-state policy differs from the optimal action at the true SoC. Applied identically to `optimizer.py`, `analyzer.js`, and `simulate_diagnostics.py`.
- **Lower SoC resolution**: `SOC_RESOLUTION_WH` reduced from 25 → 10 Wh for finer state-space granularity.
- **Efficiency corrections**: self-learning charge efficiency correction; discharge efficiency correction added; efficiency correction removed from price calculations (belongs in physics, not cost).
- **Battery balancing**: new feature to keep cells balanced during idle periods.
- **SoC-dependent power derating**: BMS absorption limits modelled via derating at high/low SoC.
- **Oscillation filter fix**: incorrectly removed charge blocks with 15-min price data — fixed.
- **Terminal price tweaks**: tail price used in follow-schedule mode to prevent premature discharge stop in slowly rising price periods.
- **Various bug fixes**: partial first DP step erratic setpoint, small battery SoC filter, 15-min price data support, Nordpool datetime format, recorder import.

## Test plan

- [ ] Run `python -m pytest tests/ -v` — all tests pass
- [ ] Run `pre-commit run --all-files` — no issues
- [ ] Load diagnostics JSON in `docs/analyzer.html` and verify schedule matches `simulate_diagnostics.py` output
- [ ] Check shadow price and SoC trajectory are consistent between forward pass and backward pass V-table