### PR TITLE
fix: add hysteresis to hybrid mode idle/zero_grid and charging/zero_grid transitions

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -43,7 +43,9 @@ from .const import (
     DEFAULT_MANUAL_POWER_SETPOINT_W,
     DEFAULT_MIN_PRICE_SPREAD,
     CONF_PV_DC_COUPLED,
+    CONF_ZERO_GRID_DEADBAND_W,
     CONF_ZERO_GRID_RESPONSE_TIME_S,
+    DEFAULT_ZERO_GRID_DEADBAND_W,
     DEFAULT_ZERO_GRID_RESPONSE_TIME_S,
     MODE_FOLLOW_SCHEDULE,
     MODE_HYBRID,
@@ -1710,6 +1712,18 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 self.config.get(CONF_MIN_PRICE_SPREAD, DEFAULT_MIN_PRICE_SPREAD),
             )
         )
+        # Reuse the user-tunable zero-grid deadband as the hysteresis band for
+        # the hybrid-mode idle/zero_grid and charging/zero_grid transitions
+        # below: both address the same real-time sensor-noise problem the
+        # deadband already exists to solve.
+        hybrid_deadband_w = float(
+            live_options.get(
+                CONF_ZERO_GRID_DEADBAND_W,
+                self.config.get(
+                    CONF_ZERO_GRID_DEADBAND_W, DEFAULT_ZERO_GRID_DEADBAND_W
+                ),
+            )
+        )
 
         # Synthesise start_times for fallback paths that have no real timestamps
         now_utc = dt_util.utcnow()
@@ -2025,16 +2039,17 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 has_upcoming_discharge = any(
                     m == ACTION_DISCHARGING for m in result.mode_schedule[1:]
                 )
-                # Hysteresis: use a ±BATTERY_MODE_THRESHOLD_W band around the 0 W
-                # crossing so grid power hovering near zero (e.g. consumption ≈ PV
-                # production) doesn't flip idle/zero_grid every realtime tick.
+                # Hysteresis: use a ±hybrid_deadband_w band (the user-tunable
+                # zero-grid deadband) around the 0 W crossing so grid power
+                # hovering near zero (e.g. consumption ≈ PV production) doesn't
+                # flip idle/zero_grid every realtime tick.
                 if self._last_hybrid_idle_decision == "zero_grid":
                     # Was capturing surplus; keep doing so until grid climbs
                     # solidly positive (surplus has genuinely disappeared).
-                    has_pv_surplus = current_grid < BATTERY_MODE_THRESHOLD_W
+                    has_pv_surplus = current_grid < hybrid_deadband_w
                 else:
                     # Was idle; only start capturing once surplus is solid.
-                    has_pv_surplus = current_grid < -BATTERY_MODE_THRESHOLD_W
+                    has_pv_surplus = current_grid < -hybrid_deadband_w
                 if has_upcoming_discharge and not has_pv_surplus:
                     # Preserve capacity (discharge planned, no PV surplus)
                     effective_mode = ACTION_IDLE

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -230,6 +230,17 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # so small oscillations around the shadow-price threshold are damped.
         self._last_hybrid_decision: str = "zero_grid"
 
+        # Hysteresis state for the hybrid idle branch: tracks whether we were in
+        # "idle" or "zero_grid" so grid power hovering near 0 W doesn't flip the
+        # mode every realtime-update tick.
+        self._last_hybrid_idle_decision: str = ACTION_IDLE
+
+        # Hysteresis state for the hybrid charging branch: tracks whether we were
+        # following the DP schedule ("charging") or capturing PV surplus only
+        # ("zero_grid") so surplus hovering near the coverage threshold doesn't
+        # flip the mode every realtime-update tick.
+        self._last_hybrid_charge_decision: str = ACTION_CHARGING
+
         # Diagnostic history ring buffers (not persisted across restarts).
         # optimizer_run_log: one entry per 15-min optimizer run (24 h @ 15 min = 96).
         # setpoint_log: one entry every time the real-time setpoint changes.
@@ -2014,12 +2025,23 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 has_upcoming_discharge = any(
                     m == ACTION_DISCHARGING for m in result.mode_schedule[1:]
                 )
-                if has_upcoming_discharge and current_grid >= 0:
+                # Hysteresis: use a ±BATTERY_MODE_THRESHOLD_W band around the 0 W
+                # crossing so grid power hovering near zero (e.g. consumption ≈ PV
+                # production) doesn't flip idle/zero_grid every realtime tick.
+                if self._last_hybrid_idle_decision == "zero_grid":
+                    # Was capturing surplus; keep doing so until grid climbs
+                    # solidly positive (surplus has genuinely disappeared).
+                    has_pv_surplus = current_grid < BATTERY_MODE_THRESHOLD_W
+                else:
+                    # Was idle; only start capturing once surplus is solid.
+                    has_pv_surplus = current_grid < -BATTERY_MODE_THRESHOLD_W
+                if has_upcoming_discharge and not has_pv_surplus:
                     # Preserve capacity (discharge planned, no PV surplus)
                     effective_mode = ACTION_IDLE
                 else:
                     # Either no discharge planned, or PV surplus to capture
                     effective_mode = "zero_grid"
+                self._last_hybrid_idle_decision = effective_mode
                 effective_power = 0.0
             elif result.optimal_mode == ACTION_DISCHARGING:
                 # Decide: full-rate export vs zero_grid (self-consumption only).
@@ -2073,24 +2095,38 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                     # deadlock that stops charging.
                     effective_mode = result.optimal_mode
                     effective_power = result.optimal_power_kw
-                elif (
-                    -current_grid
-                    >= result.optimal_power_kw * 1000 * _SURPLUS_COVERS_PLAN_FRACTION
-                ):
-                    # PV surplus covers (most of) the planned charge: use
-                    # zero_grid to dynamically match the actual surplus instead
-                    # of fixed-rate charging. Fixed charging may import from
-                    # grid when clouds pass.
-                    effective_mode = "zero_grid"
-                    effective_power = 0.0
+                    self._last_hybrid_charge_decision = ACTION_CHARGING
                 else:
-                    # The DP planned substantially more charging than the
-                    # current export surplus — it wants grid charging (e.g. a
-                    # cheap price hour that happens to coincide with a small PV
-                    # surplus). Zero_grid would only charge the surplus and
-                    # forfeit the planned arbitrage, so follow the schedule.
-                    effective_mode = result.optimal_mode
-                    effective_power = result.optimal_power_kw
+                    # Hysteresis: apply a ±5% band around the coverage threshold
+                    # (same pattern as the discharge decision above) so PV surplus
+                    # hovering near _SURPLUS_COVERS_PLAN_FRACTION of the planned
+                    # charge power doesn't flip zero_grid/charging every tick.
+                    # • Was zero_grid → stay unless surplus drops below 95% of threshold
+                    # • Was charging → switch only once surplus reaches 105% of threshold
+                    if self._last_hybrid_charge_decision == "zero_grid":
+                        coverage_threshold = _SURPLUS_COVERS_PLAN_FRACTION * 0.95
+                    else:
+                        coverage_threshold = _SURPLUS_COVERS_PLAN_FRACTION * 1.05
+                    if (
+                        -current_grid
+                        >= result.optimal_power_kw * 1000 * coverage_threshold
+                    ):
+                        # PV surplus covers (most of) the planned charge: use
+                        # zero_grid to dynamically match the actual surplus instead
+                        # of fixed-rate charging. Fixed charging may import from
+                        # grid when clouds pass.
+                        effective_mode = "zero_grid"
+                        effective_power = 0.0
+                        self._last_hybrid_charge_decision = "zero_grid"
+                    else:
+                        # The DP planned substantially more charging than the
+                        # current export surplus — it wants grid charging (e.g. a
+                        # cheap price hour that happens to coincide with a small PV
+                        # surplus). Zero_grid would only charge the surplus and
+                        # forfeit the planned arbitrage, so follow the schedule.
+                        effective_mode = result.optimal_mode
+                        effective_power = result.optimal_power_kw
+                        self._last_hybrid_charge_decision = ACTION_CHARGING
             else:
                 effective_mode = result.optimal_mode
                 effective_power = result.optimal_power_kw

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -22,6 +22,7 @@ from custom_components.battery_controller.const import (
     CONF_POWER_PRODUCTION_SENSORS,
     CONF_PRICE_SENSOR,
     CONF_ROUND_TRIP_EFFICIENCY,
+    CONF_ZERO_GRID_DEADBAND_W,
     MODE_FOLLOW_SCHEDULE,
     MODE_HYBRID,
     MODE_ZERO_GRID,
@@ -3208,7 +3209,11 @@ async def test_hybrid_large_surplus_uses_zero_grid(hass, monkeypatch):
 
 
 async def _run_hybrid_mode_sequence(
-    hass, monkeypatch, fake_result: OptimizationResult, grid_sequence: list[float]
+    hass,
+    monkeypatch,
+    fake_result: OptimizationResult,
+    grid_sequence: list[float],
+    deadband_w: float | None = None,
 ) -> list[str]:
     """Run hybrid optimization repeatedly on one coordinator, varying grid power.
 
@@ -3257,7 +3262,9 @@ async def _run_hybrid_mode_sequence(
         lambda: fixed_now,
     )
     live_entry = MagicMock()
-    live_entry.options = {}
+    live_entry.options = (
+        {} if deadband_w is None else {CONF_ZERO_GRID_DEADBAND_W: deadband_w}
+    )
     monkeypatch.setattr(hass.config_entries, "async_get_entry", lambda eid: live_entry)
 
     coord.zero_grid_controller = MagicMock()
@@ -3319,10 +3326,10 @@ async def test_hybrid_idle_zero_grid_hysteresis_prevents_flicker(hass, monkeypat
     """Grid power hovering near 0 W must not flip idle/zero_grid every tick.
 
     The optimizer wants idle (preserve capacity for an upcoming discharge).
-    The first tick has a solid PV surplus (-100 W, below -BATTERY_MODE_THRESHOLD_W)
-    so it enters zero_grid. The second tick is a small positive import (20 W) —
-    within the ±BATTERY_MODE_THRESHOLD_W band — so it must stay in zero_grid
-    rather than flicker back to idle.
+    The first tick has a solid PV surplus (-100 W, below the default -50 W
+    zero-grid-deadband band) so it enters zero_grid. The second tick is a
+    small positive import (20 W) — within the ±50 W deadband — so it must
+    stay in zero_grid rather than flicker back to idle.
     """
     fake_result = OptimizationResult(
         power_schedule_kw=[0.0, 2.0],
@@ -3342,3 +3349,36 @@ async def test_hybrid_idle_zero_grid_hysteresis_prevents_flicker(hass, monkeypat
         hass, monkeypatch, fake_result, grid_sequence=[-100.0, 20.0]
     )
     assert modes == ["zero_grid", "zero_grid"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_idle_zero_grid_deadband_is_configurable(hass, monkeypatch):
+    """The hysteresis band width follows the user's zero_grid_deadband_w setting.
+
+    Same grid sequence as the default-band test above, but with the deadband
+    turned down to 10 W. The 20 W import on the second tick now exceeds the
+    (smaller) band, so the mode must flip back to idle — proving the band
+    width actually comes from the live config value, not a fixed constant.
+    """
+    fake_result = OptimizationResult(
+        power_schedule_kw=[0.0, 2.0],
+        mode_schedule=["idle", "discharging"],
+        soc_schedule_kwh=[5.0, 5.0, 3.0],
+        total_cost=0.0,
+        baseline_cost=0.0,
+        savings=0.0,
+        optimal_power_kw=0.0,
+        optimal_mode="idle",
+        shadow_price_eur_kwh=0.15,
+        price_forecast=[0.10, 0.12],
+        pv_forecast=[0.5, 0.5],
+        consumption_forecast=[0.3, 0.3],
+    )
+    modes = await _run_hybrid_mode_sequence(
+        hass,
+        monkeypatch,
+        fake_result,
+        grid_sequence=[-100.0, 20.0],
+        deadband_w=10.0,
+    )
+    assert modes == ["zero_grid", "idle"]

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -3205,3 +3205,140 @@ async def test_hybrid_large_surplus_uses_zero_grid(hass, monkeypatch):
     """When the surplus covers the planned charge, zero_grid follows the surplus."""
     data = await _run_hybrid_charge_case(hass, monkeypatch, grid_w=-3500.0)
     assert data["optimal_mode"] == "zero_grid"
+
+
+async def _run_hybrid_mode_sequence(
+    hass, monkeypatch, fake_result: OptimizationResult, grid_sequence: list[float]
+) -> list[str]:
+    """Run hybrid optimization repeatedly on one coordinator, varying grid power.
+
+    Used to verify hysteresis: unlike `_run_hybrid_charge_case`, which builds a
+    fresh coordinator per call (so it can't observe state carried between
+    realtime-update ticks), this reuses the same coordinator so the
+    `_last_hybrid_idle_decision` / `_last_hybrid_charge_decision` hysteresis
+    state persists across the calls in grid_sequence.
+    """
+    from unittest.mock import patch as upatch
+
+    coord = _make_coordinator(hass)
+    coord.control_mode = MODE_HYBRID
+    fixed_now = datetime(2026, 3, 21, 10, 0, 0, tzinfo=timezone.utc)
+    coord.forecast_coordinator.data = {
+        "pv_forecast_kw": [0.5, 0.5],
+        "consumption_forecast_kw": [0.3, 0.3],
+        "current_pv_kw": 0.5,
+        "current_dc_pv_kw": 0.0,
+        "current_consumption_kw": 0.3,
+    }
+    hass.states.async_set("sensor.test_price", "0.10")
+    monkeypatch.setattr(coord, "_refresh_battery_config", lambda: None)
+    monkeypatch.setattr(
+        coord,
+        "get_current_battery_state",
+        lambda: BatteryState(soc_kwh=5.0, soc_percent=50.0, power_kw=0.0, mode="idle"),
+    )
+    monkeypatch.setattr(coord, "_split_setpoint", lambda kw, _mode="": {"bat1": kw})
+    monkeypatch.setattr(coord._price_model, "has_data", lambda: False)
+    monkeypatch.setattr(coord._feed_in_price_model, "has_data", lambda: False)
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.extract_price_forecast_with_timestamps",
+        lambda state: ([0.10, 0.12], [fixed_now, fixed_now + timedelta(hours=1)], 60),
+    )
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.compute_step_durations_hours",
+        lambda *a: [1.0, 1.0],
+    )
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.resample_forecast",
+        lambda values, src, dst: list(values),
+    )
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
+        lambda: fixed_now,
+    )
+    live_entry = MagicMock()
+    live_entry.options = {}
+    monkeypatch.setattr(hass.config_entries, "async_get_entry", lambda eid: live_entry)
+
+    coord.zero_grid_controller = MagicMock()
+    coord.zero_grid_controller.get_control_action = MagicMock(
+        return_value={
+            "target_power_kw": 0.0,
+            "target_power_w": 0.0,
+            "action_mode": "idle",
+            "raw_target_w": 0.0,
+            "dp_schedule_w": 0.0,
+            "mode": "idle",
+        }
+    )
+
+    modes: list[str] = []
+    with upatch(
+        "custom_components.battery_controller.coordinator_optimization.optimize_battery_schedule",
+        return_value=fake_result,
+    ):
+        for grid_w in grid_sequence:
+            monkeypatch.setattr(coord, "_get_realtime_grid_w", lambda gw=grid_w: gw)
+            data = await coord._run_optimization()
+            modes.append(data["optimal_mode"])
+    return modes
+
+
+@pytest.mark.asyncio
+async def test_hybrid_charge_surplus_hysteresis_prevents_flicker(hass, monkeypatch):
+    """PV surplus hovering around the 80% coverage threshold must not flip the
+    effective mode every realtime tick.
+
+    Planned charge is 3 kW, so the coverage threshold is 2400 W. The first
+    tick has a solid 2600 W surplus (enters zero_grid). The second tick drops
+    to 2350 W: below the raw 2400 W threshold, but within the ±5% hysteresis
+    band, so it must stay in zero_grid rather than flicker back to charging.
+    """
+    fake_result = OptimizationResult(
+        power_schedule_kw=[3.0, 0.0],
+        mode_schedule=["charging", "idle"],
+        soc_schedule_kwh=[5.0, 7.8, 7.8],
+        total_cost=0.0,
+        baseline_cost=0.0,
+        savings=0.0,
+        optimal_power_kw=3.0,
+        optimal_mode="charging",
+        shadow_price_eur_kwh=0.15,
+        price_forecast=[0.10, 0.12],
+        pv_forecast=[0.5, 0.5],
+        consumption_forecast=[0.3, 0.3],
+    )
+    modes = await _run_hybrid_mode_sequence(
+        hass, monkeypatch, fake_result, grid_sequence=[-2600.0, -2350.0]
+    )
+    assert modes == ["zero_grid", "zero_grid"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_idle_zero_grid_hysteresis_prevents_flicker(hass, monkeypatch):
+    """Grid power hovering near 0 W must not flip idle/zero_grid every tick.
+
+    The optimizer wants idle (preserve capacity for an upcoming discharge).
+    The first tick has a solid PV surplus (-100 W, below -BATTERY_MODE_THRESHOLD_W)
+    so it enters zero_grid. The second tick is a small positive import (20 W) —
+    within the ±BATTERY_MODE_THRESHOLD_W band — so it must stay in zero_grid
+    rather than flicker back to idle.
+    """
+    fake_result = OptimizationResult(
+        power_schedule_kw=[0.0, 2.0],
+        mode_schedule=["idle", "discharging"],
+        soc_schedule_kwh=[5.0, 5.0, 3.0],
+        total_cost=0.0,
+        baseline_cost=0.0,
+        savings=0.0,
+        optimal_power_kw=0.0,
+        optimal_mode="idle",
+        shadow_price_eur_kwh=0.15,
+        price_forecast=[0.10, 0.12],
+        pv_forecast=[0.5, 0.5],
+        consumption_forecast=[0.3, 0.3],
+    )
+    modes = await _run_hybrid_mode_sequence(
+        hass, monkeypatch, fake_result, grid_sequence=[-100.0, 20.0]
+    )
+    assert modes == ["zero_grid", "zero_grid"]


### PR DESCRIPTION
## Description

In `hybrid` control mode, `_handle_realtime_update` (`coordinator_optimization.py`) recomputes the effective mode every `zero_grid_response_time` seconds (default 10s). Two of its decisions used hard zero-crossing / threshold tests with no deadband:

1. **Idle branch**: `zero_grid` vs `idle` based purely on `current_grid >= 0`.
2. **Charging branch**: `zero_grid` vs `charging` based on whether PV surplus covers ≥80% (`_SURPLUS_COVERS_PLAN_FRACTION`) of the planned charge power.

The existing "commitment filter" only guards `charging`/`discharging → idle` transitions, so it never damped these. In practice, ordinary sensor noise (grid power hovering near 0 W, or PV surplus hovering near the 80% threshold) flipped the effective mode on nearly every realtime tick, producing visible mode churn (idle/charging/zero_grid) in the optimizer's mode sensor/history.

## Fix

Apply the same hysteresis pattern already used for the discharge decision (a last-decision-dependent ±band):
- Idle branch: a ±band around the 0 W crossing, using the existing user-tunable **Zero Grid Deadband** setting (`CONF_ZERO_GRID_DEADBAND_W`, default 50 W) rather than a fixed constant.
- Charging branch: a ±5% band around `_SURPLUS_COVERS_PLAN_FRACTION`.

Both are tracked via new `_last_hybrid_idle_decision` / `_last_hybrid_charge_decision` instance state, mirroring the existing `_last_hybrid_decision` pattern for the discharge case.

This is realtime coordinator logic, not the DP engine, so no changes were needed to keep `optimizer.py` / `docs/analyzer.js` / `simulate/simulate_diagnostics.py` in sync.

## Testing

- Added `test_hybrid_charge_surplus_hysteresis_prevents_flicker`, `test_hybrid_idle_zero_grid_hysteresis_prevents_flicker`, and `test_hybrid_idle_zero_grid_deadband_is_configurable`, driving the same coordinator through consecutive realtime ticks and asserting the mode doesn't flip when the next tick lands inside the hysteresis band (and does flip when the configured deadband is narrowed). Verified the flicker tests fail on the pre-fix code and pass after the fix.
- Full suite: `python -m pytest tests/ -v` — all passing (197 tests).
- `mypy custom_components/battery_controller/coordinator_optimization.py` — clean.
- `ruff format` / `ruff check --fix` — clean.

## Type of change

- [x] `fix:` Bug fix (patch version bump)

## Checklist

- [x] Commit title follows Conventional Commits
- [x] Tests added
- [x] CI is green — pending
- [x] PR targets the `dev` branch

Fixes #81