### PR TITLE
fix: passive DC PV charging continues during active charge actions

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -134,22 +134,26 @@ DC-coupled PV uses its own path efficiency (`pv_dc_efficiency` ≈ 0.97, MPPT on
 
 ### 4.2 Charging (`action_w > 0`)
 
-When charging at power `P` (W):
+When charging at AC setpoint `P` (W):
 
-1. **Use DC PV first** (free energy, higher efficiency):
+1. **AC grid draw**: the grid supplies the setpoint directly; conversion losses
+   are internal to the inverter and captured in the SoC transition:
    ```
-   dc_charge_w = min(P, pv_dc_production_w × dc_eff)
-   ac_charge_w = P - dc_charge_w
-   ```
-
-2. **AC grid draw** for the remainder:
-   ```
-   grid_to_battery_w = ac_charge_w / charge_eff
+   grid_to_battery_w = P
+   ac_stored_wh      = P × dt × charge_eff
    ```
 
-3. **Remaining DC PV** not absorbed by battery flows to AC through the inverter at 96% efficiency.
+2. **Passive DC PV continues on top**: the AC setpoint only controls AC-side
+   exchange — DC MPPT charging is independent of it and fills the headroom
+   that remains after the AC-charged energy:
+   ```
+   headroom_wh       = max(0, max_soc_wh - soc_wh - ac_stored_wh)
+   passive_charge_wh = min(pv_dc_production_w × dc_eff × dt, headroom_wh)
+   ```
 
-4. **Throughput**: `P × dt / 1000` kWh (for degradation).
+3. **Remaining DC PV** not absorbed by the battery flows to AC through the inverter at 96% efficiency.
+
+4. **Throughput**: `(ac_stored_wh + passive_charge_wh) / 1000` kWh (for degradation).
 
 ### 4.3 Discharging (`action_w < 0`)
 
@@ -230,7 +234,7 @@ V[t][s] = min over all actions a of:
 
 where `s'` is the SoC state after applying action `a`:
 
-- **Charging**: `s' = s + a × dt × sqrt(RTE)` (energy stored in battery)
+- **Charging**: `s' = s + a × dt × sqrt(RTE)` plus passive DC PV charging up to the remaining headroom (if DC-coupled)
 - **Discharging**: `s' = s - |a| × dt / sqrt(RTE)` (energy drawn from battery, with losses)
 - **Idle**: `s' = s` (or passive DC PV charging if DC-coupled)
 
@@ -342,7 +346,7 @@ for each step i:
 
 When there is a **PV surplus** at a charging step (PV production > consumption), the charge cost is the feed-in opportunity cost (what could have been earned by exporting that PV) rather than the grid buy price.
 
-**DC-coupled PV**: For systems with DC-coupled PV, passive charging from the DC PV array occurs even when the battery is idle. The oscillation filter accounts for this by subtracting the passive DC PV contribution from the active charge power when calculating charge cost. If all charging would come from passive DC PV anyway, the effective cost is zero and the charge step is never suppressed.
+**DC-coupled PV**: Passive DC PV charging happens regardless of the AC setpoint (idle and active charging alike), so the commanded charge power is AC-only and the filter prices it directly against the PV-surplus/grid blend — no passive-DC deduction is needed.
 
 The window size is `max(2 h, battery_capacity / max_discharge_power)` — larger batteries need a wider window because a full charge/discharge cycle takes longer.
 

--- a/custom_components/battery_controller/optimizer.py
+++ b/custom_components/battery_controller/optimizer.py
@@ -93,6 +93,12 @@ def _rebuild_schedule(
             )
             delta_soc = current_soc_kwh - prev_soc_kwh
             actual_power_kw = delta_soc / (step_h * _charge_eff) if step_h > 0 else 0.0
+            if pv_dc_coupled and t < len(pv_dc_forecast) and pv_dc_forecast[t] > 0:
+                # Passive DC MPPT charging continues on top of the AC charge.
+                headroom_kwh = max(0.0, max_soc_kwh - current_soc_kwh)
+                current_soc_kwh += min(
+                    pv_dc_forecast[t] * pv_dc_efficiency * step_h, headroom_kwh
+                )
         elif commanded_power_kw < 0:
             current_soc_kwh = max(
                 current_soc_kwh - abs(commanded_power_kw) * step_h / _discharge_eff,
@@ -241,7 +247,9 @@ def calculate_step_cost(
        - PV panels connected directly to battery inverter DC bus
        - Charge efficiency ~97% (MPPT only, no AC conversion)
        - This PV power is "free" and doesn't pass through grid meter
-       - In idle mode: DC PV passively charges battery up to available headroom
+       - The AC setpoint only controls AC-side exchange: DC MPPT charging
+         continues both in idle mode AND on top of an active charge action,
+         up to the available SoC headroom
        - Excess DC PV (when battery full or discharging) goes through inverter to AC
 
     3. Degradation:
@@ -281,31 +289,35 @@ def calculate_step_cost(
     pv_dc_production_w = max(0.0, pv_dc_production_w)
 
     # Handle DC-coupled PV
-    # DC PV can charge battery directly at higher efficiency.
-    # In idle mode (action_w == 0) DC-coupled inverters still absorb DC PV into
-    # the battery up to available headroom — the AC setpoint of 0 only stops
-    # AC-side grid charging, not DC MPPT charging.
-    dc_charge_w = 0.0
-    ac_charge_w = 0.0
+    # DC PV charges the battery directly at higher efficiency. The AC setpoint
+    # only controls AC-side power exchange; DC MPPT charging continues
+    # regardless of the setpoint. So passive DC PV charging happens both in
+    # idle mode AND on top of an active AC charge action — an explicit charge
+    # command never reduces the amount of DC PV the battery absorbs.
     dc_pv_excess_w = pv_dc_production_w  # DC PV not used by battery -> goes to AC
     throughput_kwh = 0.0
 
     if action_w > 0:  # CHARGING
-        # Use DC PV first (free energy, higher efficiency)
-        dc_charge_w = min(action_w, pv_dc_production_w * dc_eff)
-        ac_charge_w = action_w - dc_charge_w
-
-        # DC PV not used by battery goes to AC side (through inverter)
-        dc_pv_used_w = dc_charge_w / dc_eff if dc_eff > 0 else 0.0
-        dc_pv_excess_w = max(0.0, pv_dc_production_w - dc_pv_used_w)
-
         # AC charging: grid draws the AC setpoint directly; losses are internal
-        # to the inverter, captured in the SoC transition
-        grid_to_battery_w = ac_charge_w  # grid draws AC setpoint power
+        # to the inverter, captured in the SoC transition.
+        grid_to_battery_w = action_w  # grid draws AC setpoint power
+        ac_stored_wh = action_w * time_step_hours * charge_eff
+        throughput_kwh = ac_stored_wh / 1000  # actual stored Wh via AC
 
-        throughput_kwh = (
-            action_w * time_step_hours * charge_eff / 1000
-        )  # actual stored Wh
+        if battery_config.pv_dc_coupled and pv_dc_production_w > 0:
+            # DC MPPT charging continues on top of the AC charge, limited by
+            # the headroom that remains after the AC-charged energy.
+            max_soc_wh = battery_config.max_soc_kwh * 1000
+            headroom_wh = max(0.0, max_soc_wh - soc_wh - ac_stored_wh)
+            passive_charge_wh = min(
+                pv_dc_production_w * dc_eff * time_step_hours, headroom_wh
+            )
+            passive_charge_w = (
+                passive_charge_wh / time_step_hours if time_step_hours > 0 else 0.0
+            )
+            dc_pv_consumed_w = passive_charge_w / dc_eff if dc_eff > 0 else 0.0
+            dc_pv_excess_w = max(0.0, pv_dc_production_w - dc_pv_consumed_w)
+            throughput_kwh += passive_charge_wh / 1000
 
     elif action_w < 0:  # DISCHARGING
         # All DC PV excess goes to AC side when discharging
@@ -584,10 +596,10 @@ def optimize_battery_schedule(
             max_dis_w = soc_max_discharge_w[s_idx]
 
             for action_w in actions:
-                # SoC transition: action_w is battery-side power (explicit AC command).
-                # For DC-coupled systems in idle mode (action_w == 0), the MPPT
-                # charger passively charges the battery from DC PV up to available
-                # headroom — the AC setpoint of 0 only stops AC-side grid charging.
+                # SoC transition: action_w is the explicit AC setpoint. For
+                # DC-coupled systems the MPPT charger passively charges the
+                # battery from DC PV up to available headroom regardless of the
+                # AC setpoint — both in idle and on top of an active charge.
                 # Efficiency losses are on the grid/AC side and handled in
                 # calculate_step_cost.
                 if action_w > 0:
@@ -597,6 +609,12 @@ def optimize_battery_schedule(
                     new_soc_wh = soc_wh + energy_change_wh
                     if new_soc_wh > max_soc_wh:
                         continue
+                    if battery_config.pv_dc_coupled and pv_dc_w > 0:
+                        dc_eff = battery_config.pv_dc_efficiency
+                        headroom_wh = max(0.0, max_soc_wh - new_soc_wh)
+                        new_soc_wh += min(
+                            pv_dc_w * dc_eff * time_step_hours, headroom_wh
+                        )
                 elif action_w < 0:
                     if -action_w > max_dis_w:
                         continue
@@ -745,6 +763,10 @@ def optimize_battery_schedule(
                 new_soc_wh = current_soc + action_w * time_step_hours * charge_eff
                 if new_soc_wh > max_soc_wh:
                     continue
+                if battery_config.pv_dc_coupled and pv_dc_w > 0:
+                    dc_eff = battery_config.pv_dc_efficiency
+                    headroom_wh = max(0.0, float(max_soc_wh) - new_soc_wh)
+                    new_soc_wh += min(pv_dc_w * dc_eff * time_step_hours, headroom_wh)
             elif action_w < 0:
                 if -action_w > max_dis_w:
                     continue
@@ -1034,8 +1056,9 @@ def _filter_oscillations(
     def get_charge_cost(timestep: int, charge_power_kw: float) -> float:
         """Get the marginal cost of charging for the actual commanded power.
 
-        For DC-coupled PV: passive charging happens even at idle (free). Only the
-        portion of active charging above the passive DC PV contribution costs money.
+        The commanded power is the AC setpoint only: passive DC PV charging
+        happens regardless of the setpoint (also at idle), so it is never part
+        of the commanded power and needs no deduction here.
         """
         if (
             charge_power_kw <= 0
@@ -1045,31 +1068,9 @@ def _filter_oscillations(
         ):
             return price_forecast[timestep]
 
-        # DC PV passive charge at idle is free — only charge above this costs money
-        effective_charge_kw = charge_power_kw
-        if pv_dc_coupled and pv_dc_forecast:
-            step_h = (
-                step_durations_hours[timestep]
-                if timestep < len(step_durations_hours)
-                else step_durations_hours[-1]
-            )
-            passive_charge_kw = (
-                pv_dc_forecast[timestep] * pv_dc_efficiency
-                if timestep < len(pv_dc_forecast)
-                else 0.0
-            )
-            # Cap passive charge by available headroom (approximate using max_soc)
-            max_passive_kwh = (max_soc_kwh - min_soc_kwh) if step_h > 0 else 0.0
-            passive_charge_kw = (
-                min(passive_charge_kw, max_passive_kwh / step_h) if step_h > 0 else 0.0
-            )
-            effective_charge_kw = max(0.0, charge_power_kw - passive_charge_kw)
-            if effective_charge_kw <= 0:
-                return 0.0  # All charging is passive DC PV, no cost
-
         pv_surplus_kw = max(0.0, pv_forecast[timestep] - consumption_forecast[timestep])
-        from_pv_kw = min(effective_charge_kw, pv_surplus_kw)
-        from_grid_kw = max(0.0, effective_charge_kw - from_pv_kw)
+        from_pv_kw = min(charge_power_kw, pv_surplus_kw)
+        from_grid_kw = max(0.0, charge_power_kw - from_pv_kw)
         total_kw = from_pv_kw + from_grid_kw
         if total_kw <= 0:
             return price_forecast[timestep]

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -27,13 +27,19 @@ function calculateStepCost(stepH, socWh, actionW, gridPrice, feedInPrice,
   let dcPvExcessW = pvDcW;
 
   if (actionW > 0) {
-    // Charging
-    const dcChargeW = Math.min(actionW, pvDcW * dcEff);
-    const acChargeW = actionW - dcChargeW;
-    const dcPvUsedW = dcEff > 0 ? dcChargeW / dcEff : 0;
-    dcPvExcessW     = Math.max(0, pvDcW - dcPvUsedW);
-    gridToBatteryW  = acChargeW;
-    throughputKwh   = actionW * stepH * chargeEff / 1000;
+    // Charging: grid draws the AC setpoint; passive DC MPPT charging
+    // continues on top, limited by the remaining headroom.
+    gridToBatteryW  = actionW;
+    const acStoredWh = actionW * stepH * chargeEff;
+    throughputKwh   = acStoredWh / 1000;
+    if (pvDcCoupled && pvDcW > 0 && maxSocWh !== undefined) {
+      const headroomWh      = Math.max(0, maxSocWh - socWh - acStoredWh);
+      const passiveChargeWh = Math.min(pvDcW * dcEff * stepH, headroomWh);
+      const passiveChargeW  = stepH > 0 ? passiveChargeWh / stepH : 0;
+      const dcPvConsumedW   = dcEff > 0 ? passiveChargeW / dcEff : 0;
+      dcPvExcessW    = Math.max(0, pvDcW - dcPvConsumedW);
+      throughputKwh += passiveChargeWh / 1000;
+    }
   } else if (actionW < 0) {
     // Discharging
     dcPvExcessW     = pvDcW;
@@ -174,12 +180,21 @@ function runDP(cfg, currentSocKwh, priceFc, feedInFc, pvFc, consumFc,
           if (actionW > maxChgW) continue;
           newSocWh = socWh + actionW * stepH * chargeEff;
           if (newSocWh > maxSocWh) continue;
+          if (cfg.pvDcCoupled && pvDcW > 0) {
+            const headroomWh = Math.max(0, maxSocWh - newSocWh);
+            newSocWh += Math.min(pvDcW * cfg.pvDcEfficiency * stepH, headroomWh);
+          }
         } else if (actionW < 0) {
           if (-actionW > maxDisW) continue;
           newSocWh = socWh - Math.abs(actionW) * stepH / dischargeEff;
           if (newSocWh < minSocWh) continue;
         } else {
-          newSocWh = socWh;
+          if (cfg.pvDcCoupled && pvDcW > 0) {
+            const headroomWh = Math.max(0, maxSocWh - socWh);
+            newSocWh = socWh + Math.min(pvDcW * cfg.pvDcEfficiency * stepH, headroomWh);
+          } else {
+            newSocWh = socWh;
+          }
         }
 
         const newSocIdx = findNearestSocIdx(newSocWh, socStates);
@@ -274,6 +289,10 @@ function forwardPass(dpResult, cfg, currentSocKwh, pvDcFc, inputs, chargeEffOver
         if (actionW > maxChgW) continue;
         newSocWh = curSocWh + actionW * stepH * chargeEff;
         if (newSocWh > maxSocWh) continue;
+        if (cfg.pvDcCoupled && pvDcW > 0) {
+          const headroomWh = Math.max(0, maxSocWh - newSocWh);
+          newSocWh += Math.min(pvDcW * cfg.pvDcEfficiency * stepH, headroomWh);
+        }
       } else if (actionW < 0) {
         if (-actionW > maxDisW) continue;
         newSocWh = curSocWh - Math.abs(actionW) * stepH / dischargeEff;
@@ -362,6 +381,10 @@ function rebuildSoc(powerKw, modes, cfg, currentSocKwh, stepDurations, pvDcFc) {
     if (modes[t] === 'charging' && p < -1e-9) {
       const actionW = -p * 1000;   // positive
       curSocWh = Math.min(curSocWh + actionW * stepH * chargeEff, maxSocWh);
+      if (cfg.pvDcCoupled && pvDcW > 0) {
+        const headroomWh = Math.max(0, maxSocWh - curSocWh);
+        curSocWh += Math.min(pvDcW * cfg.pvDcEfficiency * stepH, headroomWh);
+      }
     } else if (modes[t] === 'discharging' && p > 1e-9) {
       const actionW = p * 1000;    // positive
       curSocWh = Math.max(curSocWh - actionW * stepH / dischargeEff, minSocWh);
@@ -401,19 +424,12 @@ function filterOscillations(powerKw, modes, cfg, priceFc, feedInFc, pvFc,
   const filtMode = [...modes];
 
   function getChargeCost(i, chargePowKw) {
+    // The commanded power is the AC setpoint only: passive DC PV charging
+    // happens regardless of the setpoint, so it needs no deduction here.
     if (chargePowKw <= 0 || !pvFc || !consumFc || !feedInFc) return priceFc[i];
-    let effectiveKw = chargePowKw;
-    if (pvDcCoupled && pvDcFc) {
-      const stepH     = stepDurations[i] || 0.25;
-      const passiveKw = (pvDcFc[i] || 0) * pvDcEfficiency;
-      const maxPassiveKwh = maxSocKwh - minSocKwh;
-      const cappedPassive = stepH > 0 ? Math.min(passiveKw, maxPassiveKwh / stepH) : 0;
-      effectiveKw = Math.max(0, chargePowKw - cappedPassive);
-      if (effectiveKw <= 0) return 0.0;
-    }
     const pvSurplusKw = Math.max(0, (pvFc[i] || 0) - (consumFc[i] || 0));
-    const fromPv  = Math.min(effectiveKw, pvSurplusKw);
-    const fromGrid = Math.max(0, effectiveKw - fromPv);
+    const fromPv  = Math.min(chargePowKw, pvSurplusKw);
+    const fromGrid = Math.max(0, chargePowKw - fromPv);
     const total   = fromPv + fromGrid;
     if (total <= 0) return priceFc[i];
     return (fromPv * feedInFc[i] + fromGrid * priceFc[i]) / total;

--- a/simulate/simulate_diagnostics.py
+++ b/simulate/simulate_diagnostics.py
@@ -230,20 +230,27 @@ def calculate_step_cost(
     pv_production_w = max(0.0, pv_production_w)
     pv_dc_production_w = max(0.0, pv_dc_production_w)
 
-    dc_charge_w = 0.0
-    ac_charge_w = 0.0
     dc_pv_excess_w = pv_dc_production_w
     throughput_kwh = 0.0
 
     if action_w > 0:
-        dc_charge_w = min(action_w, pv_dc_production_w * dc_eff)
-        ac_charge_w = action_w - dc_charge_w
-        dc_pv_used_w = dc_charge_w / dc_eff if dc_eff > 0 else 0.0
-        dc_pv_excess_w = max(0.0, pv_dc_production_w - dc_pv_used_w)
-        grid_to_battery_w = ac_charge_w  # grid draws AC setpoint power
-        throughput_kwh = (
-            action_w * time_step_hours * charge_eff / 1000
-        )  # actual stored Wh
+        # AC charging: grid draws the AC setpoint; passive DC MPPT charging
+        # continues on top, limited by the remaining headroom.
+        grid_to_battery_w = action_w  # grid draws AC setpoint power
+        ac_stored_wh = action_w * time_step_hours * charge_eff
+        throughput_kwh = ac_stored_wh / 1000  # actual stored Wh via AC
+        if battery_config.pv_dc_coupled and pv_dc_production_w > 0:
+            max_soc_wh = battery_config.max_soc_kwh * 1000
+            headroom_wh = max(0.0, max_soc_wh - soc_wh - ac_stored_wh)
+            passive_charge_wh = min(
+                pv_dc_production_w * dc_eff * time_step_hours, headroom_wh
+            )
+            passive_charge_w = (
+                passive_charge_wh / time_step_hours if time_step_hours > 0 else 0.0
+            )
+            dc_pv_consumed_w = passive_charge_w / dc_eff if dc_eff > 0 else 0.0
+            dc_pv_excess_w = max(0.0, pv_dc_production_w - dc_pv_consumed_w)
+            throughput_kwh += passive_charge_wh / 1000
     elif action_w < 0:
         dc_pv_excess_w = pv_dc_production_w
         usable_power_w = abs(action_w)  # AC output = discharge setpoint
@@ -401,6 +408,12 @@ def run_dp(
                     new_soc_wh = soc_wh + energy_change_wh
                     if new_soc_wh > max_soc_wh:
                         continue
+                    if battery_config.pv_dc_coupled and pv_dc_w > 0:
+                        dc_eff = battery_config.pv_dc_efficiency
+                        headroom_wh = max(0.0, max_soc_wh - new_soc_wh)
+                        new_soc_wh += min(
+                            pv_dc_w * dc_eff * time_step_hours, headroom_wh
+                        )
                 elif action_w < 0:
                     if -action_w > max_dis_w:
                         continue
@@ -409,7 +422,15 @@ def run_dp(
                     if new_soc_wh < min_soc_wh:
                         continue
                 else:
-                    new_soc_wh = soc_wh
+                    if battery_config.pv_dc_coupled and pv_dc_w > 0:
+                        dc_eff = battery_config.pv_dc_efficiency
+                        headroom_wh = max(0.0, max_soc_wh - soc_wh)
+                        passive_wh = min(
+                            pv_dc_w * dc_eff * time_step_hours, headroom_wh
+                        )
+                        new_soc_wh = soc_wh + passive_wh
+                    else:
+                        new_soc_wh = soc_wh
 
                 new_soc_idx = _find_nearest_soc_idx(new_soc_wh, soc_states)
                 if action_w != 0 and new_soc_idx == s_idx:
@@ -560,6 +581,10 @@ def forward_pass(
                 new_soc_wh = current_soc + action_w * time_step_hours * charge_eff
                 if new_soc_wh > max_soc_wh:
                     continue
+                if battery_config.pv_dc_coupled and pv_dc_w > 0:
+                    dc_eff = battery_config.pv_dc_efficiency
+                    headroom_wh = max(0.0, float(max_soc_wh) - new_soc_wh)
+                    new_soc_wh += min(pv_dc_w * dc_eff * time_step_hours, headroom_wh)
             elif action_w < 0:
                 if -action_w > max_dis_w:
                     continue

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -151,14 +151,16 @@ class TestCalculateStepCost:
         # Charging adds degradation: 2000 * 0.25 / 1000 * 0.03 = 0.015
         assert cost_charge > cost_idle
 
-    def test_dc_pv_charges_at_higher_efficiency(self, dc_battery_config):
-        """DC-coupled PV charging avoids grid draw when DC PV covers the full action.
+    def test_dc_pv_charging_continues_passively_during_active_charge(
+        self, dc_battery_config
+    ):
+        """Passive DC PV charging continues on top of an active AC charge.
 
-        With action_w = AC setpoint model:
-        - AC case: 2000W action with no PV → full 2000W drawn from grid
-        - DC case: 2000W action with 2200W DC PV (> action_w / dc_eff = 2062W) →
-          dc_charge_w covers the full action, ac_charge_w = 0 → no grid draw for charging
-        The DC case has lower grid cost because the full charge comes from DC PV.
+        The AC setpoint only controls AC-side exchange: both cases draw the
+        full 2000 W setpoint from the grid (same grid cost), but the DC case
+        additionally stores the DC PV passively, so it has higher throughput
+        and therefore slightly higher degradation cost. The stored DC energy
+        is rewarded through the SoC transition (V[t+1]), not the step cost.
         """
         cost_ac = calculate_step_cost(
             time_step_hours=0.25,
@@ -184,10 +186,42 @@ class TestCalculateStepCost:
             rte=0.90,
             degradation_cost_per_kwh=0.03,
             battery_config=dc_battery_config,
-            pv_dc_production_w=2200,  # > action_w / dc_eff: DC PV fully covers the charge
+            pv_dc_production_w=2200,  # absorbed passively on top of the AC charge
         )
-        # DC PV covers full charge → no grid draw for battery; AC case draws 2000W from grid
-        assert cost_dc <= cost_ac
+        # Grid cost identical (both draw the 2000 W setpoint + 1000 W load);
+        # the DC case only adds degradation for the passively stored PV:
+        # 2200 * 0.97 * 0.25 / 1000 * 0.03 = 0.016 EUR.
+        extra_degradation = 2200 * 0.97 * 0.25 / 1000 * 0.03
+        assert cost_dc == pytest.approx(cost_ac + extra_degradation)
+
+    def test_dc_pv_passive_charge_capped_by_headroom_during_charge(
+        self, dc_battery_config
+    ):
+        """Passive DC PV during an active charge only fills remaining headroom."""
+        # soc 8500 Wh, max 9000 Wh. AC charge stores 2000 * 0.25 * sqrt(0.9)
+        # = 474 Wh → headroom left = 26 Wh; passive DC absorbs only that.
+        cost = calculate_step_cost(
+            time_step_hours=0.25,
+            soc_wh=8500,
+            action_w=2000,
+            grid_price=0.30,
+            feed_in_price=0.07,
+            pv_production_w=0,
+            consumption_w=0,
+            rte=0.90,
+            degradation_cost_per_kwh=0.0,
+            battery_config=dc_battery_config,
+            pv_dc_production_w=3000,
+        )
+        # Remaining headroom after AC charge:
+        ac_stored_wh = 2000 * 0.25 * math.sqrt(0.90)
+        headroom_wh = 9000 - 8500 - ac_stored_wh
+        dc_consumed_w = (headroom_wh / 0.25) / 0.97
+        dc_excess_w = 3000 - dc_consumed_w
+        # Net grid = 2000 (setpoint) - excess * 0.96 (to AC)
+        net_grid_w = 2000 - dc_excess_w * 0.96
+        expected = abs(net_grid_w) * 0.25 / 1000 * (0.30 if net_grid_w > 0 else -0.07)
+        assert cost == pytest.approx(expected, abs=1e-6)
 
     def test_dc_pv_passive_charge_when_idle(self, dc_battery_config):
         """In idle mode, DC-coupled inverters passively charge the battery from DC PV.
@@ -1669,27 +1703,31 @@ class TestForwardPassDCIdlePassiveCharge:
             pv_dc_peak_power_kwp=3.0,
             pv_dc_efficiency=0.97,
         )
-        # Flat prices → no arbitrage, battery should be idle
-        # Strong DC PV → passive charging should raise SoC
-        prices = [0.20, 0.20, 0.20, 0.20]
-        pv_dc = [3.0, 3.0, 3.0, 3.0]  # 3 kW DC PV all steps
+        # PV in the morning, expensive consumption in the evening: storing the
+        # DC PV passively (idle) and discharging later is clearly optimal, so
+        # the forward pass must take the idle + passive-charge branch.
+        prices = [0.20, 0.20, 0.60, 0.60]
+        pv_dc = [3.0, 3.0, 0.0, 0.0]  # 3 kW DC PV in the first two steps
 
         result = optimize_battery_schedule(
             battery_config=cfg,
-            current_soc_kwh=5.0,
+            current_soc_kwh=2.0,
             price_forecast=prices,
-            feed_in_forecast=None,
+            feed_in_forecast=[0.07] * 4,
             pv_forecast=[0.0] * 4,
-            consumption_forecast=[0.5] * 4,
+            consumption_forecast=[0.0, 0.0, 3.0, 3.0],
             step_durations_hours=[1.0, 1.0, 1.0, 1.0],
             pv_dc_forecast=pv_dc,
-            degradation_cost_per_kwh=0.5,  # Very high: forces idle
-            min_price_spread=1.0,  # Very high: blocks all arbitrage
+            degradation_cost_per_kwh=0.03,
+            min_price_spread=0.05,
         )
-        # With DC PV passive charging and idle action, SoC should increase
         assert len(result.soc_schedule_kwh) == 5
-        # SoC at end should be >= initial (passive charging)
-        assert result.soc_schedule_kwh[-1] >= result.soc_schedule_kwh[0] - 0.01
+        # PV steps are idle (passive charging only) and raise the SoC by
+        # ~2.91 kWh per step (3 kW × 0.97).
+        assert result.mode_schedule[0] == "idle"
+        assert result.soc_schedule_kwh[1] == pytest.approx(2.0 + 3.0 * 0.97, abs=0.05)
+        # Stored PV is discharged during the expensive consumption steps.
+        assert "discharging" in result.mode_schedule[2:]
 
 
 class TestFilterOscillationsGetChargeCostZeroTotal:


### PR DESCRIPTION
## Problem
For DC-coupled systems the model was internally inconsistent between idle and active charging:

- **Idle** (`action_w == 0`): DC PV passively charges the battery up to headroom (correct — the AC setpoint only stops AC-side charging, not the MPPT).
- **Active charge** (`action_w > 0`): total battery charging was capped at the AC setpoint, with DC PV "used first" inside the setpoint.

Consequence: a small charge command (e.g. 500 W with 1 kW DC PV) absorbed **less** energy than doing nothing — physically impossible for a hybrid inverter, and it made small charge actions strictly dominated by idle in the DP. The SoC transition also stored the DC portion at `sqrt(RTE)` while the cost model priced it at `dc_eff` (0.97).

## Fix
The AC setpoint now only controls AC-side exchange, consistently in all branches:

- **Charging**: grid draws the full setpoint (stored at `charge_eff`); passive DC MPPT charging continues on top, limited by the headroom remaining after the AC charge; excess DC PV flows to AC at 96%.
- **Oscillation filter** (`get_charge_cost`): commanded charge power is AC-only, so the passive-DC deduction was removed.
- Applied to `calculate_step_cost`, the backward + forward DP transitions, and `_rebuild_schedule`.

Synced to `docs/analyzer.js` and `simulate/simulate_diagnostics.py` per CLAUDE.md. While syncing, both turned out to be missing the **idle** passive-charging transition in their backward DP relative to `optimizer.py` — that pre-existing drift is fixed here too. `ALGORITHM.md` §4.2 rewritten.

## Behavioral note
With this model the DP may discharge a small amount during PV hours when feed-in ≈ terminal value: routing PV to AC export avoids storage degradation for energy that would only be sold at the same price later. That is economically correct given a degradation cost; it shows up in one updated test scenario (see `test_dc_pv_idle_charges_battery_in_forward_pass`, which now uses a store-then-consume scenario where idle+passive charging is genuinely optimal).

## Tests
- `test_dc_pv_charges_at_higher_efficiency` replaced by two tests asserting the new semantics (identical grid cost, extra throughput/degradation for passively stored PV; headroom capping during active charge)
- Full suite green, pre-commit green