### PR TITLE
fix: don't reset commitment and setpoint when re-selecting the active control mode

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -310,6 +310,12 @@ class OptimizationCoordinator(DataUpdateCoordinator):
     @control_mode.setter
     def control_mode(self, mode: str) -> None:
         """Set control mode and reset commitment state to prevent stale locks."""
+        if mode == self._control_mode:
+            # Re-selecting the active mode (e.g. an automation periodically
+            # calling select.select_option) must not reset the commitment
+            # filter or force the real-time loop through an idle setpoint —
+            # nothing changed, so there is no stale state to clear.
+            return
         self._control_mode = mode
         self._committed_action = ACTION_IDLE
         self._committed_price = 0.0

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -247,6 +247,27 @@ async def test_mode_switch_resets_commitment(hass):
     # Mode switch must mark the next optimization run as triggered by a mode change.
     assert coordinator._optimization_trigger_source == "mode_change"
 
+    # Re-selecting the already-active mode is a no-op: it must NOT reset the
+    # commitment filter or force the real-time loop through an idle setpoint
+    # (e.g. an automation periodically calling select.select_option).
+    coordinator._committed_action = "charging"
+    coordinator._committed_power = 1.2
+    coordinator._committed_price = 0.25
+    coordinator._committed_step_start = fixed_now
+    coordinator._effective_mode = "charging"
+    coordinator._controller_schedule_w = 1200.0
+    coordinator._optimization_trigger_source = "price_boundary"
+
+    coordinator.control_mode = MODE_HYBRID  # same as current mode
+
+    assert coordinator._committed_action == "charging"
+    assert coordinator._committed_power == 1.2
+    assert coordinator._committed_price == 0.25
+    assert coordinator._committed_step_start == fixed_now
+    assert coordinator._effective_mode == "charging"
+    assert coordinator._controller_schedule_w == 1200.0
+    assert coordinator._optimization_trigger_source == "price_boundary"
+
 
 def _make_coordinator(hass):
     """Build a minimal OptimizationCoordinator for scheduling tests."""


### PR DESCRIPTION
## Description

Found during a post-release review of everything on `dev` since v2.5.3.

The `control_mode` setter resets the commitment filter, and since #88 (b744edd) it additionally forces the cached setpoint to `idle` so the real-time loop stops applying the previous mode's schedule while the mode-change re-optimization is running. That reset is correct for an actual mode *change*, but it also fired when the selected mode was already active.

HA's select entity invokes `async_select_option` on every `select.select_option` service call, regardless of the current state. An automation, dashboard script, or voice assistant that periodically re-asserts the current mode would therefore:

- wipe the commitment filter (`_committed_action`/`_committed_power`/…), defeating the anti-oscillation power lock within the price period, and
- drop the battery to an idle setpoint (`_effective_mode = idle`, `_controller_schedule_w = 0`) until the next optimization run completes — a visible dip in charge/discharge for what should be a no-op.

This PR guards the setter: when the requested mode equals the current mode, nothing is stale, so nothing is reset. The existing `test_mode_switch_resets_commitment` is extended with a same-mode re-select case asserting that commitment state, cached setpoint, and the trigger-source label all survive; the extended test fails on the unfixed code.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed (no docs impact)
- [x] CI is green (locally: full suite passes, pre-commit incl. ruff/mypy clean)
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Without the fix, the extended test fails:

```
FAILED tests/test_coordinator_optimization.py::test_mode_switch_resets_commitment
```