### PR TITLE
docs: clarify Hybrid mode trade-off and rolling-horizon re-optimization

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -398,24 +398,24 @@ The shadow price is always the raw DP value — there is no separate "post-proce
 
 ## 10. Rolling-Horizon Execution
 
-The optimizer runs every 15 minutes. Each run:
+The optimizer runs every 15 minutes, plus on a handful of event-driven triggers (new price period, a significant price change, a stale price/SoC sensor recovering, and a scheduled mid-period correction run at the midpoint of the current price period — see `coordinator_optimization.py`). Each run:
 
 1. Reads the current SoC and latest forecasts.
-2. Calls `optimize_battery_schedule()` with the latest forecasts and calibration overrides.
+2. Calls `optimize_battery_schedule()` with the latest forecasts and calibration overrides, re-solving the **entire** horizon from scratch (the terminal condition is derived fresh from the feed-in forecast each time — see [Section 5](#5-terminal-condition) — not carried over from the previous run's shadow price).
 3. Executes **only the first step** of the resulting schedule (`optimal_power_kw`).
-4. Saves the new shadow price for the next run.
+4. Exposes the new shadow price for hybrid-mode thresholding and diagnostics.
 
-This is called a **rolling horizon** or **receding horizon** approach. Re-optimizing every 15 minutes allows the schedule to adapt as prices are updated, PV production deviates from forecast, or household consumption changes.
+This is called a **rolling horizon** or **receding horizon** approach. Re-optimizing every 15 minutes (or sooner, on the triggers above) allows the schedule to adapt as prices are updated, PV production deviates from forecast, or household consumption changes.
 
-The shadow price acts as a **bridge between runs**: it encodes how much future value will be lost or gained by entering the next horizon with more or less stored energy. Without it, each run is blind to what happens after the forecast ends, potentially draining the battery just before prices spike.
+Because capacity is limited, each full re-solve is a **global allocation** across every cheap/negative-price opportunity in the horizon — how much of the current window to use now versus reserve for a better one later. A small change in inputs between two runs (price forecast update, revised PV/consumption forecast, or actual SoC drifting from the previous plan) can shift that allocation enough that two runs a few minutes apart show a visibly different schedule for what looks like an unchanged situation. This is expected, not a bug.
 
 ### Convergence
 
-On the first run there is no prior shadow price, so the terminal condition falls back to the tail average of the feed-in forecast. As runs accumulate over days and weeks:
-- The shadow price converges to a value that reflects typical overnight vs. daytime price patterns and seasonal PV output.
-- The historical price model (which provides forecasts before day-ahead prices are published) also improves with more recorder data.
+The DP itself is stateless between runs — there is no shadow-price carry-over — but two things it depends on *do* build up from HA recorder history over time:
+- The **historical price model** (used before day-ahead prices are published, and to extend a short horizon) improves as more price/weather data accumulates.
+- The **household consumption pattern** needs several weeks of kWh sensor history to build accurate forecasts.
 
-During the convergence period (first 2–4 weeks), the schedule may change more noticeably between runs and may appear more aggressive than the long-run optimum.
+While these are still calibrating (first 2–4 weeks), forecasts are noisier, so the schedule may change more noticeably between runs — including between two runs within the same 15-minute slot — and may appear more aggressive than the long-run optimum.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ The integration runs three cascading coordinators:
 > **Note:** The Optimization Coordinator doesn't only run on the fixed 15-minute clock.
 > It also re-runs immediately when a new price period starts, on a significant price
 > change, when a stale price/SoC sensor becomes available again, and once at the
-> midpoint of the current price period (a scheduled "mid-period correction" run). Two
-> schedule snapshots taken a few minutes apart within the same nominal interval can
-> therefore legitimately differ — this is expected behavior, not a bug.
+> midpoint of the current price period (a scheduled "mid-period correction" run). Each
+> run re-solves the entire rolling horizon from scratch, so two schedule snapshots
+> taken a few minutes apart can look meaningfully different — see [Learning
+> period](#learning-period--give-the-optimizer-time-to-calibrate) for why.
 
 #### Subentry Structure
 Battery Controller uses **subentries** to manage hardware flexibly:
@@ -92,17 +93,28 @@ The model also **extends the planning horizon** when live prices cover less than
 
 > **Allow at least 2–4 weeks of operation before judging the optimizer's performance.**
 
-The optimizer uses a technique called *rolling-horizon dynamic programming*. On each run it calculates not only the optimal schedule, but also a **shadow price** (λ) — the marginal value of one extra kWh stored in the battery, given the current price forecast.
+The optimizer uses *rolling-horizon dynamic programming*: on **every** run it re-solves the entire planning horizon (24–36 hours) from scratch, starting from the current SoC. The value of stored energy at the end of the horizon (the terminal condition) is set from the price forecast itself — a clipped tail-average of the feed-in price — not carried over from the previous run.
 
-That shadow price is fed back as the **terminal condition** of the next run: it tells the optimizer what stored energy will be worth *after* the planning horizon ends. A well-calibrated shadow price makes consecutive schedules consistent with each other and prevents the optimizer from over-charging or over-discharging near the horizon boundary.
+Because battery capacity is limited, this is a **global allocation problem**: the DP weighs using the current cheap/negative-price window now against reserving capacity for a *better* opportunity later in the horizon. On a rerun, small input changes can shift that trade-off enough to visibly change today's plan:
 
-On the **first run** there is no shadow price yet, so the optimizer falls back to the average sell price at the end of the forecast. As runs accumulate (every 15 minutes), the shadow price converges toward the true marginal value of storage for your household's typical price and consumption pattern. During this convergence period you may notice:
+- A price forecast update (day-ahead prices publishing, a revised historical-model estimate, or simply a new period starting).
+- An updated PV or consumption forecast.
+- The actual SoC drifting from what the previous plan assumed — e.g. because **Hybrid** mode diverged to zero-grid instead of following the DP schedule exactly (see [Control Modes](#control-modes)).
 
-- The schedule changing more noticeably between runs.
+Because the whole horizon is re-optimized rather than patched incrementally, even a modest change in one of these inputs can shift how much capacity is allocated to the current window versus a later one — so two runs a few minutes apart (see the re-optimization triggers above) can show different schedules for what looks like the same situation. This is expected DP behavior, not a bug.
+
+This effect is most visible in the first weeks, while two data-driven models are still building up from HA recorder history:
+
+- The **household consumption pattern** and **historical price model**, which need time to learn typical usage and price patterns.
+- The **shadow price** (λ) — the marginal value of storage, used by Hybrid mode as its charge/discharge threshold — is noisier while the forecasts feeding into it are still inaccurate.
+
+During this convergence period you may notice:
+
+- The schedule changing more noticeably between runs, including between two runs within the same 15-minute slot.
 - The optimizer occasionally charging or discharging more aggressively than expected.
 - Estimated savings that appear lower than the long-run optimum.
 
-Both the **historical price model** and the **shadow price** build up from HA recorder data, so the longer the integration runs, the better the forecasts and the more stable the resulting schedule.
+The longer the integration runs, the more accurate the underlying forecasts become and the more stable the resulting schedule.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ The integration runs three cascading coordinators:
 2. **Forecast Coordinator** (every 15 min): Calculates PV production and consumption forecasts
 3. **Optimization Coordinator** (every 15 min): Runs the DP optimizer and zero-grid controller (see [ALGORITHM.md](ALGORITHM.md) for full algorithmic details)
 
+> **Note:** The Optimization Coordinator doesn't only run on the fixed 15-minute clock.
+> It also re-runs immediately when a new price period starts, on a significant price
+> change, when a stale price/SoC sensor becomes available again, and once at the
+> midpoint of the current price period (a scheduled "mid-period correction" run). Two
+> schedule snapshots taken a few minutes apart within the same nominal interval can
+> therefore legitimately differ — this is expected behavior, not a bug.
+
 #### Subentry Structure
 Battery Controller uses **subentries** to manage hardware flexibly:
 - **Battery subentries**: Each contains its own capacity, power limits, SoC sensor, and optional power sensor.
@@ -315,6 +322,14 @@ The **Battery power sensor** you configure as input (`battery_power_sensor`) is 
   lock applies to the published controller setpoint too, not just the diagnostic
   `optimal_power` value.
 - **Hybrid** (recommended): DP schedule for arbitrage, zero-grid for self-consumption.
+  When the DP schedule says `idle` and no discharge is planned soon, Hybrid still
+  opportunistically captures PV surplus into the battery via zero-grid — even if the
+  feed-in price is currently positive and exporting that surplus would be more
+  profitable. This trades a small amount of arbitrage profit for resilience (keeping
+  headroom available for real-time consumption spikes, e.g. a cloud passing over the
+  panels while a large appliance switches on). If you want the strictly cost-optimal
+  schedule with no opportunistic charging, use **Follow Schedule** instead — Hybrid is
+  recommended for robustness, not maximum arbitrage profit.
 - **Manual**: Target power set via `number.battery_controller_manual_power_setpoint`.
 
 Change the active mode with the **Control Mode** select entity, or use a service call in an automation.

--- a/custom_components/battery_controller/diagnostics.py
+++ b/custom_components/battery_controller/diagnostics.py
@@ -187,7 +187,8 @@ async def async_get_config_entry_diagnostics(
                 "feed_in_price_forecast_model": data.get(
                     "feed_in_price_forecast_model"
                 ),
-                # Terminal shadow price (= current shadow price; next run uses it as terminal)
+                # Current shadow price, exported for informational/analyzer display only.
+                # Not used as the DP terminal condition (see optimizer.py terminal_price).
                 "terminal_shadow_price": data.get("shadow_price_eur_kwh"),
             }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -181,7 +181,7 @@
       </table>
     </div>
     <div id="profitability-legend" class="mt-2 text-xs text-gray-400">
-      Terminal price λ = <span id="terminal-price-label">—</span> €/kWh (re-computed; integration may use rolling shadow price) ·
+      Terminal price λ = <span id="terminal-price-label">—</span> €/kWh (re-computed from the feed-in forecast tail, same as the integration) ·
       Break-even discharge: <span id="breakeven-discharge-label">—</span> €/kWh ·
       Break-even charge: <span id="breakeven-charge-label">—</span> €/kWh
     </div>
@@ -1155,9 +1155,6 @@ function prefillSim(d) {
       addFcRow(prices[i]||0.15, feedInVal, pvFc[i]||0, consumFc[i]||1.5);
     }
   }
-  // Pre-fill terminal shadow price from previous DP run (stored in schedule)
-  if (sched.terminal_shadow_price !== undefined && sched.terminal_shadow_price !== null) {
-    }
   window._simChargeEffCorrection =
     opt.charge_eff_correction
     ?? ((opt.optimizer_run_log && opt.optimizer_run_log.length)

--- a/simulate/simulate_diagnostics.py
+++ b/simulate/simulate_diagnostics.py
@@ -164,7 +164,7 @@ def extract_inputs(diag: dict) -> tuple:
     # Use actual feed-in forecast from schedule if available (new diagnostics field)
     feed_in_forecast = sched.get("feed_in_price_forecast") or list(price_forecast)
 
-    # Terminal shadow price stored in schedule for DP reproduction
+    # Shadow price from the diagnostics snapshot; informational only (not a DP input).
     terminal_shadow_price = sched.get("terminal_shadow_price")
     charge_eff_correction = opt_data.get("charge_eff_correction")
     if charge_eff_correction is None:
@@ -990,10 +990,10 @@ def print_whatif(
 
     print()
     print(
-        "  The actual terminal price comes from the shadow price (λ) of the previous run"
+        "  The actual terminal price comes from the feed-in forecast, not the previous"
     )
     print(
-        "  when available, otherwise from min(feed_in_forecast[-1], 6-step tail average)"
+        "  run's shadow price: max(0, min(feed_in_forecast[-1], clipped 6h tail average))"
     )
     print(f"  = {terminal_price:.4f} €/kWh")
     print(


### PR DESCRIPTION
## Description

Prompted by community forum questions about confusing behavior:
- Why Hybrid mode charges the battery via zero-grid even when the feed-in price is currently positive.
- Why the schedule can look meaningfully different between two reruns of the optimizer just minutes apart.

Changes:
- README: expanded the **Hybrid** control mode description to explain that it opportunistically captures PV surplus for resilience/headroom, even when exporting would be more profitable — a deliberate trade-off, not a bug. Pointed users to **Follow Schedule** for the strictly cost-optimal alternative.
- README/ALGORITHM.md: added a note on the Optimization Coordinator's event-driven re-run triggers (new price period, significant price change, sensor recovery, mid-period correction), and rewrote the "Learning period" / "Rolling-Horizon Execution" sections to explain *why* full-horizon re-solves can shift a schedule noticeably between nearby runs (a global capacity-allocation problem sensitive to small input changes).
- Corrected a stale claim in README.md and ALGORITHM.md §10 that the shadow price is fed forward as the next run's terminal condition — `optimizer.py` deliberately does **not** do this (avoids a circular self-suppression bug at peak prices; terminal price comes from the feed-in forecast tail average instead). ALGORITHM.md §9 already stated this correctly, so §10 contradicted §9.
- Cleaned up the same stale assumption in a few code comments/labels: `diagnostics.py`, `simulate_diagnostics.py`, and `docs/index.html` (also removed a dead, empty `if` block left over from a removed pre-fill feature).

No functional/behavioral changes — documentation and comments only.

## Type of change

- [x] `docs:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit titles follow Conventional Commits (`docs:`)
- [ ] Tests added or updated — not applicable, no code behavior changed
- [x] Documentation updated
- [ ] CI is green — pending
- [x] PR targets the `dev` branch

## Screenshots / Logs (optional)

N/A