### PR TITLE
fix: redistribute setpoint when the concentration winner is at its SoC limit

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -1015,25 +1015,33 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             else (winner_cfg.min_soc_kwh + winner_cfg.max_soc_kwh) / 2
         )
 
+        others = [
+            (sid, cfg) for sid, cfg in self._individual_battery_configs if sid != winner
+        ]
         if total_kw > 0:
             headroom = max(0.0, winner_cfg.max_soc_kwh - winner_soc_kwh)
             if headroom <= 0:
+                # Winner is full (can happen via selection hysteresis): hand
+                # the whole setpoint to the remaining batteries instead of
+                # dropping it.
+                if others:
+                    for sid, val in self._proportional_split(total_kw, others).items():
+                        result[sid] = val
                 return result
             clamped = min(total_kw, winner_cfg.max_charge_at_soc(winner_soc_kwh))
         else:
             available = max(0.0, winner_soc_kwh - winner_cfg.min_soc_kwh)
             if available <= 0:
+                # Winner is empty: redistribute the discharge to the others.
+                if others:
+                    for sid, val in self._proportional_split(total_kw, others).items():
+                        result[sid] = val
                 return result
             clamped = max(total_kw, -winner_cfg.max_discharge_at_soc(winner_soc_kwh))
 
         result[winner] = clamped
         overflow = total_kw - clamped
         if abs(overflow) > 1e-6:
-            others = [
-                (sid, cfg)
-                for sid, cfg in self._individual_battery_configs
-                if sid != winner
-            ]
             if others:
                 for sid, val in self._proportional_split(overflow, others).items():
                     result[sid] = val

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -2808,3 +2808,25 @@ def test_soc_sensor_in_wh_converted(hass):
     state = coord._read_battery_state(subentry, cfg)
     assert state.soc_kwh == pytest.approx(5.0)
     assert state.soc_percent == pytest.approx(50.0)
+
+
+def test_concentrate_redistributes_when_winner_full(hass):
+    """A full concentration winner must not drop the charge setpoint."""
+    # bat1 full (9.0 = max SoC), bat2 nearly full; gap below split threshold.
+    coord = _make_two_battery_coord(hass, soc1_kwh=9.0, soc2_kwh=8.7)
+    # Selection hysteresis keeps the previously active (now full) battery.
+    coord._zero_grid_active_battery = "bat1"
+    result = coord._split_setpoint(1.0, MODE_ZERO_GRID)
+    # bat1 has no headroom; the setpoint must go to bat2 instead of vanishing.
+    assert result["bat1"] == pytest.approx(0.0, abs=1e-6)
+    assert result["bat2"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_concentrate_redistributes_when_winner_empty(hass):
+    """An empty concentration winner must not drop the discharge setpoint."""
+    # bat1 empty (1.0 = min SoC), bat2 slightly above; gap below split threshold.
+    coord = _make_two_battery_coord(hass, soc1_kwh=1.0, soc2_kwh=1.3)
+    coord._zero_grid_active_battery = "bat1"
+    result = coord._split_setpoint(-1.0, MODE_ZERO_GRID)
+    assert result["bat1"] == pytest.approx(0.0, abs=1e-6)
+    assert result["bat2"] == pytest.approx(-1.0, abs=1e-6)


### PR DESCRIPTION
## Problem
`_concentrate()` returned an all-zero split when the selected (winner) battery had no headroom while charging, or no available energy while discharging — even when the other batteries could absorb the setpoint. This situation is reachable: the selection hysteresis can keep a now-full (or now-empty) battery active while the SoC gap between batteries is still below the proportional-split threshold. The whole charge/discharge setpoint then silently vanished.

## Fix
When the winner is at its SoC limit, the full setpoint is now redistributed to the remaining batteries via the existing `_proportional_split` (which already handles per-battery power limits and overflow).

## Tests
- New tests: full winner with charge setpoint → other battery receives it; empty winner with discharge setpoint → other battery receives it
- Full suite green, pre-commit green