### PR TITLE
fix: apply grid capacity cap to baseline cost

### DIFF
--- a/custom_components/battery_controller/optimizer.py
+++ b/custom_components/battery_controller/optimizer.py
@@ -129,12 +129,18 @@ def _calculate_baseline_cost(
     consumption_forecast: list[float],
     step_durations_hours: list[float],
     pv_dc_forecast: list[float],
+    max_grid_power_kw: float = 0.0,
 ) -> float:
     """Calculate horizon cost without battery action.
 
     Baseline scenario: no battery exists. DC-coupled PV panels would still
     produce power, but without a battery to absorb it, all DC PV goes through
     the inverter to AC (at DC_TO_AC_INVERTER_EFFICIENCY).
+
+    The grid capacity cap (max_grid_power_kw, 0 = unlimited) is applied the
+    same way as in calculate_step_cost: without it, the baseline could "sell"
+    PV beyond the physical grid connection, inflating baseline revenue and
+    distorting the reported savings.
     """
     baseline_cost = 0.0
     n_steps = min(len(price_forecast), len(pv_forecast), len(consumption_forecast))
@@ -150,6 +156,9 @@ def _calculate_baseline_cost(
         dc_pv_to_ac_w = pv_dc_w * DC_TO_AC_INVERTER_EFFICIENCY if pv_dc_w > 0 else 0
         total_pv_w = pv_w + dc_pv_to_ac_w
         net_grid_w = consumption_w - total_pv_w
+        if max_grid_power_kw > 0:
+            cap_w = max_grid_power_kw * 1000
+            net_grid_w = max(-cap_w, min(cap_w, net_grid_w))
         energy_kwh = abs(net_grid_w) * time_step_hours / 1000
         if net_grid_w > 0:
             baseline_cost += energy_kwh * grid_price
@@ -925,6 +934,7 @@ def optimize_battery_schedule(
         consumption_forecast=consumption_forecast[:n_steps],
         step_durations_hours=step_durations_hours[:n_steps],
         pv_dc_forecast=pv_dc_forecast[:n_steps],
+        max_grid_power_kw=battery_config.max_grid_power_kw,
     )
 
     # Savings = value added by battery ACTIONS only.

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -526,7 +526,12 @@ function computeBaselineCost(inputs, cfg) {
     // All DC PV → AC at DC_TO_AC_EFF (no battery to absorb it)
     const dcPvToAcW = pvDcW > 0 ? pvDcW * DC_TO_AC_EFF : 0;
     const totalPvW  = pvW + dcPvToAcW;
-    const netGridW  = consumW - totalPvW;
+    let netGridW    = consumW - totalPvW;
+    // Apply the grid capacity cap like calculateStepCost does.
+    if (cfg.maxGridPowerKw > 0) {
+      const capW = cfg.maxGridPowerKw * 1000;
+      netGridW   = Math.max(-capW, Math.min(capW, netGridW));
+    }
     const energyKwh = Math.abs(netGridW) * stepH / 1000;
     baseline += netGridW > 0 ? energyKwh * priceFc[t] : -energyKwh * feedIn;
   }

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -2573,3 +2573,66 @@ class TestEffOverrideZeroGuard:
         )
         assert result is not None
         assert len(result.power_schedule_kw) == 4
+
+
+class TestBaselineGridCap:
+    """Baseline cost must respect the grid capacity cap like the step cost does."""
+
+    def test_baseline_export_capped(self):
+        from custom_components.battery_controller.optimizer import (
+            _calculate_baseline_cost,
+        )
+
+        # 10 kW PV surplus, 3 kW export cap, 1 hour, feed-in 0.10:
+        # uncapped revenue would be 1.00 EUR; capped it is 0.30 EUR.
+        cost = _calculate_baseline_cost(
+            price_forecast=[0.20],
+            feed_in_forecast=[0.10],
+            pv_forecast=[10.0],
+            consumption_forecast=[0.0],
+            step_durations_hours=[1.0],
+            pv_dc_forecast=[0.0],
+            max_grid_power_kw=3.0,
+        )
+        assert cost == pytest.approx(-0.30)
+
+    def test_baseline_unlimited_when_cap_zero(self):
+        from custom_components.battery_controller.optimizer import (
+            _calculate_baseline_cost,
+        )
+
+        cost = _calculate_baseline_cost(
+            price_forecast=[0.20],
+            feed_in_forecast=[0.10],
+            pv_forecast=[10.0],
+            consumption_forecast=[0.0],
+            step_durations_hours=[1.0],
+            pv_dc_forecast=[0.0],
+            max_grid_power_kw=0.0,
+        )
+        assert cost == pytest.approx(-1.00)
+
+    def test_savings_consistent_with_capped_baseline(self):
+        """optimize_battery_schedule passes the configured cap to the baseline."""
+        cfg = BatteryConfig(
+            capacity_kwh=10.0,
+            max_charge_power_kw=5.0,
+            max_discharge_power_kw=5.0,
+            round_trip_efficiency=0.90,
+            min_soc_percent=10.0,
+            max_soc_percent=90.0,
+            max_grid_power_kw=3.0,
+        )
+        result = optimize_battery_schedule(
+            battery_config=cfg,
+            current_soc_kwh=5.0,
+            price_forecast=[0.20] * 4,
+            feed_in_forecast=[0.10] * 4,
+            pv_forecast=[10.0] * 4,
+            consumption_forecast=[0.0] * 4,
+            step_durations_hours=[1.0] * 4,
+            degradation_cost_per_kwh=0.03,
+            min_price_spread=0.05,
+        )
+        # Capped baseline: 4 h x 3 kW x 0.10 = 1.20 EUR revenue.
+        assert result.baseline_cost == pytest.approx(-1.20)


### PR DESCRIPTION
## Problem
`calculate_step_cost` clamps net grid exchange to `max_grid_power_kw` (the grid connection capacity), but `_calculate_baseline_cost` did not. For installations with a constrained grid connection the baseline could "sell" PV beyond the physical connection limit, inflating baseline revenue. Since `savings = baseline − optimized`, the comparison mixed a capped optimized cost with an uncapped baseline, distorting the reported savings.

## Fix
`_calculate_baseline_cost` now accepts `max_grid_power_kw` and clamps `net_grid_w` exactly like `calculate_step_cost`; `optimize_battery_schedule` passes the configured cap. Same change in `computeBaselineCost` in `docs/analyzer.js` (the standalone simulator has no baseline function).

## Tests
- New tests: export capped at the connection limit, unlimited when cap = 0, and end-to-end `baseline_cost` consistency through `optimize_battery_schedule`
- Full suite green, pre-commit green