### PR TITLE
fix: guard against zero battery capacity in zero-grid SoC percentage

### DIFF
--- a/custom_components/battery_controller/zero_grid_controller.py
+++ b/custom_components/battery_controller/zero_grid_controller.py
@@ -255,7 +255,11 @@ class ZeroGridController:
             "mode": mode,
             "action_mode": action_mode,
             "soc_kwh": current_soc_kwh,
-            "soc_percent": (current_soc_kwh / self.battery_config.capacity_kwh) * 100,
+            "soc_percent": (
+                (current_soc_kwh / self.battery_config.capacity_kwh) * 100
+                if self.battery_config.capacity_kwh > 0
+                else 0.0
+            ),
         }
 
 

--- a/tests/test_zero_grid_controller.py
+++ b/tests/test_zero_grid_controller.py
@@ -361,3 +361,25 @@ class TestZeroDeadband:
         # Both calls should return finite values without raising
         assert isinstance(t1, float)
         assert isinstance(t2, float)
+
+
+def test_get_control_action_zero_capacity_does_not_crash():
+    """A zero-capacity battery config must not raise ZeroDivisionError."""
+    from custom_components.battery_controller.battery_model import BatteryConfig
+    from custom_components.battery_controller.zero_grid_controller import (
+        ZeroGridController,
+        ZeroGridControllerConfig,
+    )
+
+    controller = ZeroGridController(
+        ZeroGridControllerConfig(),
+        BatteryConfig(capacity_kwh=0.0),
+    )
+    action = controller.get_control_action(
+        current_grid_w=500.0,
+        current_soc_kwh=0.0,
+        current_battery_w=0.0,
+        dp_schedule_w=0.0,
+        mode="zero_grid",
+    )
+    assert action["soc_percent"] == 0.0


### PR DESCRIPTION
## Problem
`ZeroGridController.get_control_action()` computed `soc_percent` as `current_soc_kwh / capacity_kwh * 100` without a guard. A zero-capacity (misconfigured) battery raised `ZeroDivisionError` in the real-time control loop. Other SoC-percentage calculations in the codebase (e.g. `BatteryState.from_soc_kwh`, the coordinator's combined state) already guard this case.

## Fix
Returns `0.0` when `capacity_kwh <= 0`, consistent with the existing guards. Regression test added.

## Tests
Full suite green, pre-commit green.