### PR TITLE
fix: DST-safe index-based skip for daily price arrays

### DIFF
--- a/custom_components/battery_controller/helpers.py
+++ b/custom_components/battery_controller/helpers.py
@@ -65,6 +65,22 @@ def _first_entry_has_timestamp(entries: Any) -> bool:
     )
 
 
+def _skip_index_since_local_midnight(now_local: datetime, interval_minutes: int) -> int:
+    """Return the number of fully elapsed price periods since local midnight.
+
+    Uses true elapsed time (now - midnight) rather than wall-clock
+    hour*60+minute: daily price arrays (raw_today/today) contain one entry per
+    period since midnight, so on DST transition days (23- or 25-hour days)
+    wall-clock arithmetic points at the wrong entry.
+    """
+    midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    # Subtract via POSIX timestamps: naive subtraction of two datetimes that
+    # share the same tzinfo ignores UTC-offset changes, which is exactly the
+    # DST case this helper needs to handle.
+    elapsed_min = (now_local.timestamp() - midnight.timestamp()) / 60
+    return int(elapsed_min // interval_minutes)
+
+
 def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int]:
     """Extract price forecast and detected interval from a Home Assistant price state.
 
@@ -191,7 +207,7 @@ def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int
     if _raw_ref and not _raw_first_has_ts:
         now_local = dt_util.now()
         raw_interval = _detect_interval_from_entries(_raw_ref)
-        skip_index = (now_local.hour * 60 + now_local.minute) // raw_interval
+        skip_index = _skip_index_since_local_midnight(now_local, raw_interval)
         forecast = []
         for entry in raw_today_list[skip_index:]:
             price = _normalize_price_value(entry)
@@ -211,7 +227,7 @@ def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int
     interval = _detect_interval_from_entries(today_attr)
     if interval == 60:
         interval = _detect_interval_from_entries(tomorrow_attr)
-    skip_index = (now_local.hour * 60 + now_local.minute) // interval
+    skip_index = _skip_index_since_local_midnight(now_local, interval)
     combined: list[Any] = []
     if isinstance(today_attr, list):
         combined.extend(today_attr[skip_index:])
@@ -420,7 +436,7 @@ def extract_price_forecast_with_timestamps(
     if _raw_ref and not _raw_first_has_ts:
         now_local = dt_util.now()
         raw_interval = _detect_interval_from_entries(_raw_ref)
-        skip_index = (now_local.hour * 60 + now_local.minute) // raw_interval
+        skip_index = _skip_index_since_local_midnight(now_local, raw_interval)
         forecast = []
         for entry in raw_today_list[skip_index:]:
             price = _normalize_price_value(entry)
@@ -444,7 +460,7 @@ def extract_price_forecast_with_timestamps(
     interval = _detect_interval_from_entries(today_attr)
     if interval == 60:
         interval = _detect_interval_from_entries(tomorrow_attr)
-    skip_index = (now_local.hour * 60 + now_local.minute) // interval
+    skip_index = _skip_index_since_local_midnight(now_local, interval)
     combined: list[Any] = []
     if isinstance(today_attr, list):
         combined.extend(today_attr[skip_index:])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1207,3 +1207,44 @@ class TestForecastSkipPast:
 
         prices, interval = h.extract_price_forecast_with_interval(state)
         assert prices == [0.10, 0.11, 0.12]
+
+
+class TestDstSafeSkipIndex:
+    """Index-based skip must use elapsed time, not wall-clock arithmetic."""
+
+    def test_25_hour_day_skips_correct_entries(self, monkeypatch):
+        """On the DST fall-back day, raw_today has 25 entries; wall-clock 04:30
+        is 5.5 elapsed hours, so 5 entries must be skipped (not 4)."""
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        from custom_components.battery_controller import helpers as h
+
+        tz = ZoneInfo("Europe/Amsterdam")
+        # 2026-10-25: EU DST ends, 03:00 -> 02:00 (25-hour day).
+        # fold=1 selects the post-transition 04:30 = 5.5 h after midnight.
+        now_local = datetime(2026, 10, 25, 4, 30, tzinfo=tz)
+        monkeypatch.setattr(h.dt_util, "now", lambda: now_local)
+
+        prices = [float(i) for i in range(25)]  # one entry per hour-period
+        state = MagicMock()
+        state.attributes = {"raw_today": prices, "raw_tomorrow": []}
+        state.state = "0.0"
+
+        forecast, interval = h.extract_price_forecast_with_interval(state)
+        assert interval == 60
+        # Elapsed = 5.5 h -> skip 5 entries; first remaining entry is index 5.
+        assert forecast[0] == 5.0
+
+    def test_skip_index_helper_normal_day(self):
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        from custom_components.battery_controller.helpers import (
+            _skip_index_since_local_midnight,
+        )
+
+        tz = ZoneInfo("Europe/Amsterdam")
+        now_local = datetime(2026, 6, 10, 15, 47, tzinfo=tz)
+        assert _skip_index_since_local_midnight(now_local, 60) == 15
+        assert _skip_index_since_local_midnight(now_local, 15) == 63


### PR DESCRIPTION
## Problem
The index-based skip for price formats without per-entry timestamps (`raw_today`/`today`, priorities 5/6) computed the number of elapsed price periods as `hour*60 + minute`. Daily price arrays contain one entry per period **since midnight**, so on DST transition days (23/25-hour local days) wall-clock arithmetic points at the wrong entry for the rest of the day — step 0 then uses a price up to one hour off, and every subsequent step shifts with it.

Example: on the EU fall-back day at wall-clock 04:30, 5.5 hours have elapsed since midnight (the array has 25 entries), but `hour*60+minute` skips only 4 entries.

## Fix
New shared helper `_skip_index_since_local_midnight()` computes truly elapsed time since local midnight using POSIX timestamps. (Plain subtraction of two datetimes sharing the same `tzinfo` ignores UTC-offset changes in Python, which is exactly the case that matters here.) Applied to all four call sites in both extract functions.

## Tests
- New tests: 25-hour fall-back day (Europe/Amsterdam, 2026-10-25) skips the correct number of entries; normal-day helper behaviour for 60- and 15-min intervals
- Full suite green, pre-commit green