### PR TITLE
fix: align commitment-filter spread with the oscillation filter

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -2011,7 +2011,9 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         commitment_reason = ""
         if self._control_mode not in (MODE_ZERO_GRID, MODE_MANUAL):
             sqrt_rte = battery_config.round_trip_efficiency**0.5
-            commit_spread = degradation_cost_per_kwh * 2.0 / sqrt_rte + min_spread
+            # Same economics as the post-DP oscillation filter in optimizer.py:
+            # min_arbitrage_spread = (2 x degradation + min_spread) / sqrt(RTE).
+            commit_spread = (2.0 * degradation_cost_per_kwh + min_spread) / sqrt_rte
             current_price = resampled_prices[0] if resampled_prices else 0.0
             soc_at_limit = (
                 battery_state.soc_kwh <= battery_config.min_soc_kwh * 1.02


### PR DESCRIPTION
## Problem
The commitment filter's comment says it uses "the same economics as the post-DP oscillation filter in optimizer.py", but the formulas differed:

- commitment filter: `2 × degradation / √RTE + min_spread`
- oscillation filter: `(2 × degradation + min_spread) / √RTE`

The `min_spread` term was not corrected for round-trip losses, so the commitment threshold was slightly laxer (≈ 0.003 €/kWh at default settings) than the filter it claims to mirror — the two could disagree near the threshold.

## Fix
Both now use `(2 × degradation + min_spread) / √RTE`, with a comment pointing at the oscillation filter as the source of truth.

## Tests
Full suite green, pre-commit green.