### PR TITLE
refactor: remove dead terminal_shadow_price parameter

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -49,7 +49,6 @@ The optimizer must respect physical constraints: SoC must stay within `[min_soc,
 | `step_durations_hours[t]` | h | Duration of each time step (typically 0.25 h = 15 min) |
 | `degradation_cost_per_cycle` | EUR/cycle | Battery wear cost per full charge+discharge cycle (converted to EUR/kWh by coordinator: `÷ usable_kwh`) |
 | `min_price_spread` | EUR/kWh | Minimum buy/sell spread to trigger arbitrage |
-| `terminal_shadow_price` | EUR/kWh | Marginal value of stored energy from previous run (optional) |
 
 **Battery configuration:**
 
@@ -212,8 +211,7 @@ The negative sign is because `V` represents cost — more stored energy means lo
 
 **Choosing `terminal_price`:**
 
-1. **Preferred**: `terminal_shadow_price` from the previous optimizer run. This is the marginal value of stored energy derived from the full price structure (see [Section 9](#9-shadow-price-calculation)). It is more stable than a single end-of-horizon price.
-2. **Fallback**: `min(feed_in_forecast[-1], average of last 6 feed-in prices)` — blended tail to dampen transient price spikes at the forecast boundary.
+`min(feed_in_forecast[-1], clipped average of the last 6 h of feed-in prices)` — a blended tail that dampens transient price spikes at the forecast boundary. The shadow price from the previous run is deliberately **not** used as terminal value: λ ≈ sqrt(RTE) × P_best, so using it would make discharge at the best price hour break-even and suppress discharge exactly at the peak (a circular dependency in rolling-horizon re-optimization). The shadow price is only used by hybrid mode as the charge/discharge switching threshold.
 
 ---
 
@@ -390,7 +388,7 @@ Charge-speed correction: when runtime calibration detects that the battery gains
 
 The shadow price is always the raw DP value — there is no separate "post-processed" shadow price. Post-processing filters affect `total_cost` and `savings` (where the difference between raw and processed values shows the impact of filtered actions), but the shadow price is a DP concept that is not modified by post-processing.
 
-**Use as terminal condition**: λ is passed to the next optimizer run as `terminal_shadow_price`, replacing the end-of-horizon feed-in price in the terminal condition. This makes consecutive 15-minute runs consistent with each other (rolling-horizon stability).
+**Use by hybrid mode**: λ is used by the coordinator as the charge/discharge switching threshold in hybrid mode. It is deliberately not fed back into the next run's terminal condition (see [Section 5](#5-terminal-condition)).
 
 ---
 
@@ -399,7 +397,7 @@ The shadow price is always the raw DP value — there is no separate "post-proce
 The optimizer runs every 15 minutes. Each run:
 
 1. Reads the current SoC and latest forecasts.
-2. Calls `optimize_battery_schedule()` with the previous run's shadow price as `terminal_shadow_price`.
+2. Calls `optimize_battery_schedule()` with the latest forecasts and calibration overrides.
 3. Executes **only the first step** of the resulting schedule (`optimal_power_kw`).
 4. Saves the new shadow price for the next run.
 

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -161,7 +161,6 @@ class OptimizationCoordinator(DataUpdateCoordinator):
 
         # Last optimization result and effective mode (persists between real-time updates)
         self._last_result: OptimizationResult | None = None
-        self._last_shadow_price: float | None = None
         self._effective_mode: str = ACTION_IDLE
         self._effective_power: float = 0.0
         # Schedule power currently sent to the controller after all mode resolution
@@ -1847,12 +1846,6 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             len(resampled_prices),
         )
 
-        _LOGGER.debug(
-            "Terminal shadow price: %s",
-            f"{self._last_shadow_price:.4f} €/kWh"
-            if self._last_shadow_price is not None
-            else "none (first run, using feed-in tail)",
-        )
         # Convert degradation cost from per-cycle to per-kWh throughput for the optimizer.
         # One cycle = max_soc_kwh - min_soc_kwh (usable capacity).
         usable_kwh = battery_config.max_soc_kwh - battery_config.min_soc_kwh
@@ -1872,12 +1865,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             degradation_cost_per_kwh,
             min_spread,
             pv_dc_forecast,
-            self._last_shadow_price,
             charge_eff_override,
             discharge_eff_override,
         )
 
-        self._last_shadow_price = result.shadow_price_eur_kwh
         self._last_result = result
 
         # Get current grid power: prefer real sensor, fall back to estimate

--- a/custom_components/battery_controller/optimizer.py
+++ b/custom_components/battery_controller/optimizer.py
@@ -380,7 +380,6 @@ def optimize_battery_schedule(
     degradation_cost_per_kwh: float = 0.03,
     min_price_spread: float = 0.05,
     pv_dc_forecast: list[float] | None = None,  # kW (DC-coupled PV)
-    terminal_shadow_price: float | None = None,  # EUR/kWh from previous run
     charge_eff_override: float | None = None,  # Override charge-side efficiency only
     discharge_eff_override: float
     | None = None,  # Override discharge-side efficiency only
@@ -403,12 +402,6 @@ def optimize_battery_schedule(
         degradation_cost_per_kwh: Degradation cost in EUR/kWh
         min_price_spread: Minimum price spread for arbitrage
         pv_dc_forecast: DC-coupled PV production forecast in kW (optional)
-        terminal_shadow_price: Shadow price (λ) from the previous optimization
-            run, used as the terminal condition value for stored energy.  When
-            provided this replaces the feed-in tail average, producing a more
-            stable rolling-horizon schedule because λ is derived from the full
-            price structure rather than a single end-of-horizon price point.
-            Must be ≥ 0; negative values are ignored (fallback to feed-in tail).
         charge_eff_override: Override for the charge-side SoC transition only.
             When provided, charging state transitions use this value instead of
             sqrt(RTE) so the DP plans less charge within the step when charging
@@ -512,9 +505,9 @@ def optimize_battery_schedule(
     # re-optimisation the "best" hours are often the current hours, so this
     # circular dependency suppresses discharge exactly at the peak.  The tail
     # average is naturally below peak prices and avoids this trap.
-    # terminal_shadow_price is still passed to the caller and used by hybrid
-    # mode as the charge/discharge switching threshold — it is just no longer
-    # used to initialise V[T].
+    # The shadow price is still returned to the caller and used by hybrid
+    # mode as the charge/discharge switching threshold — it is just not used
+    # to initialise V[T].
     # The lookback window is time-based (6 h) so behaviour is identical for
     # 15-min, 30-min and 60-min price intervals.
     #

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -75,7 +75,7 @@ function findNearestSocIdx(socWh, socStates) {
 }
 
 function runDP(cfg, currentSocKwh, priceFc, feedInFc, pvFc, consumFc,
-               stepDurations, degradCost, minPriceSpread, pvDcFc, terminalShadowPrice, chargeEffOverride, dischargeEffOverride) {
+               stepDurations, degradCost, minPriceSpread, pvDcFc, chargeEffOverride, dischargeEffOverride) {
 
   const rte      = cfg.rte;
   const sqrtRte  = Math.sqrt(rte);
@@ -571,7 +571,7 @@ function computeTotalCost(powerKw, socKwh, inputs, cfg) {
 
 function runOptimizer(cfg, currentSocKwh, inputs) {
   const { priceFc, feedInFc, pvFc, consumFc, stepDurations, degradCost,
-          minPriceSpread, pvDcFc, terminalShadowPrice, chargeEffCorrection,
+          minPriceSpread, pvDcFc, chargeEffCorrection,
           dischargeEffCorrection } = inputs;
   const nominalSqrtRte = Math.sqrt(cfg.rte);
   const chargeEffOverride =
@@ -584,7 +584,7 @@ function runOptimizer(cfg, currentSocKwh, inputs) {
       : null;
 
   const dp = runDP(cfg, currentSocKwh, priceFc, feedInFc, pvFc, consumFc,
-                   stepDurations, degradCost, minPriceSpread, pvDcFc, terminalShadowPrice, chargeEffOverride, dischargeEffOverride);
+                   stepDurations, degradCost, minPriceSpread, pvDcFc, chargeEffOverride, dischargeEffOverride);
   let { powerKw, modes } = forwardPass(dp, cfg, currentSocKwh, pvDcFc, inputs, chargeEffOverride, dischargeEffOverride);
 
   // Post-processing filters (matching optimizer.py)

--- a/docs/index.html
+++ b/docs/index.html
@@ -309,8 +309,6 @@
         <input id="sp-spread" type="number" value="0.05" step="0.01" class="sim-input mt-0.5"></label>
       <label class="block"><span class="kv-label">Step duration (hours) — 0.25 = 15 min, 1.0 = 60 min</span>
         <input id="sp-step-h" type="number" value="0.25" step="0.0833" min="0.0833" max="1" class="sim-input mt-0.5"></label>
-      <label class="block"><span class="kv-label">Terminal shadow price (€/kWh, 0=auto)</span>
-        <input id="sp-terminal" type="number" value="0" step="0.01" class="sim-input mt-0.5"></label>
       <label class="flex items-center gap-2 mt-2 cursor-pointer">
         <input id="sp-pv-curtailed" type="checkbox" class="w-4 h-4 rounded">
         <span class="kv-label">PV Curtailed (zero out all PV forecasts)</span>
@@ -901,7 +899,7 @@ function renderDiagnostics(raw) {
       consumFc.length ? consumFc : new Array(prices.length).fill(0),
       resolvedStepDurs.length ? resolvedStepDurs : null,
       degradPerKwhDp, opts.min_price_spread || 0.05,
-      null, sched.terminal_shadow_price ?? null);
+      null);
     // Use shadow price from diagnostics if available; otherwise compute from V
     if (opt.shadow_price_eur_kwh === undefined || opt.shadow_price_eur_kwh === null) {
       const shadow = computeShadowPrice(dp2.V, dp2.socStates, bs.soc_kwh || 5);
@@ -1090,7 +1088,6 @@ function getSimParams() {
     degradation:   g('sp-degradation'),
     minPriceSpread:g('sp-spread'),
     stepH:         g('sp-step-h') || 0.25,
-    terminalShadowPrice: g('sp-terminal') || null,
     charge_eff_correction: window._simChargeEffCorrection ?? null,
     discharge_eff_correction: window._simDischargeEffCorrection ?? null,
   };
@@ -1156,8 +1153,7 @@ function prefillSim(d) {
   }
   // Pre-fill terminal shadow price from previous DP run (stored in schedule)
   if (sched.terminal_shadow_price !== undefined && sched.terminal_shadow_price !== null) {
-    set('sp-terminal', sched.terminal_shadow_price);
-  }
+    }
   window._simChargeEffCorrection =
     opt.charge_eff_correction
     ?? ((opt.optimizer_run_log && opt.optimizer_run_log.length)
@@ -1182,7 +1178,6 @@ function runSimulator() {
       if (price.length < 2) { statusEl.textContent = '⚠ Add at least 2 rows'; return; }
 
       const stepH   = p.stepH || 0.25;
-      const termSP  = p.terminalShadowPrice > 0 ? p.terminalShadowPrice : null;
       const simUsableKwh = (p.maxSocKwh - p.minSocKwh) || 1;
       const degradPerKwhSim = p.degradation / simUsableKwh;
       const pvCurtailed = document.getElementById('sp-pv-curtailed').checked;
@@ -1193,7 +1188,7 @@ function runSimulator() {
         consumFc: consump,
         stepDurations: new Array(price.length).fill(stepH),
         degradCost: degradPerKwhSim, minPriceSpread: p.minPriceSpread,
-        pvDcFc: null, terminalShadowPrice: termSP,
+        pvDcFc: null,
         chargeEffCorrection: p.charge_eff_correction,
         dischargeEffCorrection: p.discharge_eff_correction,
       };

--- a/simulate/brute_force_step0.py
+++ b/simulate/brute_force_step0.py
@@ -117,7 +117,6 @@ def run_sweep(diag_path: str) -> list[dict]:
                 degradation_cost_per_kwh=degradation_cost,
                 min_price_spread=min_price_spread,
                 pv_dc_forecast=pv_dc_forecast,
-                terminal_shadow_price=terminal_shadow_price,
             )
 
             power_schedule, mode_schedule, soc_schedule = forward_pass(

--- a/simulate/bruteforce_diagnostics.py
+++ b/simulate/bruteforce_diagnostics.py
@@ -102,7 +102,6 @@ def run_scenarios(
 
     degradation_cost = float(options.get("degradation_cost_per_kwh", 0.04))
     min_price_spread = float(options.get("min_price_spread", 0.0))
-    terminal_shadow_price = schedule.get("terminal_shadow_price")
 
     if soc_deltas is None:
         soc_deltas = [-0.20, -0.15, -0.10, -0.05, 0.0, 0.05, 0.10, 0.15, 0.20]
@@ -129,7 +128,6 @@ def run_scenarios(
                     step_durations_hours=sliced["step_durations_hours"],
                     degradation_cost_per_kwh=degradation_cost,
                     min_price_spread=min_price_spread,
-                    terminal_shadow_price=terminal_shadow_price,
                 )
                 first_step_h = float(sliced["step_durations_hours"][0])
                 full_step_h = (

--- a/simulate/simulate_diagnostics.py
+++ b/simulate/simulate_diagnostics.py
@@ -308,7 +308,6 @@ def run_dp(
     degradation_cost_per_kwh,
     min_price_spread,
     pv_dc_forecast=None,
-    terminal_shadow_price=None,
     charge_eff_override=None,
     discharge_eff_override=None,
 ):
@@ -1119,9 +1118,8 @@ def main():
         f"min_spread={min_price_spread:.3f} €/kWh"
     )
     if terminal_shadow_price is not None:
-        print(
-            f"  terminal_shadow_price (from previous run): {terminal_shadow_price:.4f} €/kWh"
-        )
+        # Informational only: the DP terminal condition uses the feed-in tail.
+        print(f"  shadow price (from diagnostics): {terminal_shadow_price:.4f} €/kWh")
 
     # Show charge/discharge efficiency calibration state if present in diagnostics
     opt_top = diag.get("data", diag).get("optimization", {})
@@ -1180,7 +1178,6 @@ def main():
         degradation_cost_per_kwh=degradation_cost,
         min_price_spread=min_price_spread,
         pv_dc_forecast=pv_dc_forecast,
-        terminal_shadow_price=terminal_shadow_price,
         charge_eff_override=charge_eff_override,
         discharge_eff_override=discharge_eff_override,
     )

--- a/simulate/test_ha_vs_sim.py
+++ b/simulate/test_ha_vs_sim.py
@@ -124,7 +124,6 @@ def main():
         step_durations_hours=step_durations_hours,
         degradation_cost_per_kwh=degradation_cost,
         min_price_spread=min_price_spread,
-        terminal_shadow_price=terminal_shadow_price,
     )
 
     print("=" * 120)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -934,8 +934,8 @@ class TestMicroCycleFilter:
         assert soc == [5.0, 5.0, 5.0]
 
 
-class TestTerminalShadowPrice:
-    """Tests for terminal_shadow_price parameter."""
+class TestShadowPriceOutput:
+    """Tests for the shadow price returned by the optimizer."""
 
     def _base_args(self, battery_config):
         return dict(
@@ -948,39 +948,8 @@ class TestTerminalShadowPrice:
             min_price_spread=0.05,
         )
 
-    def test_shadow_price_not_used_as_terminal(self, battery_config):
-        """terminal_shadow_price must not affect the DP terminal condition.
-
-        Using the shadow price as terminal_price creates a circular dependency in
-        rolling-horizon re-optimisation: λ ≈ sqrt(RTE) × P_best, so the opportunity
-        cost of discharging at P_best becomes P_best — making peak-hour discharge
-        break-even and degradation tips it to idle.  The terminal value now always
-        uses the feed-in tail average; terminal_shadow_price is only passed through
-        to the caller for use as the hybrid mode switching threshold.
-        """
-        flat_price = [0.20] * 8
-        feed_in = [0.07] * 8
-        args = self._base_args(battery_config)
-
-        result_high = optimize_battery_schedule(
-            price_forecast=flat_price,
-            feed_in_forecast=feed_in,
-            terminal_shadow_price=0.40,
-            **args,
-        )
-        result_low = optimize_battery_schedule(
-            price_forecast=flat_price,
-            feed_in_forecast=feed_in,
-            terminal_shadow_price=0.01,
-            **args,
-        )
-
-        assert result_high.power_schedule_kw == result_low.power_schedule_kw, (
-            "terminal_shadow_price should not influence the DP schedule"
-        )
-
-    def test_fallback_when_no_shadow_price(self, battery_config):
-        """Without shadow price, optimizer uses feed-in tail average as terminal."""
+    def test_terminal_uses_feed_in_tail(self, battery_config):
+        """The terminal condition uses the feed-in tail average."""
         price = [0.10, 0.10, 0.10, 0.30, 0.30, 0.30, 0.30, 0.30]
         feed_in = [0.07] * 8
         args = self._base_args(battery_config)
@@ -988,70 +957,27 @@ class TestTerminalShadowPrice:
         result = optimize_battery_schedule(
             price_forecast=price,
             feed_in_forecast=feed_in,
-            terminal_shadow_price=None,
             **args,
         )
         # Should return a valid result with no crash
         assert len(result.power_schedule_kw) == 8
         assert result.shadow_price_eur_kwh >= 0.0
 
-    def test_shadow_price_always_ignored_for_terminal(self, battery_config):
-        """Any terminal_shadow_price value (None, negative, positive) gives identical DP results."""
-        price = [0.20] * 8
-        feed_in = [0.07] * 8
-        args = self._base_args(battery_config)
-
-        result_none = optimize_battery_schedule(
-            price_forecast=price,
-            feed_in_forecast=feed_in,
-            terminal_shadow_price=None,
-            **args,
-        )
-        result_neg = optimize_battery_schedule(
-            price_forecast=price,
-            feed_in_forecast=feed_in,
-            terminal_shadow_price=-0.10,
-            **args,
-        )
-        result_pos = optimize_battery_schedule(
-            price_forecast=price,
-            feed_in_forecast=feed_in,
-            terminal_shadow_price=0.50,
-            **args,
-        )
-
-        assert result_none.power_schedule_kw == result_neg.power_schedule_kw
-        assert result_none.power_schedule_kw == result_pos.power_schedule_kw
-
-    def test_shadow_price_self_consistency(self, battery_config):
-        """Shadow price fed back as terminal should be close to the new shadow price."""
-        # Stable price scenario: shadow price should converge after one round-trip.
+    def test_shadow_price_within_reasonable_bounds(self, battery_config):
+        """The returned shadow price stays within a reasonable price range."""
         price = [0.10, 0.10, 0.20, 0.20, 0.10, 0.10, 0.20, 0.20]
         feed_in = [0.07] * 8
         args = self._base_args(battery_config)
 
-        # Run 1: no prior shadow price
-        result1 = optimize_battery_schedule(
+        result = optimize_battery_schedule(
             price_forecast=price,
             feed_in_forecast=feed_in,
-            terminal_shadow_price=None,
             **args,
         )
-        lambda1 = result1.shadow_price_eur_kwh
-
-        # Run 2: feed shadow price from run 1 back as terminal condition
-        result2 = optimize_battery_schedule(
-            price_forecast=price,
-            feed_in_forecast=feed_in,
-            terminal_shadow_price=lambda1,
-            **args,
-        )
-        lambda2 = result2.shadow_price_eur_kwh
-
-        # Shadow price should not explode — stay within a reasonable range of the prices
+        lam = result.shadow_price_eur_kwh
         max_price = max(price)
-        assert 0.0 <= lambda2 <= max_price * 2, (
-            f"Shadow price {lambda2} after feedback is outside reasonable bounds"
+        assert 0.0 <= lam <= max_price * 2, (
+            f"Shadow price {lam} is outside reasonable bounds"
         )
 
 


### PR DESCRIPTION
## Problem
The optimizer stopped using `terminal_shadow_price` as the terminal condition some time ago (the feed-in tail average is used instead, with the circular-dependency rationale documented inline), but the parameter survived everywhere, documenting behaviour that no longer exists:

- `optimize_battery_schedule()` accepted and silently ignored it, while its docstring claimed it *replaces* the feed-in tail
- the coordinator kept a `_last_shadow_price` attribute and logged "Terminal shadow price" before every run
- `docs/analyzer.js` (`runDP`) and the `simulate/` scripts carried it through their signatures
- the diagnostics simulator UI in `docs/index.html` had a "Terminal shadow price" input field that did nothing
- `ALGORITHM.md` §5 still listed it as the *preferred* terminal value

## Fix
Removed the dead parameter and plumbing throughout, and rewrote the affected `ALGORITHM.md` sections to describe the actual behaviour. The shadow price itself is still computed and returned — hybrid mode uses it as the charge/discharge switching threshold.

Tests asserting "the parameter has no effect" were replaced by tests of the shadow-price output itself.

## Tests
Full suite green, pre-commit green.