### PR TITLE
fix: make PV Curtailment Suggested purely price-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ The **Battery power sensor** you configure as input (`battery_power_sensor`) is 
 
 | Entity | Description |
 |--------|-------------|
-| PV Curtailment Suggested | ON when feed-in price is negative and the battery can no longer absorb excess PV production (SoC at maximum, or actual charge power significantly below setpoint) |
+| PV Curtailment Suggested | ON when the feed-in price is negative — purely price-based: exporting costs money, so curtailing PV is worth considering |
 | Use Maximum Power Suggested | ON when the grid buy price is negative — signals that consuming as much as possible (battery charge, flexible loads) is beneficial |
 
 ### Switch

--- a/custom_components/battery_controller/binary_sensor.py
+++ b/custom_components/battery_controller/binary_sensor.py
@@ -15,22 +15,11 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ABSORPTION_THRESHOLD
 from .coordinator import OptimizationCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-
-# Minimum charging setpoint (W) below which the absorption check is skipped (noise floor).
-_MIN_SETPOINT_W = 200.0
-
-# Hysteresis exit threshold for condition B (fraction of setpoint). Entry uses
-# ABSORPTION_THRESHOLD (0.70); recovery requires climbing back to this higher
-# fraction so real-time sensor noise near the entry threshold — the actual
-# power is republished every zero_grid_response_time_s (default 10s) — doesn't
-# flap the sensor on/off between DP re-optimizations.
-_ABSORPTION_RECOVER_THRESHOLD = 0.85
 
 
 async def async_setup_entry(
@@ -75,15 +64,13 @@ class BatteryControllerBinarySensor(
 
 
 class PVCurtailmentSensor(BatteryControllerBinarySensor):
-    """Suggests curtailing PV when the feed-in price is negative and the battery
-    can no longer absorb the excess production.
+    """Suggests curtailing PV production while the feed-in price is negative.
 
-    ON when:
-      1. Current feed-in price < 0 (exporting costs money), AND
-      2. The battery is unable to absorb more:
-         - SoC is at or near its configured maximum, OR
-         - Actual charging power is significantly below the charge setpoint
-           (inverter / battery has reached its limit).
+    Purely price-based: ON when the current feed-in price < 0 (exporting costs
+    money), OFF otherwise. Battery state is deliberately not consulted — the
+    sensor signals the price condition; whether curtailment is executed (and
+    how the battery is used during it) is left to the user's automation and
+    the controller's own PV-curtailed handling.
     """
 
     _attr_translation_key = "pv_curtailment"
@@ -97,7 +84,6 @@ class PVCurtailmentSensor(BatteryControllerBinarySensor):
         entry: ConfigEntry,
     ) -> None:
         super().__init__(coordinator, device, entry, "pv_curtailment")
-        self._condition_b_active = False
 
     @property
     def is_on(self) -> bool | None:
@@ -105,41 +91,7 @@ class PVCurtailmentSensor(BatteryControllerBinarySensor):
             return None
 
         feed_in_price = self.coordinator.data.get("current_feed_in_price", 0.0)
-        if feed_in_price >= 0:
-            return False
-
-        battery_state = self.coordinator.data.get("battery_state")
-        control_action = self.coordinator.data.get("control_action", {})
-
-        if battery_state is None:
-            # Price is negative but no battery state info — suggest curtailment.
-            return True
-
-        # Condition A: battery SoC is at (or very near) configured maximum.
-        battery_config = self.coordinator.battery_config
-        if battery_state.soc_kwh >= battery_config.max_soc_kwh * 0.98:
-            return True
-
-        # Condition B: battery is being asked to charge but actual power is
-        # significantly less than the setpoint → battery/inverter is limiting.
-        # Hysteresis (entry at ABSORPTION_THRESHOLD, recovery at the higher
-        # _ABSORPTION_RECOVER_THRESHOLD) avoids flapping on/off between DP
-        # re-optimizations: actual_w is republished every
-        # zero_grid_response_time_s from a live sensor and can hover around a
-        # single threshold on its own.
-        # control_action["target_power_w"]: positive = charge (controller convention)
-        setpoint_w = control_action.get("target_power_w", 0.0)
-        actual_w = battery_state.power_kw * 1000  # positive = charging
-
-        if setpoint_w <= _MIN_SETPOINT_W:
-            self._condition_b_active = False
-        elif actual_w < setpoint_w * ABSORPTION_THRESHOLD:
-            self._condition_b_active = True
-        elif actual_w >= setpoint_w * _ABSORPTION_RECOVER_THRESHOLD:
-            self._condition_b_active = False
-        # else: within the hysteresis band — keep the previous state.
-
-        return self._condition_b_active
+        return bool(feed_in_price < 0)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -195,10 +195,6 @@ SOC_UNCERTAINTY_RESERVE_FRACTION = (
     0.10  # max fraction of capacity reserved for solar forecast uncertainty
 )
 
-# Absorption detection: actual battery power must be at least this fraction of the
-# charge setpoint before the battery is considered unable to absorb more charge.
-ABSORPTION_THRESHOLD = 0.70  # fraction of setpoint
-
 # Real-time control thresholds
 BATTERY_MODE_THRESHOLD_W = 50.0  # W — battery power above/below this sets mode
 SETPOINT_STABLE_THRESHOLD_KW = 0.010  # kW (10 W) — setpoint "stable" if within this

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -80,7 +80,22 @@ class TestPVCurtailmentSensor:
         )
         assert sensor.is_on is True
 
-    def test_is_on_true_when_soc_at_max(self):
+    def test_is_on_true_when_price_negative_regardless_of_battery_state(self):
+        """Purely price-based: negative price = ON, even while the battery is
+        absorbing the full setpoint or has plenty of SoC headroom."""
+        battery_state = MagicMock()
+        battery_state.soc_kwh = 5.0  # well below max
+        battery_state.power_kw = 1.0  # absorbing the full 1000W setpoint
+        sensor = self._make_sensor(
+            data={
+                "current_feed_in_price": -0.05,
+                "battery_state": battery_state,
+                "control_action": {"target_power_w": 1000.0},
+            }
+        )
+        assert sensor.is_on is True
+
+    def test_is_on_true_when_soc_at_max_and_price_negative(self):
         battery_state = MagicMock()
         battery_state.soc_kwh = 9.85  # 98.5% of 10.0 kWh
         battery_state.power_kw = -0.5
@@ -93,84 +108,11 @@ class TestPVCurtailmentSensor:
         )
         assert sensor.is_on is True
 
-    def test_is_on_true_when_setpoint_high_and_actual_low(self):
-        """Condition B: setpoint >200W and actual < 70% of setpoint."""
-        battery_state = MagicMock()
-        battery_state.soc_kwh = 5.0  # well below max
-        battery_state.power_kw = 0.1  # 100W actual
-        sensor = self._make_sensor(
-            data={
-                "current_feed_in_price": -0.05,
-                "battery_state": battery_state,
-                "control_action": {"target_power_w": 1000.0},  # setpoint 1000W
-            }
-        )
-        # actual 100W < 0.70 * 1000W = 700W → True
-        assert sensor.is_on is True
-
-    def test_is_on_false_when_setpoint_below_threshold(self):
-        """Setpoint <= 200W: condition B does not trigger."""
+    def test_follows_price_sign_flips(self):
+        """The sensor tracks the price sign directly, with no latched state."""
         battery_state = MagicMock()
         battery_state.soc_kwh = 5.0
-        battery_state.power_kw = 0.0
-        sensor = self._make_sensor(
-            data={
-                "current_feed_in_price": -0.05,
-                "battery_state": battery_state,
-                "control_action": {"target_power_w": 150.0},  # below _MIN_SETPOINT_W
-            }
-        )
-        assert sensor.is_on is False
-
-    def test_is_on_false_when_actual_power_sufficient(self):
-        """Battery absorbing enough power (>=70% of setpoint)."""
-        battery_state = MagicMock()
-        battery_state.soc_kwh = 5.0
-        battery_state.power_kw = 0.8  # 800W actual
-        sensor = self._make_sensor(
-            data={
-                "current_feed_in_price": -0.05,
-                "battery_state": battery_state,
-                "control_action": {"target_power_w": 1000.0},
-            }
-        )
-        # 800W >= 0.70 * 1000W = 700W → should not trigger condition B
-        assert sensor.is_on is False
-
-    def test_condition_b_hysteresis_holds_on_through_noise_band(self):
-        """Once triggered, condition B must stay on while actual power hovers
-        between ABSORPTION_THRESHOLD and _ABSORPTION_RECOVER_THRESHOLD instead
-        of flapping with every real-time (~5-10s) sensor update."""
-        battery_state = MagicMock()
-        battery_state.soc_kwh = 5.0
-        battery_state.power_kw = 0.1  # 100W: well below 70% of 1000W setpoint
-        sensor = self._make_sensor(
-            data={
-                "current_feed_in_price": -0.05,
-                "battery_state": battery_state,
-                "control_action": {"target_power_w": 1000.0},
-            }
-        )
-        assert sensor.is_on is True  # entry: 100W < 700W
-
-        # Noisy reading recovers to 750W — within the hysteresis band
-        # (700W-850W) — must NOT clear the suggestion yet.
         battery_state.power_kw = 0.75
-        assert sensor.is_on is True
-
-        # Recovers above the exit threshold (850W) — now it clears.
-        battery_state.power_kw = 0.9
-        assert sensor.is_on is False
-
-        # Dips back into the band — stays off (no re-trigger inside the band).
-        battery_state.power_kw = 0.75
-        assert sensor.is_on is False
-
-    def test_condition_b_hysteresis_resets_when_setpoint_drops(self):
-        """A setpoint falling below the noise floor clears a latched condition B."""
-        battery_state = MagicMock()
-        battery_state.soc_kwh = 5.0
-        battery_state.power_kw = 0.1
         sensor = self._make_sensor(
             data={
                 "current_feed_in_price": -0.05,
@@ -180,8 +122,11 @@ class TestPVCurtailmentSensor:
         )
         assert sensor.is_on is True
 
-        sensor.coordinator.data["control_action"] = {"target_power_w": 100.0}
+        sensor.coordinator.data["current_feed_in_price"] = 0.10
         assert sensor.is_on is False
+
+        sensor.coordinator.data["current_feed_in_price"] = -0.02
+        assert sensor.is_on is True
 
     def test_extra_state_attributes_empty_when_no_data(self):
         sensor = self._make_sensor(data=None)
@@ -305,9 +250,8 @@ class TestPVCurtailmentMissingControlAction:
         return PVCurtailmentSensor(coord, device, entry)
 
     def test_missing_target_power_w_does_not_raise(self):
-        """control_action dict with no target_power_w key falls back to 0.0."""
-        # Condition B requires setpoint > _MIN_SETPOINT_W (200W);
-        # default 0.0 means it never triggers — sensor should return False.
+        """control_action dict with no target_power_w key must not break is_on."""
+        # Purely price-based: negative price → ON regardless of control_action.
         sensor = self._make_sensor(
             data={
                 "current_feed_in_price": -0.05,
@@ -316,10 +260,10 @@ class TestPVCurtailmentMissingControlAction:
             }
         )
         sensor.coordinator.battery_config.max_soc_kwh = 10.0
-        assert sensor.is_on is False
+        assert sensor.is_on is True
 
     def test_none_control_action_does_not_raise(self):
-        """control_action absent from data dict entirely falls back to empty dict."""
+        """control_action absent from data dict entirely must not break is_on."""
         sensor = self._make_sensor(
             data={
                 "current_feed_in_price": -0.05,
@@ -328,7 +272,7 @@ class TestPVCurtailmentMissingControlAction:
             }
         )
         sensor.coordinator.battery_config.max_soc_kwh = 10.0
-        assert sensor.is_on is False
+        assert sensor.is_on is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

> [!NOTE]
> This PR was repurposed. It originally fixed a stale hysteresis latch in the condition-B absorption check; per the owner's clarification the sensor was always meant to be **purely price-based**, which removes that code path (and the bug) entirely.

The PV Curtailment Suggested sensor coupled its state to live battery behaviour: with a negative feed-in price it only switched ON when the battery was near its maximum SoC or was absorbing significantly less than the charge setpoint. That second-guessed the sensor's intent — signal the price condition — and required hysteresis (added in 61aac44) to keep the battery-power comparison from flapping between DP re-optimizations, which in turn carried a stale-latch bug across price-sign flips.

Changes:

- `is_on` is now simply `current_feed_in_price < 0`.
- The SoC-near-max and absorption (condition A/B) checks, the condition-B hysteresis latch, and the now-unused `ABSORPTION_THRESHOLD` constant are removed.
- The sensor's diagnostic attributes (`current_feed_in_price`, `battery_soc_percent`, `battery_power_kw`, `charge_setpoint_w`) are unchanged, so existing automations reading attributes keep working.
- README entity description updated; tests rewritten to assert the price-based behaviour (including sign flips with no latched state).

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed (README entity table)
- [x] CI is green (locally: full suite passes, pre-commit incl. ruff/mypy clean)
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Behaviour change to be aware of: with a negative feed-in price the sensor is now ON even while the battery still has headroom and is absorbing the surplus. Automations that used the sensor as "battery can't take it anymore" should switch to the diagnostic attributes or their own condition.