### PR TITLE
feat: add hybrid+ control mode that gates PV-surplus capture on the price forecast

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -394,6 +394,8 @@ The shadow price is always the raw DP value — there is no separate "post-proce
 
 **Use by hybrid mode**: λ is used by the coordinator as the charge/discharge switching threshold in hybrid mode. It is deliberately not fed back into the next run's terminal condition (see [Section 5](#5-terminal-condition)).
 
+**Use by hybrid+ mode**: hybrid+ additionally uses λ to gate PV-surplus capture. Plain hybrid stores any surplus as soon as it appears; hybrid+ only stores it when `λ × sqrt(RTE)` exceeds the current feed-in price. Because λ already prices in upcoming cheap-surplus hours (e.g. a midday PV peak coinciding with low prices), a low λ means the battery can be filled more cheaply later — so the current surplus is exported at the (higher) feed-in price instead, with a ±5% hysteresis band around the threshold to prevent oscillation.
+
 ---
 
 ## 10. Rolling-Horizon Execution
@@ -566,7 +568,7 @@ When concentrating, which battery is chosen depends on the control mode:
 
 | Mode | Selection criterion |
 |------|---------------------|
-| `zero_grid` / `hybrid` | Closest to 50% rel\_soc — can handle charge and discharge direction changes longest without hitting a SoC limit |
+| `zero_grid` / `hybrid` / `hybrid_plus` | Closest to 50% rel\_soc — can handle charge and discharge direction changes longest without hitting a SoC limit |
 | Scheduled charge | Lowest rel\_soc (most headroom) |
 | Scheduled discharge | Highest rel\_soc (most energy available) |
 

--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -396,6 +396,8 @@ The shadow price is always the raw DP value — there is no separate "post-proce
 
 **Use by hybrid+ mode**: hybrid+ additionally uses λ to gate PV-surplus capture. Plain hybrid stores any surplus as soon as it appears; hybrid+ only stores it when `λ × sqrt(RTE)` exceeds the current feed-in price. Because λ already prices in upcoming cheap-surplus hours (e.g. a midday PV peak coinciding with low prices), a low λ means the battery can be filled more cheaply later — so the current surplus is exported at the (higher) feed-in price instead, with a ±5% hysteresis band around the threshold to prevent oscillation.
 
+Conversely, when little future surplus is forecast, λ stays high: every kWh not captured now would have to be bought from the grid later, or is missing during expensive evening hours. The threshold `λ × sqrt(RTE) ≥ feed-in` is then met and hybrid+ captures the surplus immediately — identical to plain hybrid. No separate rule is needed; the shadow price encodes "how cheaply can the battery still be filled later" by construction. Exporting only wins when the battery would fill up anyway (little headroom relative to the forecast surplus) or when stored energy has little future value (flat prices, no discharge opportunity).
+
 ---
 
 ## 10. Rolling-Horizon Execution

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Battery Controller works with any battery inverter and electricity meter — it 
 - **DC-coupled PV support**: Higher efficiency for panels directly on the battery inverter's DC bus (hybrid inverters)
 - **Zero-grid control**: Real-time battery control to minimize grid exchange
 - **Degradation-aware**: Accounts for battery wear in optimization decisions
-- **Multiple control modes**: Zero-grid, follow schedule, hybrid, or manual
+- **Multiple control modes**: Zero-grid, follow schedule, hybrid, hybrid+, or manual
 - **Negative price handling**: Suggests PV curtailment or maximum power consumption during negative prices
 
 ---
@@ -294,7 +294,7 @@ The **Battery power sensor** you configure as input (`battery_power_sensor`) is 
 
 | Entity | Options | Description |
 |--------|---------|-------------|
-| Control Mode | `zero_grid`, `follow_schedule`, `hybrid`, `manual` | Active battery control strategy |
+| Control Mode | `zero_grid`, `follow_schedule`, `hybrid`, `hybrid_plus`, `manual` | Active battery control strategy |
 
 ### Number Entities
 
@@ -315,6 +315,10 @@ The **Battery power sensor** you configure as input (`battery_power_sensor`) is 
   lock applies to the published controller setpoint too, not just the diagnostic
   `optimal_power` value.
 - **Hybrid** (recommended): DP schedule for arbitrage, zero-grid for self-consumption.
+- **Hybrid+**: Like Hybrid, but consults the price forecast before storing PV surplus.
+  When the shadow price says the battery can be filled more cheaply later (e.g. a
+  midday PV peak at low prices), the surplus is exported at the current feed-in price
+  instead of charged, and the battery charges later from the cheaper surplus.
 - **Manual**: Target power set via `number.battery_controller_manual_power_setpoint`.
 
 Change the active mode with the **Control Mode** select entity, or use a service call in an automation.
@@ -332,7 +336,7 @@ same price period, the lock is reflected in `battery_setpoint` as well.
 | Control Mode | Optimal Mode | Power Sensor to Use |
 |-------------|-------------|---------------------|
 | `follow_schedule` | `charging` / `discharging` | `sensor.battery_controller_battery_setpoint` (W) |
-| `hybrid` / `zero_grid` | `charging` / `discharging` / `zero_grid` | `sensor.battery_controller_battery_setpoint` (W) |
+| `hybrid` / `hybrid_plus` / `zero_grid` | `charging` / `discharging` / `zero_grid` | `sensor.battery_controller_battery_setpoint` (W) |
 
 ### Example Automation
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ The **Battery power sensor** you configure as input (`battery_power_sensor`) is 
   When the shadow price says the battery can be filled more cheaply later (e.g. a
   midday PV peak at low prices), the surplus is exported at the current feed-in price
   instead of charged, and the battery charges later from the cheaper surplus.
+  When little future surplus is forecast, stored energy stays valuable (it displaces
+  grid import or serves expensive evening hours), so the surplus is captured
+  immediately — identical to Hybrid. Exporting only wins when the battery would fill
+  up anyway or the stored energy has little future value.
 - **Manual**: Target power set via `number.battery_controller_manual_power_setpoint`.
 
 Change the active mode with the **Control Mode** select entity, or use a service call in an automation.

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -20,9 +20,20 @@ PLATFORMS: list[Platform] = [
 MODE_ZERO_GRID = "zero_grid"
 MODE_FOLLOW_SCHEDULE = "follow_schedule"
 MODE_HYBRID = "hybrid"
+# Hybrid+ behaves like hybrid, but consults the price forecast (via the DP
+# shadow price) before storing PV surplus: when the battery can be filled more
+# cheaply later (e.g. a midday PV peak at low prices), the surplus is exported
+# at the current feed-in price instead of charged.
+MODE_HYBRID_PLUS = "hybrid_plus"
 MODE_MANUAL = "manual"
 
-CONTROL_MODES = [MODE_ZERO_GRID, MODE_FOLLOW_SCHEDULE, MODE_HYBRID, MODE_MANUAL]
+CONTROL_MODES = [
+    MODE_ZERO_GRID,
+    MODE_FOLLOW_SCHEDULE,
+    MODE_HYBRID,
+    MODE_HYBRID_PLUS,
+    MODE_MANUAL,
+]
 
 # Battery action modes
 ACTION_IDLE = "idle"

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -49,6 +49,7 @@ from .const import (
     DEFAULT_ZERO_GRID_RESPONSE_TIME_S,
     MODE_FOLLOW_SCHEDULE,
     MODE_HYBRID,
+    MODE_HYBRID_PLUS,
     MODE_MANUAL,
     MODE_ZERO_GRID,
     PRICE_CHANGE_REOPTIMIZE_ABS_EUR,
@@ -243,6 +244,18 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # flip the mode every realtime-update tick.
         self._last_hybrid_charge_decision: str = ACTION_CHARGING
 
+        # Hysteresis state for the hybrid+ surplus-capture decision: tracks
+        # whether the last decision was to store PV surplus ("zero_grid") or
+        # export it ("idle") so a shadow price hovering near the feed-in price
+        # doesn't flip the mode every optimization run.
+        self._last_hybrid_plus_capture_decision: str = "zero_grid"
+
+        # Whether hybrid+ currently blocks PV-surplus capture (exporting at the
+        # current feed-in price is worth more than storing). Gates the
+        # realtime idle→zero_grid upgrade in _resolve_controller_mode so a
+        # surplus appearing between optimizer runs isn't captured anyway.
+        self._hybrid_plus_capture_blocked: bool = False
+
         # Diagnostic history ring buffers (not persisted across restarts).
         # optimizer_run_log: one entry per 15-min optimizer run (24 h @ 15 min = 96).
         # setpoint_log: one entry every time the real-time setpoint changes.
@@ -291,6 +304,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._committed_price = 0.0
         self._committed_power = 0.0
         self._committed_step_start = None
+        self._last_hybrid_plus_capture_decision = "zero_grid"
+        self._hybrid_plus_capture_blocked = False
 
     @property
     def last_failure_reason(self) -> str | None:
@@ -703,6 +718,38 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # Negate: user enters positive=discharge, controller expects positive=charge
         return -stored
 
+    def _hybrid_plus_should_capture_surplus(
+        self, shadow_price_eur_kwh: float, current_feed_in: float
+    ) -> bool:
+        """Return whether hybrid+ should store PV surplus rather than export it.
+
+        Storing 1 kWh of AC surplus puts sqrt(RTE) kWh in the battery, each
+        worth the DP shadow price λ — the marginal value of stored energy given
+        the full price and PV forecast. Exporting the same kWh yields the
+        current feed-in price. When λ × sqrt(RTE) is below the feed-in price,
+        the forecast says the battery can be filled more cheaply later (e.g.
+        the midday PV peak at low prices), so exporting now is worth more than
+        storing.
+
+        Applies a ±5% hysteresis band around the feed-in threshold (same
+        pattern as the hybrid discharge decision) so a shadow price hovering
+        near the feed-in price doesn't flip the decision every run.
+        """
+        if current_feed_in <= 0:
+            # Exporting earns nothing (or costs money): always capture.
+            self._last_hybrid_plus_capture_decision = "zero_grid"
+            return True
+        sqrt_rte = float(self.battery_config.round_trip_efficiency) ** 0.5
+        store_value = shadow_price_eur_kwh * sqrt_rte
+        if self._last_hybrid_plus_capture_decision == "zero_grid":
+            should_capture = bool(store_value >= current_feed_in * 0.95)
+        else:
+            should_capture = bool(store_value >= current_feed_in * 1.05)
+        self._last_hybrid_plus_capture_decision = (
+            "zero_grid" if should_capture else ACTION_IDLE
+        )
+        return should_capture
+
     def _resolve_controller_mode(
         self, effective_mode: str, current_grid_w: float
     ) -> str:
@@ -714,6 +761,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         This prevents oscillation when the battery successfully absorbs PV and
         grid reads near 0 W (which would otherwise flip back to idle mode,
         stopping the charge, causing the grid to go negative again).
+
+        In hybrid+ mode the upgrade is suppressed while surplus capture is
+        blocked (exporting is worth more than storing per the shadow price),
+        so idle genuinely means "export the surplus".
 
         Args:
             effective_mode: The resolved mode from optimization logic.
@@ -728,12 +779,18 @@ class OptimizationCoordinator(DataUpdateCoordinator):
 
         if effective_mode == "zero_grid":
             return "zero_grid"
-        # Upgrade idle → zero_grid only in zero_grid/hybrid modes (not follow_schedule
-        # or manual, where idle must mean truly stop). Only when grid is actually
-        # exporting (negative), i.e. real PV surplus — not just near-zero import noise.
+        # Upgrade idle → zero_grid only in zero_grid/hybrid/hybrid+ modes (not
+        # follow_schedule or manual, where idle must mean truly stop). Only when
+        # grid is actually exporting (negative), i.e. real PV surplus — not just
+        # near-zero import noise. Hybrid+ additionally requires that surplus
+        # capture is economical per the last optimizer run.
         if (
             effective_mode == ACTION_IDLE
             and self._control_mode not in (MODE_FOLLOW_SCHEDULE, MODE_MANUAL)
+            and not (
+                self._control_mode == MODE_HYBRID_PLUS
+                and self._hybrid_plus_capture_blocked
+            )
             and current_grid_w < 0
             and has_power_sensors
         ):
@@ -957,7 +1014,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
 
         Battery selection for concentration (with _SOC_HYSTERESIS to prevent
         rapid switching):
-        - zero_grid / hybrid: battery closest to 50% rel_soc — handles both
+        - zero_grid / hybrid / hybrid+: battery closest to 50% rel_soc — handles both
           charge and discharge direction changes without switching inverters.
         - scheduled charge: battery with lowest rel_soc (most headroom).
         - scheduled discharge: battery with highest rel_soc (most energy).
@@ -1001,7 +1058,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         """
         sids = [sid for sid, _ in self._individual_battery_configs]
 
-        if mode in (MODE_ZERO_GRID, MODE_HYBRID):
+        if mode in (MODE_ZERO_GRID, MODE_HYBRID, MODE_HYBRID_PLUS):
             # Prefer battery closest to 50% rel_soc: stays within limits longest
             # regardless of whether the next setpoint is charge or discharge.
             def score(sid: str) -> float:
@@ -2024,8 +2081,11 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             manual_w = self._get_manual_setpoint_w()
             effective_mode = "manual"
             effective_power = manual_w / 1000  # kW for output sensors
-        elif self._control_mode == MODE_HYBRID:
-            # Hybrid: DP schedule for arbitrage, zero_grid for self-consumption
+        elif self._control_mode in (MODE_HYBRID, MODE_HYBRID_PLUS):
+            # Hybrid: DP schedule for arbitrage, zero_grid for self-consumption.
+            # Hybrid+ additionally consults the price forecast (via the shadow
+            # price) before storing PV surplus, so surplus is exported when the
+            # battery can be filled more cheaply later.
             if result.optimal_mode == ACTION_IDLE:
                 # Optimizer wants to preserve battery capacity.
                 # This means: don't charge (even with PV surplus) and don't discharge.
@@ -2050,8 +2110,33 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 else:
                     # Was idle; only start capturing once surplus is solid.
                     has_pv_surplus = current_grid < -hybrid_deadband_w
+                # Hybrid+: check the forecast before capturing surplus. The
+                # shadow price λ already prices in upcoming cheap-surplus hours
+                # (e.g. the midday PV peak at low prices): when λ × sqrt(RTE)
+                # is below the current feed-in price, exporting now is worth
+                # more than storing, so surplus capture is blocked.
+                capture_blocked = False
+                if self._control_mode == MODE_HYBRID_PLUS:
+                    current_feed_in = (
+                        resampled_feed_in[0]
+                        if resampled_feed_in
+                        else float(
+                            self.config.get(
+                                CONF_FIXED_FEED_IN_PRICE, DEFAULT_FIXED_FEED_IN_PRICE
+                            )
+                        )
+                    )
+                    capture_blocked = not self._hybrid_plus_should_capture_surplus(
+                        result.shadow_price_eur_kwh, current_feed_in
+                    )
+                self._hybrid_plus_capture_blocked = capture_blocked
                 if has_upcoming_discharge and not has_pv_surplus:
                     # Preserve capacity (discharge planned, no PV surplus)
+                    effective_mode = ACTION_IDLE
+                elif capture_blocked and has_pv_surplus:
+                    # Hybrid+: export the surplus at the current feed-in price
+                    # instead of storing it; the DP schedule charges later when
+                    # surplus is cheaper.
                     effective_mode = ACTION_IDLE
                 else:
                     # Either no discharge planned, or PV surplus to capture

--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -364,6 +364,7 @@
           "zero_grid": "Zero grid",
           "follow_schedule": "Follow schedule",
           "hybrid": "Hybrid",
+          "hybrid_plus": "Hybrid+",
           "manual": "Manual"
         }
       }

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -364,6 +364,7 @@
           "zero_grid": "Zero grid",
           "follow_schedule": "Follow schedule",
           "hybrid": "Hybrid",
+          "hybrid_plus": "Hybrid+",
           "manual": "Manual"
         }
       }

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -312,6 +312,7 @@
           "zero_grid": "Nul op de meter",
           "follow_schedule": "Volg schema",
           "hybrid": "Hybride",
+          "hybrid_plus": "Hybride+",
           "manual": "Handmatig"
         }
       }

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -25,6 +25,7 @@ from custom_components.battery_controller.const import (
     CONF_ZERO_GRID_DEADBAND_W,
     MODE_FOLLOW_SCHEDULE,
     MODE_HYBRID,
+    MODE_HYBRID_PLUS,
     MODE_ZERO_GRID,
 )
 from custom_components.battery_controller.coordinator_optimization import (
@@ -3214,6 +3215,7 @@ async def _run_hybrid_mode_sequence(
     fake_result: OptimizationResult,
     grid_sequence: list[float],
     deadband_w: float | None = None,
+    control_mode: str = MODE_HYBRID,
 ) -> list[str]:
     """Run hybrid optimization repeatedly on one coordinator, varying grid power.
 
@@ -3226,7 +3228,7 @@ async def _run_hybrid_mode_sequence(
     from unittest.mock import patch as upatch
 
     coord = _make_coordinator(hass)
-    coord.control_mode = MODE_HYBRID
+    coord.control_mode = control_mode
     fixed_now = datetime(2026, 3, 21, 10, 0, 0, tzinfo=timezone.utc)
     coord.forecast_coordinator.data = {
         "pv_forecast_kw": [0.5, 0.5],
@@ -3382,3 +3384,138 @@ async def test_hybrid_idle_zero_grid_deadband_is_configurable(hass, monkeypatch)
         deadband_w=10.0,
     )
     assert modes == ["zero_grid", "idle"]
+
+
+# ---------------------------------------------------------------------------
+# Hybrid+ mode: PV-surplus capture gated on the price forecast (shadow price)
+# ---------------------------------------------------------------------------
+
+
+def _idle_plan_result(shadow_price: float) -> OptimizationResult:
+    """Optimizer result planning idle now and charging later (cheap surplus)."""
+    return OptimizationResult(
+        power_schedule_kw=[0.0, 3.0],
+        mode_schedule=["idle", "charging"],
+        soc_schedule_kwh=[5.0, 5.0, 7.8],
+        total_cost=0.0,
+        baseline_cost=0.0,
+        savings=0.0,
+        optimal_power_kw=0.0,
+        optimal_mode="idle",
+        shadow_price_eur_kwh=shadow_price,
+        price_forecast=[0.10, 0.12],
+        pv_forecast=[0.5, 0.5],
+        consumption_forecast=[0.3, 0.3],
+    )
+
+
+@pytest.mark.asyncio
+async def test_hybrid_plus_low_shadow_price_exports_surplus(hass, monkeypatch):
+    """Hybrid+ exports PV surplus when the battery can be filled cheaper later.
+
+    The optimizer plans idle now and charging later; its shadow price of
+    0.02 EUR/kWh (× sqrt(0.92) ≈ 0.019) is well below the 0.07 EUR/kWh fixed
+    feed-in price, so exporting the current surplus beats storing it and the
+    mode must stay idle instead of upgrading to zero_grid.
+    """
+    modes = await _run_hybrid_mode_sequence(
+        hass,
+        monkeypatch,
+        _idle_plan_result(shadow_price=0.02),
+        grid_sequence=[-2000.0],
+        control_mode=MODE_HYBRID_PLUS,
+    )
+    assert modes == ["idle"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_plus_high_shadow_price_captures_surplus(hass, monkeypatch):
+    """Hybrid+ still captures surplus when stored energy is worth more than feed-in.
+
+    Shadow price 0.15 EUR/kWh (× sqrt(0.92) ≈ 0.144) exceeds the 0.07 EUR/kWh
+    feed-in price, so storing the surplus beats exporting it — same behaviour
+    as plain hybrid.
+    """
+    modes = await _run_hybrid_mode_sequence(
+        hass,
+        monkeypatch,
+        _idle_plan_result(shadow_price=0.15),
+        grid_sequence=[-2000.0],
+        control_mode=MODE_HYBRID_PLUS,
+    )
+    assert modes == ["zero_grid"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_captures_surplus_regardless_of_shadow_price(hass, monkeypatch):
+    """Plain hybrid is unchanged: surplus is captured even at a low shadow price."""
+    modes = await _run_hybrid_mode_sequence(
+        hass,
+        monkeypatch,
+        _idle_plan_result(shadow_price=0.02),
+        grid_sequence=[-2000.0],
+        control_mode=MODE_HYBRID,
+    )
+    assert modes == ["zero_grid"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_plus_self_consumption_not_gated(hass, monkeypatch):
+    """The hybrid+ gate only affects surplus capture, not self-consumption.
+
+    With the grid importing (no PV surplus) and no upcoming discharge, hybrid+
+    must still resolve idle to zero_grid for self-consumption, even though the
+    low shadow price blocks surplus capture.
+    """
+    modes = await _run_hybrid_mode_sequence(
+        hass,
+        monkeypatch,
+        _idle_plan_result(shadow_price=0.02),
+        grid_sequence=[500.0],
+        control_mode=MODE_HYBRID_PLUS,
+    )
+    assert modes == ["zero_grid"]
+
+
+def test_hybrid_plus_capture_decision_hysteresis(hass):
+    """The capture decision applies a ±5% band around the feed-in threshold.
+
+    Test coordinator: RTE 0.92 → sqrt(RTE) ≈ 0.9592; feed-in 0.07 EUR/kWh.
+    Capture threshold while capturing: 0.07 × 0.95 = 0.0665; while exporting:
+    0.07 × 1.05 = 0.0735 (both on the stored value λ × sqrt(RTE)).
+    """
+    coord = _make_coordinator(hass)
+    # Initial state is capturing: keeps capturing down to the ×0.95 band edge
+    assert coord._hybrid_plus_should_capture_surplus(0.10, 0.07) is True
+    # Stored value 0.0652 < 0.0665 → flips to exporting
+    assert coord._hybrid_plus_should_capture_surplus(0.068, 0.07) is False
+    # Stored value 0.0691 is above the raw threshold but below ×1.05 → stays
+    # exporting (this is the hysteresis: without it the decision would flip)
+    assert coord._hybrid_plus_should_capture_surplus(0.072, 0.07) is False
+    # Stored value 0.0748 ≥ 0.0735 → flips back to capturing
+    assert coord._hybrid_plus_should_capture_surplus(0.078, 0.07) is True
+
+
+def test_hybrid_plus_negative_feed_in_always_captures(hass):
+    """With zero/negative feed-in, exporting earns nothing: always capture."""
+    coord = _make_coordinator(hass)
+    assert coord._hybrid_plus_should_capture_surplus(0.0, -0.05) is True
+    assert coord._hybrid_plus_should_capture_surplus(0.0, 0.0) is True
+
+
+def test_resolve_controller_mode_hybrid_plus_blocks_surplus_upgrade(hass):
+    """The realtime idle→zero_grid upgrade respects the hybrid+ capture block."""
+    coord = _make_coordinator(hass)
+    coord._control_mode = MODE_HYBRID_PLUS
+    coord._power_consumption_sensors = ["sensor.power"]
+
+    coord._hybrid_plus_capture_blocked = True
+    assert coord._resolve_controller_mode("idle", -500.0) == "idle"
+
+    coord._hybrid_plus_capture_blocked = False
+    assert coord._resolve_controller_mode("idle", -500.0) == "zero_grid"
+
+    # Plain hybrid ignores the flag entirely
+    coord._control_mode = MODE_HYBRID
+    coord._hybrid_plus_capture_blocked = True
+    assert coord._resolve_controller_mode("idle", -500.0) == "zero_grid"


### PR DESCRIPTION
## Description

Hybrid mode charges the battery as soon as PV surplus appears, even when the forecast shows abundant cheaper surplus later in the day (e.g. the midday PV peak coinciding with low prices). In that case it is more profitable to export the morning surplus at the current feed-in price and fill the battery later from the cheap midday surplus.

This PR adds a new **Hybrid+** (`hybrid_plus`) control mode that behaves exactly like Hybrid, but consults the price forecast before storing PV surplus, using the DP shadow price λ (which already prices in all upcoming price/PV hours):

- Surplus is only captured when `λ × sqrt(RTE) ≥ current feed-in price` — i.e. when the stored energy is worth more than exporting it. Otherwise the mode stays `idle`, the surplus flows to the grid at the current feed-in price, and the battery charges later via the regular DP schedule.
- When little future surplus is forecast, λ stays high (stored energy displaces grid import or serves expensive evening hours), so the surplus is captured immediately — identical to Hybrid. No separate rule needed; the shadow price encodes this by construction.
- A ±5% hysteresis band around the feed-in threshold prevents oscillation (same pattern as the existing hybrid discharge decision).
- The realtime `idle → zero_grid` upgrade in `_resolve_controller_mode` respects the same block, so surplus appearing between 15-min optimizer runs is not captured anyway.
- Unchanged from Hybrid: discharge decisions, self-consumption when the grid is importing, DP-planned charging, and negative feed-in handling (always capture — exporting would cost money).

The DP engine itself is untouched (no changes needed in `optimizer.py` / `analyzer.js` / `simulate_diagnostics.py`); the new mode only changes how the coordinator resolves the optimizer's idle steps.

Other changes:
- `const.py`: new `MODE_HYBRID_PLUS`, added to `CONTROL_MODES` (select entity picks it up automatically)
- Translations: `Hybrid+` (en/strings) and `Hybride+` (nl)
- Multi-battery concentration selection treats `hybrid_plus` like `hybrid`/`zero_grid`
- Docs: README control-mode sections and ALGORITHM.md shadow-price section updated
- Tests: 7 new tests covering the capture/export decision, hysteresis, negative feed-in, the realtime upgrade gate, and a regression test that plain hybrid still captures unconditionally

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [x] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Full test suite passes locally (700+ tests), `pre-commit run --all-files` (ruff, ruff-format, mypy, codespell) green.