### PR TITLE
fix: clamp terminal price at zero for negative feed-in tails

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -215,7 +215,7 @@ The negative sign is because `V` represents cost — more stored energy means lo
 
 **Choosing `terminal_price`:**
 
-`min(feed_in_forecast[-1], clipped average of the last 6 h of feed-in prices)` — a blended tail that dampens transient price spikes at the forecast boundary. The shadow price from the previous run is deliberately **not** used as terminal value: λ ≈ sqrt(RTE) × P_best, so using it would make discharge at the best price hour break-even and suppress discharge exactly at the peak (a circular dependency in rolling-horizon re-optimization). The shadow price is only used by hybrid mode as the charge/discharge switching threshold.
+`max(0, min(feed_in_forecast[-1], clipped average of the last 6 h of feed-in prices))` — a blended tail that dampens transient price spikes at the forecast boundary, clamped at 0 so a negative feed-in tail never penalizes stored energy (the horizon end is artificial; the battery is never forced to sell at a loss). The shadow price from the previous run is deliberately **not** used as terminal value: λ ≈ sqrt(RTE) × P_best, so using it would make discharge at the best price hour break-even and suppress discharge exactly at the peak (a circular dependency in rolling-horizon re-optimization). The shadow price is only used by hybrid mode as the charge/discharge switching threshold.
 
 ---
 

--- a/custom_components/battery_controller/optimizer.py
+++ b/custom_components/battery_controller/optimizer.py
@@ -546,7 +546,12 @@ def optimize_battery_schedule(
         median_price = sorted_prices[len(sorted_prices) // 2]
         clipped_tail = [min(p, median_price) for p in feed_in_forecast[-lookback:]]
         avg_tail = sum(clipped_tail) / len(clipped_tail)
-        terminal_price = min(feed_in_forecast[-1], avg_tail)
+        # Clamp at 0: a negative feed-in tail must not give stored energy a
+        # negative terminal value. The horizon end is artificial — the battery
+        # is never forced to sell at a loss, so holding energy is worth at
+        # least zero. Without the clamp the DP dumps energy before the horizon
+        # ends purely to escape the artificial penalty.
+        terminal_price = max(0.0, min(feed_in_forecast[-1], avg_tail))
     else:
         terminal_price = 0.0
     for s_idx, soc_wh in enumerate(soc_states):

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -116,7 +116,8 @@ function runDP(cfg, currentSocKwh, priceFc, feedInFc, pvFc, consumFc,
     const medianPrice = sortedPrices[Math.floor(sortedPrices.length / 2)];
     const clippedTail = feedInFc.slice(-lookback).map(p => Math.min(p, medianPrice));
     const avgTail = clippedTail.reduce((s, p) => s + p, 0) / clippedTail.length;
-    terminalPrice = Math.min(feedInFc[feedInFc.length - 1], avgTail);
+    // Clamp at 0: negative feed-in tail must not penalize stored energy.
+    terminalPrice = Math.max(0, Math.min(feedInFc[feedInFc.length - 1], avgTail));
   } else {
     terminalPrice = 0;
   }

--- a/simulate/simulate_diagnostics.py
+++ b/simulate/simulate_diagnostics.py
@@ -362,7 +362,8 @@ def run_dp(
         median_price = sorted_prices[len(sorted_prices) // 2]
         clipped_tail = [min(p, median_price) for p in feed_in_forecast[-lookback:]]
         avg_tail = sum(clipped_tail) / len(clipped_tail)
-        terminal_price = min(feed_in_forecast[-1], avg_tail)
+        # Clamp at 0: negative feed-in tail must not penalize stored energy.
+        terminal_price = max(0.0, min(feed_in_forecast[-1], avg_tail))
     else:
         terminal_price = 0.0
     for s_idx, soc_wh in enumerate(soc_states):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -2600,3 +2600,36 @@ class TestBaselineGridCap:
         )
         # Capped baseline: 4 h x 3 kW x 0.10 = 1.20 EUR revenue.
         assert result.baseline_cost == pytest.approx(-1.20)
+
+
+class TestTerminalPriceClamp:
+    """Negative feed-in tail must not give stored energy a negative terminal value."""
+
+    def test_negative_feed_in_tail_does_not_force_discharge(self):
+        """With all-negative feed-in and no load, the battery should stay idle.
+
+        Without the clamp, V[T] penalizes stored energy (negative terminal
+        price), so the DP dumps energy before the horizon ends even though
+        exporting at a negative price costs money.
+        """
+        cfg = BatteryConfig(
+            capacity_kwh=10.0,
+            max_charge_power_kw=5.0,
+            max_discharge_power_kw=5.0,
+            round_trip_efficiency=0.90,
+            min_soc_percent=10.0,
+            max_soc_percent=90.0,
+        )
+        result = optimize_battery_schedule(
+            battery_config=cfg,
+            current_soc_kwh=5.0,
+            price_forecast=[0.20] * 6,
+            feed_in_forecast=[-0.05] * 6,
+            pv_forecast=[0.0] * 6,
+            consumption_forecast=[0.0] * 6,
+            step_durations_hours=[1.0] * 6,
+            degradation_cost_per_kwh=0.01,
+            min_price_spread=0.05,
+        )
+        assert all(m == "idle" for m in result.mode_schedule)
+        assert result.soc_schedule_kwh[-1] == pytest.approx(5.0)


### PR DESCRIPTION
## Problem
The terminal condition `V[T][s] = -(stored_kwh × terminal_price)` used `min(feed_in[-1], clipped tail average)` without a lower bound. With a negative feed-in tail (increasingly common on sunny days), stored energy got a **negative** terminal value, so the DP discharged the battery before the horizon ended purely to escape an artificial penalty — even though exporting at a negative price costs real money.

The horizon end is not a real deadline: the battery is never forced to sell at a loss, so stored energy is worth at least zero.

## Fix
`terminal_price = max(0.0, min(feed_in_forecast[-1], avg_tail))` — applied to all three DP implementations (`optimizer.py`, `docs/analyzer.js`, `simulate/simulate_diagnostics.py`) per CLAUDE.md, plus the terminal-condition section of `ALGORITHM.md`.

## Tests
- New regression test: all-negative feed-in, no load → schedule stays idle and SoC is preserved
- Full suite green, pre-commit green