### PR TITLE
fix: PV Curtailment Suggested lagging feed-in price and flapping mid-period

### DIFF
--- a/custom_components/battery_controller/binary_sensor.py
+++ b/custom_components/battery_controller/binary_sensor.py
@@ -25,6 +25,13 @@ PARALLEL_UPDATES = 0
 # Minimum charging setpoint (W) below which the absorption check is skipped (noise floor).
 _MIN_SETPOINT_W = 200.0
 
+# Hysteresis exit threshold for condition B (fraction of setpoint). Entry uses
+# ABSORPTION_THRESHOLD (0.70); recovery requires climbing back to this higher
+# fraction so real-time sensor noise near the entry threshold — the actual
+# power is republished every zero_grid_response_time_s (default 10s) — doesn't
+# flap the sensor on/off between DP re-optimizations.
+_ABSORPTION_RECOVER_THRESHOLD = 0.85
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -90,6 +97,7 @@ class PVCurtailmentSensor(BatteryControllerBinarySensor):
         entry: ConfigEntry,
     ) -> None:
         super().__init__(coordinator, device, entry, "pv_curtailment")
+        self._condition_b_active = False
 
     @property
     def is_on(self) -> bool | None:
@@ -114,17 +122,24 @@ class PVCurtailmentSensor(BatteryControllerBinarySensor):
 
         # Condition B: battery is being asked to charge but actual power is
         # significantly less than the setpoint → battery/inverter is limiting.
+        # Hysteresis (entry at ABSORPTION_THRESHOLD, recovery at the higher
+        # _ABSORPTION_RECOVER_THRESHOLD) avoids flapping on/off between DP
+        # re-optimizations: actual_w is republished every
+        # zero_grid_response_time_s from a live sensor and can hover around a
+        # single threshold on its own.
         # control_action["target_power_w"]: positive = charge (controller convention)
         setpoint_w = control_action.get("target_power_w", 0.0)
         actual_w = battery_state.power_kw * 1000  # positive = charging
 
-        if (
-            setpoint_w > _MIN_SETPOINT_W
-            and actual_w < setpoint_w * ABSORPTION_THRESHOLD
-        ):
-            return True
+        if setpoint_w <= _MIN_SETPOINT_W:
+            self._condition_b_active = False
+        elif actual_w < setpoint_w * ABSORPTION_THRESHOLD:
+            self._condition_b_active = True
+        elif actual_w >= setpoint_w * _ABSORPTION_RECOVER_THRESHOLD:
+            self._condition_b_active = False
+        # else: within the hysteresis band — keep the previous state.
 
-        return False
+        return self._condition_b_active
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -156,6 +156,13 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._unsub_price: Any | None = None
         self._last_price: float | None = None
 
+        # Feed-in price sensor tracking (separate entity from the buy price
+        # sensor, so it needs its own period-boundary tracking to keep
+        # current_feed_in_price — and PVCurtailmentSensor — in sync).
+        self._feed_in_price_sensor = config.get(CONF_FEED_IN_PRICE_SENSOR)
+        self._unsub_feed_in_price: Any | None = None
+        self._last_feed_in_period_start: datetime | None = None
+
         # Real-time sensors for zero_grid control (grid power only; battery sensors in subentries)
         self._power_consumption_sensors = config.get(CONF_POWER_CONSUMPTION_SENSORS, [])
         self._power_production_sensors = config.get(CONF_POWER_PRODUCTION_SENSORS, [])
@@ -355,6 +362,19 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             )
             _LOGGER.debug("Tracking price sensor: %s", self._price_sensor)
 
+        if (
+            self._feed_in_price_sensor
+            and self._feed_in_price_sensor != self._price_sensor
+        ):
+            self._unsub_feed_in_price = async_track_state_change_event(
+                self.hass,
+                [self._feed_in_price_sensor],
+                self._handle_feed_in_price_change,
+            )
+            _LOGGER.debug(
+                "Tracking feed-in price sensor: %s", self._feed_in_price_sensor
+            )
+
         if self._battery_soc_sensor:
             self._unsub_soc = async_track_state_change_event(
                 self.hass,
@@ -473,6 +493,49 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 )
                 self.hass.async_create_task(self.async_request_refresh())
             self._last_price = new_price
+
+    @callback
+    def _handle_feed_in_price_change(self, event: Event[EventStateChangedData]) -> None:
+        """Handle feed-in price sensor state changes.
+
+        When the feed-in price is a separate sensor from the buy price, its
+        period boundaries are not covered by _handle_price_change. Without
+        this listener, current_feed_in_price (and PVCurtailmentSensor) would
+        only refresh when the buy price sensor happens to change, the
+        mid-period timer fires, or the 60-min base update_interval elapses —
+        so it can lag the actual feed-in price by up to an hour.
+        """
+        new_state = event.data.get("new_state")
+        if not new_state:
+            return
+
+        try:
+            float(new_state.state)
+        except (ValueError, TypeError):
+            return  # Sensor is unavailable/unknown, ignore
+
+        old_state = event.data.get("old_state")
+        was_unavailable = (
+            self._last_feed_in_period_start is None
+            or old_state is None
+            or old_state.state in ("unknown", "unavailable")
+        )
+
+        try:
+            _, start_times, _ = extract_price_forecast_with_timestamps(new_state)
+            period_start: datetime | None = start_times[0] if start_times else None
+        except Exception:  # noqa: BLE001
+            period_start = None
+
+        if was_unavailable or (
+            period_start is not None and period_start != self._last_feed_in_period_start
+        ):
+            _LOGGER.debug(
+                "Feed-in price period changed at %s, triggering optimization",
+                period_start,
+            )
+            self._last_feed_in_period_start = period_start
+            self.hass.async_create_task(self.async_request_refresh())
 
     @callback
     def _schedule_mid_period_run(
@@ -816,6 +879,9 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if self._unsub_price:
             self._unsub_price()
             self._unsub_price = None
+        if self._unsub_feed_in_price:
+            self._unsub_feed_in_price()
+            self._unsub_feed_in_price = None
         if self._unsub_soc:
             self._unsub_soc()
             self._unsub_soc = None

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -137,6 +137,52 @@ class TestPVCurtailmentSensor:
         # 800W >= 0.70 * 1000W = 700W → should not trigger condition B
         assert sensor.is_on is False
 
+    def test_condition_b_hysteresis_holds_on_through_noise_band(self):
+        """Once triggered, condition B must stay on while actual power hovers
+        between ABSORPTION_THRESHOLD and _ABSORPTION_RECOVER_THRESHOLD instead
+        of flapping with every real-time (~5-10s) sensor update."""
+        battery_state = MagicMock()
+        battery_state.soc_kwh = 5.0
+        battery_state.power_kw = 0.1  # 100W: well below 70% of 1000W setpoint
+        sensor = self._make_sensor(
+            data={
+                "current_feed_in_price": -0.05,
+                "battery_state": battery_state,
+                "control_action": {"target_power_w": 1000.0},
+            }
+        )
+        assert sensor.is_on is True  # entry: 100W < 700W
+
+        # Noisy reading recovers to 750W — within the hysteresis band
+        # (700W-850W) — must NOT clear the suggestion yet.
+        battery_state.power_kw = 0.75
+        assert sensor.is_on is True
+
+        # Recovers above the exit threshold (850W) — now it clears.
+        battery_state.power_kw = 0.9
+        assert sensor.is_on is False
+
+        # Dips back into the band — stays off (no re-trigger inside the band).
+        battery_state.power_kw = 0.75
+        assert sensor.is_on is False
+
+    def test_condition_b_hysteresis_resets_when_setpoint_drops(self):
+        """A setpoint falling below the noise floor clears a latched condition B."""
+        battery_state = MagicMock()
+        battery_state.soc_kwh = 5.0
+        battery_state.power_kw = 0.1
+        sensor = self._make_sensor(
+            data={
+                "current_feed_in_price": -0.05,
+                "battery_state": battery_state,
+                "control_action": {"target_power_w": 1000.0},
+            }
+        )
+        assert sensor.is_on is True
+
+        sensor.coordinator.data["control_action"] = {"target_power_w": 100.0}
+        assert sensor.is_on is False
+
     def test_extra_state_attributes_empty_when_no_data(self):
         sensor = self._make_sensor(data=None)
         assert sensor.extra_state_attributes == {}

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -349,6 +349,223 @@ async def test_same_period_no_trigger_below_threshold(hass, monkeypatch):
     )
 
 
+@pytest.mark.asyncio
+async def test_async_setup_tracks_distinct_feed_in_price_sensor(hass):
+    """A feed-in price sensor different from the buy price sensor gets its own tracker."""
+    from unittest.mock import AsyncMock
+
+    weather_coordinator = MagicMock()
+    weather_coordinator.data = {}
+    forecast_coordinator = MagicMock()
+    forecast_coordinator.data = None
+    forecast_coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+
+    config = {
+        "entry_id": "test-entry",
+        CONF_PRICE_SENSOR: "sensor.test_price",
+        CONF_FEED_IN_PRICE_SENSOR: "sensor.test_feed_in_price",
+        CONF_CONTROL_MODE: MODE_FOLLOW_SCHEDULE,
+        CONF_FIXED_FEED_IN_PRICE: 0.07,
+        CONF_POWER_CONSUMPTION_SENSORS: [],
+        CONF_POWER_PRODUCTION_SENSORS: [],
+        "battery_subentries": [],
+    }
+
+    coord = OptimizationCoordinator(
+        hass, weather_coordinator, forecast_coordinator, config
+    )
+    coord._price_model = MagicMock()
+    coord._price_model.async_update_pattern = AsyncMock()
+    coord._feed_in_price_model = MagicMock()
+    coord._feed_in_price_model.async_update_pattern = AsyncMock()
+
+    tracked_entities = []
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_optimization.async_track_time_interval",
+            return_value=lambda: None,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_optimization.async_track_state_change_event",
+            side_effect=lambda h, ids, cb: (
+                tracked_entities.extend(ids) or (lambda: None)
+            ),
+        ),
+    ):
+        await coord.async_setup()
+
+    assert "sensor.test_price" in tracked_entities
+    assert "sensor.test_feed_in_price" in tracked_entities
+
+
+@pytest.mark.asyncio
+async def test_async_setup_skips_feed_in_tracker_when_same_as_price_sensor(hass):
+    """No duplicate tracker is registered when feed-in price reuses the buy price sensor."""
+    from unittest.mock import AsyncMock
+
+    weather_coordinator = MagicMock()
+    weather_coordinator.data = {}
+    forecast_coordinator = MagicMock()
+    forecast_coordinator.data = None
+    forecast_coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+
+    config = {
+        "entry_id": "test-entry",
+        CONF_PRICE_SENSOR: "sensor.test_price",
+        CONF_FEED_IN_PRICE_SENSOR: "sensor.test_price",
+        CONF_CONTROL_MODE: MODE_FOLLOW_SCHEDULE,
+        CONF_FIXED_FEED_IN_PRICE: 0.07,
+        CONF_POWER_CONSUMPTION_SENSORS: [],
+        CONF_POWER_PRODUCTION_SENSORS: [],
+        "battery_subentries": [],
+    }
+
+    coord = OptimizationCoordinator(
+        hass, weather_coordinator, forecast_coordinator, config
+    )
+    coord._price_model = MagicMock()
+    coord._price_model.async_update_pattern = AsyncMock()
+    coord._feed_in_price_model = MagicMock()
+    coord._feed_in_price_model.async_update_pattern = AsyncMock()
+
+    tracked_calls = []
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_optimization.async_track_time_interval",
+            return_value=lambda: None,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_optimization.async_track_state_change_event",
+            side_effect=lambda h, ids, cb: tracked_calls.append(ids) or (lambda: None),
+        ),
+    ):
+        await coord.async_setup()
+
+    # Only the buy price sensor is tracked — no duplicate for feed-in.
+    assert tracked_calls == [["sensor.test_price"]]
+
+
+def test_handle_feed_in_price_change_no_new_state(hass):
+    """_handle_feed_in_price_change returns early when new_state is None."""
+    coord = _make_coordinator(hass)
+    event = MagicMock()
+    event.data = {"new_state": None, "old_state": None}
+    coord._handle_feed_in_price_change(event)  # Should not raise
+
+
+def test_handle_feed_in_price_change_unavailable_state(hass):
+    """_handle_feed_in_price_change ignores unavailable/unknown states."""
+    coord = _make_coordinator(hass)
+    new_state = MagicMock()
+    new_state.state = "unavailable"
+    event = MagicMock()
+    event.data = {"new_state": new_state, "old_state": None}
+    coord._handle_feed_in_price_change(event)  # Should not raise
+
+
+@pytest.mark.asyncio
+async def test_handle_feed_in_price_change_period_boundary_triggers(hass, monkeypatch):
+    """A new feed-in price period must trigger optimization even when the buy
+    price sensor is a separate, unchanged entity."""
+    coordinator = _make_coordinator(hass)
+
+    period_a = datetime(2026, 3, 21, 10, 0, 0, tzinfo=timezone.utc)
+    period_b = datetime(2026, 3, 21, 11, 0, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.extract_price_forecast_with_timestamps",
+        lambda state: ([0.05], [period_b], 60),
+    )
+
+    coordinator._last_feed_in_period_start = period_a
+
+    refresh_called = []
+
+    async def fake_refresh():
+        refresh_called.append(True)
+
+    monkeypatch.setattr(coordinator, "async_request_refresh", fake_refresh)
+
+    old_state = MagicMock()
+    old_state.state = "0.10"
+    new_state = MagicMock()
+    new_state.state = "0.05"
+    event = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state}
+
+    coordinator._handle_feed_in_price_change(event)
+    await hass.async_block_till_done()
+
+    assert refresh_called, (
+        "optimization should be triggered at feed-in price period boundary"
+    )
+    assert coordinator._last_feed_in_period_start == period_b
+
+
+@pytest.mark.asyncio
+async def test_handle_feed_in_price_change_same_period_no_trigger(hass, monkeypatch):
+    """No refresh is triggered when the feed-in price period hasn't changed."""
+    coordinator = _make_coordinator(hass)
+    period = datetime(2026, 3, 21, 10, 0, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.extract_price_forecast_with_timestamps",
+        lambda state: ([0.05], [period], 60),
+    )
+
+    coordinator._last_feed_in_period_start = period
+
+    refresh_called = []
+
+    async def fake_refresh():
+        refresh_called.append(True)
+
+    monkeypatch.setattr(coordinator, "async_request_refresh", fake_refresh)
+
+    old_state = MagicMock()
+    old_state.state = "0.05"
+    new_state = MagicMock()
+    new_state.state = "0.05"
+    event = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state}
+
+    coordinator._handle_feed_in_price_change(event)
+    await hass.async_block_till_done()
+
+    assert not refresh_called
+
+
+@pytest.mark.asyncio
+async def test_handle_feed_in_price_change_was_unavailable_triggers(hass, monkeypatch):
+    """Sensor becoming available for the first time triggers a refresh."""
+    coordinator = _make_coordinator(hass)
+    period = datetime(2026, 3, 21, 10, 0, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.extract_price_forecast_with_timestamps",
+        lambda state: ([0.05], [period], 60),
+    )
+
+    refresh_called = []
+
+    async def fake_refresh():
+        refresh_called.append(True)
+
+    monkeypatch.setattr(coordinator, "async_request_refresh", fake_refresh)
+
+    old_state = MagicMock()
+    old_state.state = "unavailable"
+    new_state = MagicMock()
+    new_state.state = "0.05"
+    event = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state}
+
+    coordinator._handle_feed_in_price_change(event)
+    await hass.async_block_till_done()
+
+    assert refresh_called
+
+
 def test_schedule_mid_period_run_future(hass, monkeypatch):
     """Mid-period timer is registered when mid-point is in the future."""
     coordinator = _make_coordinator(hass)
@@ -599,6 +816,7 @@ async def test_async_shutdown_unsubscribes_all(hass):
     unsub_calls = {}
     for attr in (
         "_unsub_price",
+        "_unsub_feed_in_price",
         "_unsub_soc",
         "_unsub_forecast",
         "_unsub_mid_period_timer",


### PR DESCRIPTION
## Description

A user reported that `binary_sensor.pv_curtailment_suggested` doesn't track the feed-in price (which changes every 15 minutes) and also switches on/off mid-period, unrelated to any price change. Investigation found two independent bugs in `PVCurtailmentSensor` (`binary_sensor.py`) and its data source (`coordinator_optimization.py`):

1. **Stale feed-in price**: `OptimizationCoordinator` only tracked state changes on the buy price sensor (`CONF_PRICE_SENSOR`) to trigger re-optimization. When the feed-in price comes from a separate sensor (`CONF_FEED_IN_PRICE_SENSOR`), its period boundaries were never listened for — `current_feed_in_price` (and therefore the curtailment sensor) only refreshed when the buy price sensor happened to change, the mid-period correction timer fired, or the 60-minute base `update_interval` elapsed. This could lag the real feed-in price by up to an hour.
2. **Mid-period flapping**: Condition B of the sensor (battery/inverter unable to absorb the charge setpoint) compares live battery power against a single threshold (`ABSORPTION_THRESHOLD = 0.70`). This is re-evaluated every real-time zero_grid tick (`zero_grid_response_time_s`, default 10s) using the live, noisy `battery_state.power_kw` — so a reading hovering near the threshold flapped the sensor on/off independent of any price event.

## Changes

- `coordinator_optimization.py`: track the feed-in price sensor's own state changes (when it differs from the buy price sensor) and trigger re-optimization on its period boundary, mirroring the existing buy-price handler.
- `binary_sensor.py`: add an entry/recovery hysteresis band to condition B (enter at 70% of setpoint, recover at 85%) so real-time sensor noise no longer flaps the suggestion — same pattern already used for the hybrid zero_grid/charging hysteresis elsewhere in the coordinator.
- Added coverage for both fixes in `tests/test_coordinator_optimization.py` and `tests/test_binary_sensor.py`.

## Type of change

- [x] `fix:` Bug fix (patch version bump)

## Checklist

- [x] Commit title follows Conventional Commits
- [x] Tests added or updated where applicable
- [ ] Documentation updated if needed — no algorithm/DP behavior changed, so `ALGORITHM.md`/`analyzer.js`/`simulate_diagnostics.py` sync not required
- [ ] CI is green — pending, `pytest-homeassistant-custom-component` failed to build locally in this environment (unrelated `PyRIC` sdist/setuptools issue); ruff/ruff-format pass locally, please confirm via CI
- [x] PR targets the `dev` branch