### PR TITLE
fix: explicit unit handling for power and SoC sensors

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -151,6 +151,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._power_consumption_sensors = config.get(CONF_POWER_CONSUMPTION_SENSORS, [])
         self._power_production_sensors = config.get(CONF_POWER_PRODUCTION_SENSORS, [])
         self._unsub_realtime: Any | None = None
+        # Sensors already warned about for unexpected units (avoid log spam)
+        self._warned_sensor_units: set[str] = set()
 
         # First SoC sensor from any battery subentry (used for availability tracking)
         self._battery_soc_sensor: str | None = (
@@ -735,33 +737,48 @@ class OptimizationCoordinator(DataUpdateCoordinator):
 
         # Sum all consumption sensors
         for sensor_id in self._power_consumption_sensors:
-            state = self.hass.states.get(sensor_id)
-            if state and state.state not in ("unknown", "unavailable"):
-                try:
-                    value = float(state.state)
-                    # Check unit: if in kW, convert to W
-                    unit = state.attributes.get("unit_of_measurement", "W")
-                    if unit == "kW":
-                        value *= 1000
-                    total_consumption += value
-                except (ValueError, TypeError):
-                    pass
+            value = self._read_power_sensor_w(sensor_id)
+            if value is not None:
+                total_consumption += value
 
         # Sum all production sensors
         for sensor_id in self._power_production_sensors:
-            state = self.hass.states.get(sensor_id)
-            if state and state.state not in ("unknown", "unavailable"):
-                try:
-                    value = float(state.state)
-                    # Check unit: if in kW, convert to W
-                    unit = state.attributes.get("unit_of_measurement", "W")
-                    if unit == "kW":
-                        value *= 1000
-                    total_production += value
-                except (ValueError, TypeError):
-                    pass
+            value = self._read_power_sensor_w(sensor_id)
+            if value is not None:
+                total_production += value
 
         return total_consumption - total_production
+
+    def _read_power_sensor_w(self, sensor_id: str) -> float | None:
+        """Read one power sensor and convert its value to W.
+
+        Sensors without a unit attribute are assumed to report W. Sensors with
+        an unrecognized power unit are skipped (with a one-time warning):
+        silently assuming W would be off by orders of magnitude for e.g. MW.
+        """
+        state = self.hass.states.get(sensor_id)
+        if not state or state.state in ("unknown", "unavailable"):
+            return None
+        try:
+            value = float(state.state)
+        except (ValueError, TypeError):
+            return None
+        unit = state.attributes.get("unit_of_measurement", "W")
+        if unit in ("W", ""):
+            return value
+        if unit == "kW":
+            return value * 1000
+        self._warn_unit_once(sensor_id, unit, "ignoring sensor")
+        return None
+
+    def _warn_unit_once(self, sensor_id: str, unit: str, action: str) -> None:
+        """Warn about an unexpected sensor unit, once per sensor."""
+        if sensor_id in self._warned_sensor_units:
+            return
+        self._warned_sensor_units.add(sensor_id)
+        _LOGGER.warning(
+            "Sensor '%s' has unexpected unit '%s'; %s", sensor_id, unit, action
+        )
 
     async def async_shutdown(self) -> None:
         """Clean up event tracking."""
@@ -801,10 +818,18 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             state = self.hass.states.get(soc_sensor)
             if state and state.state not in ("unknown", "unavailable"):
                 unit = state.attributes.get("unit_of_measurement", "")
-                if unit == "kWh":
-                    soc_kwh = soc_value
-                    soc_percent = (soc_kwh / battery_config.capacity_kwh) * 100
+                if unit in ("kWh", "Wh"):
+                    soc_kwh = soc_value / 1000 if unit == "Wh" else soc_value
+                    soc_percent = (
+                        (soc_kwh / battery_config.capacity_kwh) * 100
+                        if battery_config.capacity_kwh > 0
+                        else 0.0
+                    )
                 else:
+                    if unit not in ("%", ""):
+                        self._warn_unit_once(
+                            soc_sensor, unit, "treating value as percent"
+                        )
                     soc_percent = soc_value
                     soc_kwh = (soc_percent / 100) * battery_config.capacity_kwh
             else:
@@ -824,12 +849,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 elif unit == "kW":
                     power_kw = power_value  # Already kW
                 else:
-                    _LOGGER.warning(
-                        "Battery power sensor '%s' has unexpected unit '%s'; "
-                        "treating value as kW",
-                        power_sensor,
-                        unit,
-                    )
+                    self._warn_unit_once(power_sensor, unit, "treating value as kW")
 
         power_w = power_kw * 1000
         if power_w > BATTERY_MODE_THRESHOLD_W:

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -2770,3 +2770,41 @@ async def test_degradation_per_cycle_converted_to_per_kwh_throughput(hass, monke
     usable_kwh = coord.battery_config.max_soc_kwh - coord.battery_config.min_soc_kwh
     assert usable_kwh == pytest.approx(9.0)
     assert captured["degradation_cost_per_kwh"] == pytest.approx(0.04 / (2 * 9.0))
+
+
+# ---------------------------------------------------------------------------
+# Sensor unit handling
+# ---------------------------------------------------------------------------
+
+
+def test_grid_power_kw_sensor_converted(hass):
+    """kW grid sensors are converted to W."""
+    coord = _make_coordinator(hass)
+    coord._power_consumption_sensors = ["sensor.grid_kw"]
+    hass.states.async_set("sensor.grid_kw", "1.5", {"unit_of_measurement": "kW"})
+    assert coord._get_realtime_grid_w() == pytest.approx(1500.0)
+
+
+def test_grid_power_unknown_unit_skipped(hass, caplog):
+    """A grid sensor with an unrecognized unit is skipped, not misread as W."""
+    coord = _make_coordinator(hass)
+    coord._power_consumption_sensors = ["sensor.grid_mw", "sensor.grid_w"]
+    hass.states.async_set("sensor.grid_mw", "2.0", {"unit_of_measurement": "MW"})
+    hass.states.async_set("sensor.grid_w", "300", {"unit_of_measurement": "W"})
+    assert coord._get_realtime_grid_w() == pytest.approx(300.0)
+    assert "unexpected unit 'MW'" in caplog.text
+    # Warning is emitted only once per sensor
+    caplog.clear()
+    coord._get_realtime_grid_w()
+    assert "unexpected unit" not in caplog.text
+
+
+def test_soc_sensor_in_wh_converted(hass):
+    """A Wh SoC sensor is converted to kWh."""
+    coord = _make_coordinator(hass)
+    hass.states.async_set("sensor.test_soc", "5000", {"unit_of_measurement": "Wh"})
+    sid, subentry = coord._battery_subentries[0]
+    cfg = dict(coord._individual_battery_configs)[sid]
+    state = coord._read_battery_state(subentry, cfg)
+    assert state.soc_kwh == pytest.approx(5.0)
+    assert state.soc_percent == pytest.approx(50.0)


### PR DESCRIPTION
## Problem
Two unit-handling gaps could silently misread sensors:

- **Grid power sensors** (`_get_realtime_grid_w`): only `kW` triggered a conversion; any other unit was treated as W. A sensor reporting in MW (or a misconfigured non-power sensor) was misread by orders of magnitude and fed straight into the zero-grid control loop.
- **Battery SoC sensors** (`_read_battery_state`): only `kWh` was recognized; a `Wh` sensor fell into the percent branch (5000 Wh read as 5000%). The kWh path also divided by capacity without a zero guard.

## Fix
- Grid power: `W` (or missing unit) and `kW` are converted explicitly; any other unit skips that sensor with a one-time warning — skipping is safer than guessing
- SoC: `Wh` is converted alongside `kWh`; unknown non-percent units warn once and keep the percent interpretation (previous behavior); zero-capacity guard added
- New `_warn_unit_once()` keeps the ~5 s realtime loop from spamming the log
- Battery power sensor's existing unknown-unit warning routed through the same once-guard

## Tests
- New tests: kW grid sensor converted; MW sensor skipped with single warning while the W sensor still counts; Wh SoC sensor converted to kWh/percent
- Full suite green, pre-commit green