### PR TITLE
refactor: replace assert with explicit fallback in _fill_missing_timestamps

### DIFF
--- a/custom_components/battery_controller/helpers.py
+++ b/custom_components/battery_controller/helpers.py
@@ -266,7 +266,8 @@ def _fill_missing_timestamps(
     if anchor_idx is None:
         return synthesize_timestamps(now, interval_minutes, len(timestamps))
     anchor = timestamps[anchor_idx]
-    assert anchor is not None
+    if anchor is None:  # unreachable; explicit so it also holds under python -O
+        return synthesize_timestamps(now, interval_minutes, len(timestamps))
     return [
         ts
         if ts is not None


### PR DESCRIPTION
## Problem
`_fill_missing_timestamps()` used `assert anchor is not None` to narrow the type after the preceding `anchor_idx is None` early return. Asserts are stripped under `python -O`, so the statement provides no runtime guarantee in optimized deployments — an anti-pattern in library code.

## Fix
Replaced with an explicit (logically unreachable) fallback to `synthesize_timestamps`, which keeps mypy's type narrowing and degrades gracefully instead of relying on a strippable statement.

## Tests
Full suite green, pre-commit green.