### PR TITLE
fix: divide per-cycle degradation cost by 2× usable capacity

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -47,7 +47,7 @@ The optimizer must respect physical constraints: SoC must stay within `[min_soc,
 | `pv_dc_forecast[t]` | kW | DC-coupled PV production for each step (optional) |
 | `consumption_forecast[t]` | kW | Expected household consumption for each step |
 | `step_durations_hours[t]` | h | Duration of each time step (typically 0.25 h = 15 min) |
-| `degradation_cost_per_cycle` | EUR/cycle | Battery wear cost per full charge+discharge cycle (converted to EUR/kWh by coordinator: `÷ usable_kwh`) |
+| `degradation_cost_per_cycle` | EUR/cycle | Battery wear cost per full charge+discharge cycle (converted to EUR/kWh by coordinator: `÷ (2 × usable_kwh)` — one cycle is charge + discharge throughput) |
 | `min_price_spread` | EUR/kWh | Minimum buy/sell spread to trigger arbitrage |
 | `terminal_shadow_price` | EUR/kWh | Marginal value of stored energy from previous run (optional) |
 
@@ -188,7 +188,7 @@ energy_kwh = |net_grid_w| × dt / 1000
 grid_cost = energy_kwh × grid_price      (if net_grid_w > 0: buying)
           = -energy_kwh × feed_in_price  (if net_grid_w < 0: selling)
 
-degradation_cost_per_kwh = degradation_cost_per_cycle / usable_kwh  (conversion in coordinator)
+degradation_cost_per_kwh = degradation_cost_per_cycle / (2 × usable_kwh)  (conversion in coordinator; a full cycle = 2 × usable_kwh throughput)
 degradation_cost = throughput_kwh × degradation_cost_per_kwh
 
 step_cost = grid_cost + degradation_cost

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -1854,10 +1854,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             else "none (first run, using feed-in tail)",
         )
         # Convert degradation cost from per-cycle to per-kWh throughput for the optimizer.
-        # One cycle = max_soc_kwh - min_soc_kwh (usable capacity).
+        # One full cycle moves the usable capacity (max_soc_kwh - min_soc_kwh) through
+        # the battery TWICE: once charging and once discharging. The optimizer applies
+        # degradation to throughput in both directions, so divide by 2 × usable_kwh —
+        # dividing by usable_kwh alone would make a full cycle cost double the
+        # configured per-cycle value.
         usable_kwh = battery_config.max_soc_kwh - battery_config.min_soc_kwh
         degradation_cost_per_kwh = (
-            degradation_cost / usable_kwh if usable_kwh > 0 else degradation_cost
+            degradation_cost / (2 * usable_kwh) if usable_kwh > 0 else degradation_cost
         )
 
         result = await self.hass.async_add_executor_job(

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -640,7 +640,9 @@ function generateTips(d) {
   const sqrtRte = Math.sqrt(rte);
   const usableKwh780 = ((bc.max_soc_kwh || 0) - (bc.min_soc_kwh || 0)) || 1;
   const degradCycle780 = opts.degradation_cost_per_cycle ?? opts.degradation_cost_per_kwh;
-  const degrad  = degradCycle780 != null ? degradCycle780 / usableKwh780 : 0.04 / usableKwh780;
+  // Per-cycle → per-kWh: a full cycle is 2 × usable kWh of throughput
+  // (charge + discharge), matching the coordinator's conversion.
+  const degrad  = degradCycle780 != null ? degradCycle780 / (2 * usableKwh780) : 0.04 / (2 * usableKwh780);
   const spread  = opts.min_price_spread         || 0.05;
   const savings = opt.savings   || 0;
   const baseline= opt.baseline_cost || 0;

--- a/docs/index.html
+++ b/docs/index.html
@@ -579,7 +579,7 @@ function renderSpreadAnalysis(bc, opts, prices) {
   const sqrtRte= Math.sqrt(rte);
   const usableKwh966 = ((bc.max_soc_kwh || 0) - (bc.min_soc_kwh || 0)) || 1;
   const degradCyc966 = opts.degradation_cost_per_cycle ?? opts.degradation_cost_per_kwh;
-  const degrad = degradCyc966 != null ? degradCyc966 / usableKwh966 : 0.04 / usableKwh966;
+  const degrad = degradCyc966 != null ? degradCyc966 / (2 * usableKwh966) : 0.04 / (2 * usableKwh966);
   if (!prices || prices.length === 0) return;
   const minP   = Math.min(...prices);
   const maxP   = Math.max(...prices);
@@ -638,7 +638,7 @@ function renderProfitabilityTable(prices, feedInFc, pvFc, consumFc, powerKw, mod
   const sqrtRte= Math.sqrt(rte);
   const usableKwh1024 = ((bc.max_soc_kwh || 0) - (bc.min_soc_kwh || 0)) || 1;
   const degradCyc1024 = opts.degradation_cost_per_cycle ?? opts.degradation_cost_per_kwh;
-  const degrad = degradCyc1024 != null ? degradCyc1024 / usableKwh1024 : 0.04 / usableKwh1024;
+  const degrad = degradCyc1024 != null ? degradCyc1024 / (2 * usableKwh1024) : 0.04 / (2 * usableKwh1024);
   const breakeven = (terminalPrice + degrad) / sqrtRte;
   const breakevenChg = (terminalPrice - degrad) * sqrtRte;
 
@@ -895,7 +895,7 @@ function renderDiagnostics(raw) {
     const feedInForDp = feedInFc || prices;
     const usableKwhDp = (cfg2.maxSocKwh - cfg2.minSocKwh) || 1;
     const degradCycleOpts = opts.degradation_cost_per_cycle ?? opts.degradation_cost_per_kwh;
-    const degradPerKwhDp = degradCycleOpts != null ? degradCycleOpts / usableKwhDp : 0.04 / usableKwhDp;
+    const degradPerKwhDp = degradCycleOpts != null ? degradCycleOpts / (2 * usableKwhDp) : 0.04 / (2 * usableKwhDp);
     const dp2 = runDP(cfg2, bs.soc_kwh || 5, prices, feedInForDp,
       pvFc.length ? pvFc : new Array(prices.length).fill(0),
       consumFc.length ? consumFc : new Array(prices.length).fill(0),
@@ -1184,7 +1184,7 @@ function runSimulator() {
       const stepH   = p.stepH || 0.25;
       const termSP  = p.terminalShadowPrice > 0 ? p.terminalShadowPrice : null;
       const simUsableKwh = (p.maxSocKwh - p.minSocKwh) || 1;
-      const degradPerKwhSim = p.degradation / simUsableKwh;
+      const degradPerKwhSim = p.degradation / (2 * simUsableKwh);
       const pvCurtailed = document.getElementById('sp-pv-curtailed').checked;
       const zeroes = new Array(price.length).fill(0);
       const inputs  = {

--- a/simulate/simulate_diagnostics.py
+++ b/simulate/simulate_diagnostics.py
@@ -148,10 +148,13 @@ def extract_inputs(diag: dict) -> tuple:
         "degradation_cost_per_cycle",
         options.get("degradation_cost_per_kwh", 0.04),  # fallback for old diagnostics
     )
-    # Convert per-cycle to per-kWh for the DP (same as coordinator)
+    # Convert per-cycle to per-kWh for the DP (same as coordinator).
+    # A full cycle moves usable capacity through the battery twice (charge +
+    # discharge) and degradation is charged on throughput in both directions,
+    # hence the division by 2 × usable_kwh.
     usable_kwh = battery.max_soc_kwh - battery.min_soc_kwh
     degradation_cost = (
-        degradation_cost_per_cycle / usable_kwh
+        degradation_cost_per_cycle / (2 * usable_kwh)
         if usable_kwh > 0
         else degradation_cost_per_cycle
     )

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -2674,3 +2674,99 @@ def test_split_setpoint_gap_resets_active_battery(hass):
     coord._split_setpoint(0.1, "follow_schedule")
     # Gap crossed threshold → proportional split → active battery reset to None
     assert coord._scheduled_active_battery is None
+
+
+# ---------------------------------------------------------------------------
+# Degradation cost conversion tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_degradation_per_cycle_converted_to_per_kwh_throughput(hass, monkeypatch):
+    """Per-cycle degradation cost is divided by 2 x usable kWh (charge + discharge)."""
+    from unittest.mock import patch as upatch
+
+    coord = _make_coordinator(hass)
+    fixed_now = datetime(2026, 3, 21, 10, 0, 0, tzinfo=timezone.utc)
+    coord.forecast_coordinator.data = {
+        "pv_forecast_kw": [0.0, 0.0],
+        "consumption_forecast_kw": [0.5, 0.5],
+        "current_pv_kw": 0.0,
+        "current_dc_pv_kw": 0.0,
+        "current_consumption_kw": 0.5,
+    }
+    hass.states.async_set("sensor.test_price", "0.20")
+    monkeypatch.setattr(coord, "_refresh_battery_config", lambda: None)
+    monkeypatch.setattr(
+        coord,
+        "get_current_battery_state",
+        lambda: BatteryState(soc_kwh=5.0, soc_percent=50.0, power_kw=0.0, mode="idle"),
+    )
+    monkeypatch.setattr(coord, "_get_realtime_grid_w", lambda: 0.0)
+    monkeypatch.setattr(coord, "_split_setpoint", lambda kw, _mode="": {"bat1": kw})
+    monkeypatch.setattr(coord._price_model, "has_data", lambda: False)
+    monkeypatch.setattr(coord._feed_in_price_model, "has_data", lambda: False)
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.extract_price_forecast_with_timestamps",
+        lambda state: ([0.20, 0.22], [fixed_now, fixed_now + timedelta(hours=1)], 60),
+    )
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.compute_step_durations_hours",
+        lambda *a: [1.0, 1.0],
+    )
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.resample_forecast",
+        lambda values, src, dst: list(values),
+    )
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
+        lambda: fixed_now,
+    )
+
+    live_entry = MagicMock()
+    live_entry.options = {"degradation_cost_per_cycle": 0.04}
+    monkeypatch.setattr(hass.config_entries, "async_get_entry", lambda eid: live_entry)
+
+    captured = {}
+
+    def fake_optimize(*args):
+        captured["degradation_cost_per_kwh"] = args[7]
+        return OptimizationResult(
+            power_schedule_kw=[0.0, 0.0],
+            mode_schedule=["idle", "idle"],
+            soc_schedule_kwh=[5.0, 5.0, 5.0],
+            total_cost=0.0,
+            baseline_cost=0.0,
+            savings=0.0,
+            optimal_power_kw=0.0,
+            optimal_mode="idle",
+            shadow_price_eur_kwh=0.15,
+            price_forecast=list(args[2]),
+            pv_forecast=[0.0, 0.0],
+            consumption_forecast=[0.5, 0.5],
+        )
+
+    coord.zero_grid_controller = MagicMock()
+    coord.zero_grid_controller.get_control_action = MagicMock(
+        return_value={
+            "target_power_kw": 0.0,
+            "target_power_w": 0.0,
+            "action_mode": "idle",
+            "raw_target_w": 0.0,
+            "dp_schedule_w": 0.0,
+            "mode": "idle",
+        }
+    )
+
+    with upatch(
+        "custom_components.battery_controller.coordinator_optimization.optimize_battery_schedule",
+        side_effect=fake_optimize,
+    ):
+        await coord._run_optimization()
+
+    # Default battery: 10 kWh, 10-100% SoC -> usable 9 kWh.
+    # One full cycle = 18 kWh throughput (charge + discharge), so
+    # 0.04 EUR/cycle -> 0.04 / 18 EUR/kWh.
+    usable_kwh = coord.battery_config.max_soc_kwh - coord.battery_config.min_soc_kwh
+    assert usable_kwh == pytest.approx(9.0)
+    assert captured["degradation_cost_per_kwh"] == pytest.approx(0.04 / (2 * 9.0))


### PR DESCRIPTION
## Problem
The coordinator converts `degradation_cost_per_cycle` to €/kWh using `÷ usable_kwh`. However, the optimizer charges degradation on throughput in **both** directions (charging and discharging), so one full cycle = `2 × usable_kwh` of throughput. As a result, a full cycle effectively cost **double** the configured value (the default 0.04 €/cycle behaved like 0.08), making the DP systematically too reluctant to cycle.

`battery_model.calculate_degradation_cost_per_kwh` already divided correctly by `2 × DoD`.

## Fix
- `coordinator_optimization.py`: conversion is now `degradation_cost / (2 × usable_kwh)`
- Same correction applied to `docs/analyzer.js`, `docs/index.html` and `simulate/simulate_diagnostics.py` (keeping all DP implementations in sync, per CLAUDE.md)
- `ALGORITHM.md` updated
- Regression test added that verifies the €/kWh value passed to the optimizer

## Tests
- Full suite green (679 tests)
- `pre-commit run --all-files` green