### PR TITLE
fix: clarify Eff. kW and stop false "SoC/power limited" warnings during zero_grid

### DIFF
--- a/docs/__tests__/analyzer.test.js
+++ b/docs/__tests__/analyzer.test.js
@@ -426,6 +426,20 @@ describe('generateTips', () => {
     expect(tips.some(t => t.t === 'warn' && t.title.toLowerCase().includes('soc/power limited'))).toBe(true);
   });
 
+  test('does not warn for zero_grid runs where effective_power_kw is 0 by design', () => {
+    const d = makeDiag();
+    d.optimization.optimizer_run_log = [
+      { effective_power_kw: 0.0, setpoint_kw: 1.8, commitment_locked: false,
+        effective_mode: 'zero_grid', timestamp: '2026-03-23T10:00:00', soc_kwh: 5.0 },
+      { effective_power_kw: 0.0, setpoint_kw: 2.1, commitment_locked: false,
+        effective_mode: 'zero_grid', timestamp: '2026-03-23T10:15:00', soc_kwh: 5.5 },
+      { effective_power_kw: 0.5, setpoint_kw: 0.5, commitment_locked: false,
+        effective_mode: 'charging', timestamp: '2026-03-23T10:30:00', soc_kwh: 6.0 },
+    ];
+    const tips = generateTips(d);
+    expect(tips.some(t => t.t === 'warn' && t.title.toLowerCase().includes('soc/power limited'))).toBe(false);
+  });
+
   test('info tip when commitment filter is active', () => {
     const d = makeDiag();
     d.optimization.optimizer_run_log = [

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -826,8 +826,13 @@ function generateTips(d) {
   const setpLog2 = opt.setpoint_log || [];
 
   if (runLog2.length > 0) {
+    // effective_power_kw is always 0 in zero_grid mode by design (the real-time
+    // controller determines power dynamically, not the DP schedule), so comparing
+    // it to setpoint_kw there would always look "limited" even under normal
+    // zero_grid charging/discharging. Only compare when effective_mode isn't zero_grid.
     const socLimitedRuns = runLog2.filter(e =>
-      Math.abs((e.setpoint_kw ?? 0) - (e.effective_power_kw ?? 0)) > 0.05
+      e.effective_mode !== 'zero_grid'
+      && Math.abs((e.setpoint_kw ?? 0) - (e.effective_power_kw ?? 0)) > 0.05
     );
     const commitLocked = runLog2.filter(e => e.commitment_locked);
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -932,8 +932,12 @@ function renderDiagnostics(raw) {
         ? `<span class="badge badge-charging">${entry.commitment_reason || 'locked'}</span>`
         : '<span class="text-gray-300">—</span>';
 
-      // Highlight rows where setpoint deviates from effective power (SoC/power limit)
-      const socLimited = Math.abs((entry.setpoint_kw ?? 0) - (entry.effective_power_kw ?? 0)) > 0.05;
+      // Highlight rows where setpoint deviates from effective power (SoC/power limit).
+      // effective_power_kw is always 0 in zero_grid mode by design (see column
+      // tooltip above), so skip the comparison there to avoid flagging normal
+      // zero_grid charging/discharging as "SoC/power limited".
+      const socLimited = entry.effective_mode !== 'zero_grid'
+        && Math.abs((entry.setpoint_kw ?? 0) - (entry.effective_power_kw ?? 0)) > 0.05;
       // Highlight rows where effective differs from DP (mode override, not commitment)
       const modeOverride = !entry.commitment_locked
         && Math.abs((entry.effective_power_kw ?? 0) - (entry.dp_power_kw ?? 0)) > 0.05;

--- a/docs/index.html
+++ b/docs/index.html
@@ -197,7 +197,7 @@
   <!-- Optimizer run history -->
   <div id="run-log-section" class="hidden bg-white rounded-xl border border-gray-200 p-5">
     <h3 class="font-semibold text-gray-700 mb-1 text-sm">🕒 Optimizer Run History <span id="run-log-count" class="text-xs text-gray-400 font-normal"></span></h3>
-    <p class="text-xs text-gray-400 mb-3">One row per 15-min optimizer run. Highlights deviations between DP output, effective mode (after hybrid/commitment logic), and the published setpoint.</p>
+    <p class="text-xs text-gray-400 mb-3">One row per 15-min optimizer run. Highlights deviations between DP output, effective mode (after hybrid/commitment logic), and the published setpoint. Note: "Eff. kW" is always 0 whenever "Eff. mode" is <code>zero_grid</code> &mdash; in zero_grid mode there is no fixed schedule power, it's continuously recalculated by the real-time (~5&ndash;10s) zero-grid controller instead. Look at "Setpoint kW" (or the Real-time Setpoint Log below) for the actual battery power during zero_grid periods.</p>
     <div class="scrolltable sticky-header">
       <table class="w-full text-xs border-collapse">
         <thead>
@@ -207,7 +207,7 @@
             <th class="border border-gray-200 px-2 py-1">DP mode</th>
             <th class="border border-gray-200 px-2 py-1">DP kW</th>
             <th class="border border-gray-200 px-2 py-1">Eff. mode</th>
-            <th class="border border-gray-200 px-2 py-1">Eff. kW</th>
+            <th class="border border-gray-200 px-2 py-1" title="Effective power from the DP schedule after hybrid/commitment resolution. Always 0 in zero_grid mode by design &mdash; see actual power in Setpoint kW.">Eff. kW</th>
             <th class="border border-gray-200 px-2 py-1">Setpoint kW</th>
             <th class="border border-gray-200 px-2 py-1">SoC kWh</th>
             <th class="border border-gray-200 px-2 py-1">Price</th>


### PR DESCRIPTION
## Description

Two related issues on the diagnostics analyzer page (`docs/index.html` / `docs/analyzer.js`), both stemming from the same root cause: `effective_power_kw` in the optimizer run log is always `0.0` whenever `effective_mode` is `zero_grid` — by design, since zero_grid mode has no fixed schedule power; the actual battery power is recalculated continuously (~5–10s) by the real-time zero-grid controller and reported separately in `setpoint_kw` / the Real-time Setpoint Log.

1. **Confusing "Eff. kW" column** — a user reported it staying at 0 for every row while the battery was visibly charging, unsure if that was a bug.
2. **False "SoC/power limited" warning** (found while investigating #1) — the analyzer's `socLimited` heuristic compared `setpoint_kw` to `effective_power_kw` unconditionally. Since `effective_power_kw` is always 0 during zero_grid, this comparison fired on nearly every normal zero_grid charge/discharge cycle, incorrectly labeling it as a SoC/power-limited event (red row highlight in the run-log table, and a "Setpoint was SoC/power limited in X/Y optimizer runs" warning tip) even though nothing was actually limited.

## Fix

- `docs/index.html`: expanded the run-log section description and added a column tooltip explaining why "Eff. kW" is 0 during zero_grid; excluded `zero_grid` rows from the `socLimited` row-highlight comparison.
- `docs/analyzer.js`: excluded `zero_grid` entries from the `socLimitedRuns` tip-generation comparison.
- The setpoint log's own `soc_limited` flag (computed in `coordinator_optimization.py`, comparing `dp_schedule_w` vs `raw_target_w`) is unaffected — it already requires `dp_schedule_w > 50 W`, which is never true during zero_grid, so it never shared this false positive.

No behavior/data-structure change in the integration itself — `simulate_diagnostics.py` and `ALGORITHM.md` don't need updates.

## Testing

- Added `does not warn for zero_grid runs where effective_power_kw is 0 by design` to `docs/__tests__/analyzer.test.js`; verified it fails (reproducing the false positive) without the fix and passes with it.
- Full JS suite: `npx jest docs/__tests__/analyzer.test.js` — 41/41 passing.

## Type of change

- [x] `fix:` Bug fix (patch version bump)

## Checklist

- [x] Tests added
- [ ] CI is green — pending
- [x] PR targets the `dev` branch