### PR TITLE
fix: skip elapsed periods in timestamped forecast_prices/forecast formats

### DIFF
--- a/custom_components/battery_controller/helpers.py
+++ b/custom_components/battery_controller/helpers.py
@@ -55,6 +55,16 @@ def _detect_interval_from_entries(entries: Any) -> int:
     return 60
 
 
+def _first_entry_has_timestamp(entries: Any) -> bool:
+    """Return True when the first entry is a dict carrying a start timestamp."""
+    if not isinstance(entries, (list, tuple)) or not entries:
+        return False
+    first = entries[0]
+    return isinstance(first, dict) and bool(
+        first.get("start") or first.get("from") or first.get("time")
+    )
+
+
 def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int]:
     """Extract price forecast and detected interval from a Home Assistant price state.
 
@@ -140,9 +150,16 @@ def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int
         if interval_forecast:
             return interval_forecast, detected_interval
 
-    # Priority 3: forecast_prices (no per-entry skip-past; interval from timestamps)
+    # Priority 3: forecast_prices (skip elapsed periods when entries carry
+    # timestamps; plain value lists are taken as-is)
     forecast_attr = state.attributes.get("forecast_prices")
     if isinstance(forecast_attr, (list, tuple)):
+        if _first_entry_has_timestamp(forecast_attr):
+            interval_forecast = []
+            detected_interval = 60
+            _extend_interval_forecast(forecast_attr, skip_past=True)
+            if interval_forecast:
+                return interval_forecast, detected_interval
         interval = _detect_interval_from_entries(forecast_attr)
         forecast: list[float] = []
         for entry in forecast_attr:
@@ -152,9 +169,15 @@ def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int
         if forecast:
             return forecast, interval
 
-    # Priority 4: generic forecast (no per-entry skip-past)
+    # Priority 4: generic forecast (same timestamp-aware skip)
     generic_forecast = state.attributes.get("forecast")
     if isinstance(generic_forecast, (list, tuple)):
+        if _first_entry_has_timestamp(generic_forecast):
+            interval_forecast = []
+            detected_interval = 60
+            _extend_interval_forecast(generic_forecast, skip_past=True)
+            if interval_forecast:
+                return interval_forecast, detected_interval
         interval = _detect_interval_from_entries(generic_forecast)
         forecast = []
         for entry in generic_forecast:
@@ -340,9 +363,20 @@ def extract_price_forecast_with_timestamps(
             )
             return interval_forecast, filled, detected_interval
 
-    # Priority 3: forecast_prices — detect interval from entries if timestamps present
+    # Priority 3: forecast_prices — skip elapsed periods and keep real
+    # timestamps when entries carry them; plain value lists are taken as-is
     forecast_attr = state.attributes.get("forecast_prices")
     if isinstance(forecast_attr, (list, tuple)):
+        if _first_entry_has_timestamp(forecast_attr):
+            interval_forecast = []
+            interval_timestamps = []
+            detected_interval = 60
+            _extend_with_timestamps(forecast_attr, skip_past=True)
+            if interval_forecast:
+                filled = _fill_missing_timestamps(
+                    interval_timestamps, detected_interval, now
+                )
+                return interval_forecast, filled, detected_interval
         interval = _detect_interval_from_entries(forecast_attr)
         forecast: list[float] = []
         for entry in forecast_attr:
@@ -356,9 +390,19 @@ def extract_price_forecast_with_timestamps(
                 interval,
             )
 
-    # Priority 4: Generic forecast — detect interval if entries carry timestamps
+    # Priority 4: Generic forecast — same timestamp-aware skip
     generic_forecast = state.attributes.get("forecast")
     if isinstance(generic_forecast, (list, tuple)):
+        if _first_entry_has_timestamp(generic_forecast):
+            interval_forecast = []
+            interval_timestamps = []
+            detected_interval = 60
+            _extend_with_timestamps(generic_forecast, skip_past=True)
+            if interval_forecast:
+                filled = _fill_missing_timestamps(
+                    interval_timestamps, detected_interval, now
+                )
+                return interval_forecast, filled, detected_interval
         interval = _detect_interval_from_entries(generic_forecast)
         forecast = []
         for entry in generic_forecast:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1143,3 +1143,67 @@ class TestSolarPositionZenith:
 
         assert elev == pytest.approx(90.0)
         assert azim == 180.0
+
+
+class TestForecastSkipPast:
+    """forecast_prices / forecast entries with timestamps skip elapsed periods."""
+
+    def _make_entries(self, now):
+        from datetime import timedelta
+
+        return [
+            {"time": (now - timedelta(hours=2)).isoformat(), "price": 0.10},
+            {"time": (now - timedelta(hours=1)).isoformat(), "price": 0.11},
+            {"time": now.isoformat(), "price": 0.12},
+            {"time": (now + timedelta(hours=1)).isoformat(), "price": 0.13},
+        ]
+
+    def test_forecast_prices_skips_elapsed_periods(self, monkeypatch):
+        from datetime import datetime, timezone
+
+        from custom_components.battery_controller import helpers as h
+
+        now = datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(h.dt_util, "utcnow", lambda: now)
+
+        state = MagicMock()
+        state.attributes = {"forecast_prices": self._make_entries(now)}
+        state.state = "0.12"
+
+        prices, interval = h.extract_price_forecast_with_interval(state)
+        assert prices == [0.12, 0.13]
+        assert interval == 60
+
+        prices, starts, interval = h.extract_price_forecast_with_timestamps(state)
+        assert prices == [0.12, 0.13]
+        assert starts[0] == now
+
+    def test_generic_forecast_skips_elapsed_periods(self, monkeypatch):
+        from datetime import datetime, timezone
+
+        from custom_components.battery_controller import helpers as h
+
+        now = datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(h.dt_util, "utcnow", lambda: now)
+
+        state = MagicMock()
+        state.attributes = {"forecast": self._make_entries(now)}
+        state.state = "0.12"
+
+        prices, interval = h.extract_price_forecast_with_interval(state)
+        assert prices == [0.12, 0.13]
+
+    def test_plain_value_lists_unchanged(self, monkeypatch):
+        from datetime import datetime, timezone
+
+        from custom_components.battery_controller import helpers as h
+
+        now = datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(h.dt_util, "utcnow", lambda: now)
+
+        state = MagicMock()
+        state.attributes = {"forecast_prices": [0.10, 0.11, 0.12]}
+        state.state = "0.10"
+
+        prices, interval = h.extract_price_forecast_with_interval(state)
+        assert prices == [0.10, 0.11, 0.12]


### PR DESCRIPTION
## Problem
The `forecast_prices` and generic `forecast` extraction paths (priorities 3/4) took all entries as-is — including periods that had already elapsed. For sensors that keep past hours in those attributes, step 0 of the optimization used a stale price and the entire horizon was shifted. The other formats (`net_prices_today`, `raw_today` with timestamps) already skip elapsed periods.

## Fix
When `forecast_prices`/`forecast` entries carry per-entry timestamps (`start`/`from`/`time`), elapsed periods are now skipped with the same logic as the other timestamp-bearing formats, and the **real** timestamps are returned instead of synthesized ones (so step durations align with actual period boundaries). Plain value lists without timestamps keep the existing as-is behaviour — there is nothing to skip against.

## Tests
- New tests: timestamped `forecast_prices` and `forecast` skip the two elapsed entries and keep real start times; plain float lists unchanged
- Full suite green, pre-commit green