### PR TITLE
ci: deploy GitHub Pages via Actions workflow instead of branch build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Prepare static site
+        run: rsync -a --exclude='__tests__' docs/ _site/
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
The built-in 'pages build and deployment' branch workflow failed on dev (run 28663546466) with 'Deployment failed, try again later' after a cancelled deployment from two rapid pushes. Replace it with an explicit Pages workflow that:
- only runs when docs/ actually changes (plus manual dispatch)
- uses a non-cancelling 'pages' concurrency group so an in-flight deployment is never aborted mid-deploy
- uploads docs/ as a static artifact (no Jekyll needed), excluding the __tests__ directory like Jekyll's underscore rule did

Requires switching Pages source to 'GitHub Actions' in repo settings.



## Description

<!-- Briefly describe what this PR does and why -->

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [ ] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [ ] Tests added or updated where applicable
- [ ] Documentation updated if needed
- [ ] CI is green
- [ ] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

<!-- Add relevant screenshots or log output -->