### PR TITLE
refactor: remove unused power limits from ZeroGridControllerConfig

### DIFF
--- a/custom_components/battery_controller/zero_grid_controller.py
+++ b/custom_components/battery_controller/zero_grid_controller.py
@@ -15,10 +15,13 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class ZeroGridControllerConfig:
-    """Configuration for the zero-grid controller."""
+    """Configuration for the zero-grid controller.
 
-    max_charge_w: float = 5000.0
-    max_discharge_w: float = 5000.0
+    Power limits are not stored here: the controller clamps setpoints with the
+    SoC-dependent limits from BatteryConfig (max_charge_at_soc /
+    max_discharge_at_soc), which are the authoritative source.
+    """
+
     deadband_w: float = 50.0  # Hysteresis to prevent oscillation
     response_time_s: float = 5.0  # Update interval
     priority: str = "schedule"  # 'zero_grid' or 'schedule' when in conflict
@@ -286,8 +289,6 @@ def create_zero_grid_controller(
     )
 
     controller_config = ZeroGridControllerConfig(
-        max_charge_w=battery_config.max_charge_power_kw * 1000,
-        max_discharge_w=battery_config.max_discharge_power_kw * 1000,
         deadband_w=float(
             config.get(CONF_ZERO_GRID_DEADBAND_W, DEFAULT_ZERO_GRID_DEADBAND_W)
         ),

--- a/tests/test_zero_grid_controller.py
+++ b/tests/test_zero_grid_controller.py
@@ -24,8 +24,6 @@ def battery_config():
 @pytest.fixture
 def controller_config():
     return ZeroGridControllerConfig(
-        max_charge_w=5000.0,
-        max_discharge_w=5000.0,
         deadband_w=50.0,
     )
 
@@ -323,8 +321,6 @@ class TestZeroDeadband:
     def test_zero_deadband_does_not_crash(self, battery_config):
         """With deadband=0 the controller runs without errors."""
         config = ZeroGridControllerConfig(
-            max_charge_w=5000.0,
-            max_discharge_w=5000.0,
             deadband_w=0.0,
         )
         controller = ZeroGridController(config, battery_config)
@@ -339,8 +335,6 @@ class TestZeroDeadband:
     def test_zero_deadband_setpoint_always_updates(self, battery_config):
         """With deadband=0 every call updates the setpoint (no hysteresis)."""
         config = ZeroGridControllerConfig(
-            max_charge_w=5000.0,
-            max_discharge_w=5000.0,
             deadband_w=0.0,
         )
         controller = ZeroGridController(config, battery_config)


### PR DESCRIPTION
## Problem
`ZeroGridControllerConfig.max_charge_w` / `max_discharge_w` were populated by `create_zero_grid_controller()` but never read anywhere: all setpoint clamping goes through the SoC-dependent limits on `BatteryConfig` (`max_charge_at_soc` / `max_discharge_at_soc`). Keeping a second, unused copy of the power limits invites divergence — a reader could reasonably assume changing them has an effect.

## Fix
Removed the dead fields and their initialization; the dataclass docstring now points at `BatteryConfig` as the authoritative source for power limits. Test fixtures updated accordingly.

## Tests
Full suite green, pre-commit green.