### PR TITLE
docs: fix inverted shadow-price threshold formulas

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -383,8 +383,8 @@ The **shadow price** λ is the marginal value of one additional kWh stored in th
 - For boundary SoC states, a one-sided difference is used.
 
 **Interpretation**:
-- If the current grid buy price is less than `λ / sqrt(RTE)`, it is profitable to charge — the stored energy is worth more than its purchase cost.
-- If the current feed-in price is greater than `λ × sqrt(RTE)`, it is profitable to discharge/export.
+- If the current grid buy price is less than `λ × sqrt(RTE)`, it is profitable to charge — 1 kWh bought from AC stores `sqrt(RTE)` kWh worth `λ` each, so the stored energy is worth more than its purchase cost.
+- If the current feed-in price is greater than `λ / sqrt(RTE)`, it is profitable to discharge/export — 1 stored kWh yields `sqrt(RTE)` kWh on the AC side, so the sale revenue exceeds the value of keeping the energy.
 
 Charge-speed correction: when runtime calibration detects that the battery gains less SoC per time step than modelled, the optimizer reduces only the **charge-side SoC transition** for planning. The economic cost model and arbitrage thresholds continue to use the nominal `sqrt(RTE)` so a charging-speed limit is not double-counted as extra energy loss.
 

--- a/custom_components/battery_controller/optimizer.py
+++ b/custom_components/battery_controller/optimizer.py
@@ -41,8 +41,10 @@ class OptimizationResult:
 
     # Shadow price: marginal value of 1 kWh stored right now (EUR/kWh).
     # Represents how much future costs decrease per additional kWh in the battery.
-    # Use as a threshold: charge when buy_price < shadow_price / sqrt(RTE),
-    # and discharge/export when feed_in_price > shadow_price * sqrt(RTE).
+    # Use as a threshold: charging 1 kWh AC stores sqrt(RTE) kWh worth λ each, so
+    # charge when buy_price < shadow_price × sqrt(RTE). Discharging 1 stored kWh
+    # yields sqrt(RTE) kWh AC, so discharge/export when
+    # feed_in_price > shadow_price / sqrt(RTE).
     shadow_price_eur_kwh: float
 
     # Metadata


### PR DESCRIPTION
## Problem
The `OptimizationResult.shadow_price_eur_kwh` docstring and the interpretation section of `ALGORITHM.md` stated the charge/discharge thresholds with `sqrt(RTE)` on the wrong side:

- **Stated**: charge when `buy < λ / √RTE`, discharge when `feed_in > λ × √RTE`
- **Correct**: charging 1 kWh AC stores `√RTE` kWh worth `λ` each → charge when `buy < λ × √RTE`. Discharging 1 stored kWh yields `√RTE` kWh AC → discharge when `feed_in > λ / √RTE`.

Since `√RTE < 1` the stated thresholds were materially different (≈11% off at RTE 0.90), which would mislead anyone using the documented formulas to interpret the shadow-price sensor or build automations on top of it.

The hybrid-mode implementation in the coordinator already used the correct comparison (`feed_in × √RTE ≥ λ`); only the documentation was wrong.

## Fix
Docstring and `ALGORITHM.md` corrected, with one line of derivation each so the direction is verifiable. Documentation only — no behavior change.

## Tests
Full suite green, pre-commit green.