### PR TITLE
fix: stale grid sensor handling in zero_grid real-time loop

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -654,26 +654,25 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             return
 
         # Stale sensor detection (P4.1): if the first grid sensor has not updated
-        # recently, treat its reading as unreliable and skip the zero_grid correction.
+        # recently its reading may be unreliable. We do NOT unconditionally skip,
+        # because a steady grid produced by the battery's own action keeps an
+        # on-change power sensor from emitting updates. Misclassifying a
+        # genuinely-steady reading as "stale" and skipping would freeze the
+        # controller in an over-committed setpoint (e.g. the battery left
+        # discharging after a Quooker/kettle spike), which only the next full
+        # optimizer run would clear. Instead the flag is handled per-mode below.
         stale_limit_s = STALE_SENSOR_MULTIPLIER * float(
             self.config.get(
                 CONF_ZERO_GRID_RESPONSE_TIME_S, DEFAULT_ZERO_GRID_RESPONSE_TIME_S
             )
         )
+        grid_sensor_stale = False
         if self._power_consumption_sensors:
             first_sensor = self._power_consumption_sensors[0]
             state = self.hass.states.get(first_sensor)
             if state is not None and state.last_updated is not None:
                 age_s = (dt_util.utcnow() - state.last_updated).total_seconds()
-                if age_s > stale_limit_s:
-                    _LOGGER.debug(
-                        "Grid power sensor '%s' is stale (%.0f s old, limit %.0f s); "
-                        "skipping zero_grid correction",
-                        first_sensor,
-                        age_s,
-                        stale_limit_s,
-                    )
-                    return
+                grid_sensor_stale = age_s > stale_limit_s
 
         # Read current battery state
         battery_state = self.get_current_battery_state()
@@ -707,7 +706,20 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             rt_effective_mode, current_grid_w
         )
 
+        # A stale grid reading is only relevant to grid-driven control. For
+        # follow_schedule / manual / idle the setpoint comes from the DP schedule
+        # or the user, not the live grid, so holding the last setpoint (as before)
+        # is correct and safe.
+        if grid_sensor_stale and controller_mode != "zero_grid":
+            _LOGGER.debug(
+                "Grid power sensor stale (>%.0f s); holding %s setpoint",
+                stale_limit_s,
+                controller_mode,
+            )
+            return
+
         # Recalculate zero_grid setpoint with actual sensor data
+        saved_last_target_w = self.zero_grid_controller.last_target_w
         control_action = self.zero_grid_controller.get_control_action(
             current_grid_w=current_grid_w,
             current_soc_kwh=battery_state.soc_kwh,
@@ -715,6 +727,31 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             dp_schedule_w=controller_schedule_w,
             mode=controller_mode,
         )
+
+        # Stale sensor in zero_grid: the live grid drives the setpoint. Acting on
+        # a steady reading is exactly what breaks a self-locking over-commitment
+        # (reducing battery power changes the grid and wakes an on-change sensor).
+        # But a genuinely dead sensor stays frozen, so only allow the setpoint to
+        # move TOWARD zero — never let a stale reading push the battery into a
+        # larger charge/discharge or flip its direction (no runaway).
+        if grid_sensor_stale:
+            prev_w = (
+                self.data.get("control_action", {}).get("target_power_w", 0.0)
+                if self.data
+                else 0.0
+            )
+            new_w = control_action["target_power_w"]
+            moves_away_from_zero = abs(new_w) > abs(prev_w) or (new_w * prev_w < 0)
+            if moves_away_from_zero:
+                # Untrustworthy while stale — restore integrator state and hold.
+                self.zero_grid_controller.reset_setpoint(saved_last_target_w)
+                _LOGGER.debug(
+                    "Grid power sensor stale; holding zero_grid setpoint "
+                    "(rejected %.0f W -> %.0f W, away from zero)",
+                    prev_w,
+                    new_w,
+                )
+                return
 
         prev_target = (
             self.data.get("control_action", {}).get("target_power_kw")

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -815,7 +815,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 "per_battery_states": dict(self._per_battery_states),
                 "battery_setpoints": battery_setpoints,
                 "optimal_power_kw": control_action["target_power_kw"],
-                "optimal_mode": control_action["action_mode"],
+                # Report the effective control mode (e.g. "zero_grid"), matching
+                # what the full optimizer run publishes. Using the instantaneous
+                # physical action here would flip the "Optimal Mode" sensor to
+                # "discharging"/"charging" between optimizer runs whenever the
+                # zero-grid loop moves the battery — even though the control mode
+                # is still zero_grid. The physical action is already visible via
+                # the Battery Power / Setpoint sensors.
+                "optimal_mode": rt_effective_mode,
             }
         )
 

--- a/custom_components/battery_controller/zero_grid_controller.py
+++ b/custom_components/battery_controller/zero_grid_controller.py
@@ -50,6 +50,21 @@ class ZeroGridController:
         self._last_target_w = 0.0
         self._setpoint_w = 0.0  # Target grid power (0 = zero-grid)
 
+    @property
+    def last_target_w(self) -> float:
+        """Return the internal setpoint memory in W (positive = charge)."""
+        return self._last_target_w
+
+    def reset_setpoint(self, value_w: float = 0.0) -> None:
+        """Force the internal setpoint memory to a specific value.
+
+        Used on mode changes and by the coordinator's stale-sensor fail-safe to
+        keep the integrator state consistent when a computed setpoint is
+        rejected.
+        """
+        self._last_target_w = value_w
+        self._setpoint_w = value_w
+
     def calculate_battery_setpoint(
         self,
         current_grid_w: float,

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -1925,6 +1925,101 @@ async def test_handle_realtime_update_stale_sensor_returns_early(hass, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_stale_zero_grid_unwinds_toward_zero(hass, monkeypatch):
+    """A stale (steady) grid sensor in zero_grid must still unwind an
+    over-committed discharge toward zero.
+
+    Reproduces the post-spike self-lock: after a Quooker/kettle spike the
+    integrator is left discharging ~1.5 kW, which holds the grid at a steady
+    export so an on-change power sensor stops updating and reads as "stale".
+    The correction must not be skipped — reducing battery power changes the
+    grid and wakes the sensor.
+    """
+    coord = _make_coordinator(hass)
+    coord._control_mode = MODE_ZERO_GRID
+    coord._power_consumption_sensors = ["sensor.grid_w"]
+    coord._last_result = MagicMock()
+    # Battery left over-discharging 1500 W after a spike.
+    coord.zero_grid_controller.reset_setpoint(-1500.0)
+    coord.data = {
+        "control_action": {"target_power_kw": -1.5, "target_power_w": -1500.0},
+        "battery_state": BatteryState(
+            soc_kwh=5.0, soc_percent=50.0, power_kw=-1.5, mode="discharging"
+        ),
+        "per_battery_states": {},
+    }
+
+    hass.states.async_set("sensor.grid_w", "-1300", {"unit_of_measurement": "W"})
+    state_time = hass.states.get("sensor.grid_w").last_updated
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
+        lambda: state_time + timedelta(seconds=30),
+    )
+    monkeypatch.setattr(coord, "_get_realtime_grid_w", lambda: -1300.0)
+    monkeypatch.setattr(
+        coord,
+        "get_current_battery_state",
+        lambda: BatteryState(
+            soc_kwh=5.0, soc_percent=50.0, power_kw=-1.5, mode="discharging"
+        ),
+    )
+    monkeypatch.setattr(coord, "_split_setpoint", lambda kw, _mode="": {})
+    updated = []
+    monkeypatch.setattr(coord, "async_set_updated_data", lambda d: updated.append(d))
+
+    await coord._handle_realtime_update(datetime.now(timezone.utc))
+
+    assert updated, "stale steady grid must still correct an over-commitment"
+    new_w = updated[-1]["control_action"]["target_power_w"]
+    # Moved toward zero (covers only base load now), not held at -1500 W.
+    assert -1500.0 < new_w <= 0.0
+    assert abs(new_w) < 1500.0
+
+
+@pytest.mark.asyncio
+async def test_stale_zero_grid_rejects_runaway(hass, monkeypatch):
+    """A stale (possibly dead/frozen) grid sensor must never drive the battery
+    into a larger discharge — the original P4.1 runaway protection is kept."""
+    coord = _make_coordinator(hass)
+    coord._control_mode = MODE_ZERO_GRID
+    coord._power_consumption_sensors = ["sensor.grid_w"]
+    coord._last_result = MagicMock()
+    coord.zero_grid_controller.reset_setpoint(-200.0)
+    coord.data = {
+        "control_action": {"target_power_kw": -0.2, "target_power_w": -200.0},
+        "battery_state": BatteryState(
+            soc_kwh=5.0, soc_percent=50.0, power_kw=-0.2, mode="discharging"
+        ),
+        "per_battery_states": {},
+    }
+
+    # Sensor frozen at a large import value.
+    hass.states.async_set("sensor.grid_w", "2000", {"unit_of_measurement": "W"})
+    state_time = hass.states.get("sensor.grid_w").last_updated
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
+        lambda: state_time + timedelta(seconds=30),
+    )
+    monkeypatch.setattr(coord, "_get_realtime_grid_w", lambda: 2000.0)
+    monkeypatch.setattr(
+        coord,
+        "get_current_battery_state",
+        lambda: BatteryState(
+            soc_kwh=5.0, soc_percent=50.0, power_kw=-0.2, mode="discharging"
+        ),
+    )
+    monkeypatch.setattr(coord, "_split_setpoint", lambda kw, _mode="": {})
+    updated = []
+    monkeypatch.setattr(coord, "async_set_updated_data", lambda d: updated.append(d))
+
+    await coord._handle_realtime_update(datetime.now(timezone.utc))
+
+    assert not updated, "stale frozen sensor must not drive a larger discharge"
+    # Integrator memory restored — not wound up further.
+    assert coord.zero_grid_controller.last_target_w == pytest.approx(-200.0)
+
+
+@pytest.mark.asyncio
 async def test_handle_realtime_update_mode_zero_grid(hass, monkeypatch):
     """_handle_realtime_update uses zero_grid schedule when control mode is zero_grid (481-482)."""
     coord = _make_coordinator(hass)

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -1974,6 +1974,48 @@ async def test_stale_zero_grid_unwinds_toward_zero(hass, monkeypatch):
     # Moved toward zero (covers only base load now), not held at -1500 W.
     assert -1500.0 < new_w <= 0.0
     assert abs(new_w) < 1500.0
+    # The control mode is still zero_grid — not the instantaneous action.
+    assert updated[-1]["optimal_mode"] == "zero_grid"
+
+
+@pytest.mark.asyncio
+async def test_realtime_zero_grid_reports_zero_grid_mode(hass, monkeypatch):
+    """In zero_grid the real-time loop must report optimal_mode='zero_grid',
+    not the instantaneous physical action, so the Optimal Mode sensor does not
+    flip to 'discharging'/'charging' between optimizer runs.
+    """
+    coord = _make_coordinator(hass)
+    coord._control_mode = MODE_ZERO_GRID
+    coord._power_consumption_sensors = ["sensor.grid_w"]
+    coord._last_result = MagicMock()
+    coord.zero_grid_controller.reset_setpoint(0.0)
+    coord.data = {
+        "control_action": {"target_power_kw": 0.0, "target_power_w": 0.0},
+        "battery_state": BatteryState(
+            soc_kwh=5.0, soc_percent=50.0, power_kw=0.0, mode="idle"
+        ),
+        "per_battery_states": {},
+    }
+
+    # Fresh sensor reading (not stale): importing 500 W → controller discharges.
+    hass.states.async_set("sensor.grid_w", "500", {"unit_of_measurement": "W"})
+    monkeypatch.setattr(coord, "_get_realtime_grid_w", lambda: 500.0)
+    monkeypatch.setattr(
+        coord,
+        "get_current_battery_state",
+        lambda: BatteryState(soc_kwh=5.0, soc_percent=50.0, power_kw=0.0, mode="idle"),
+    )
+    monkeypatch.setattr(coord, "_split_setpoint", lambda kw, _mode="": {})
+    updated = []
+    monkeypatch.setattr(coord, "async_set_updated_data", lambda d: updated.append(d))
+
+    await coord._handle_realtime_update(datetime.now(timezone.utc))
+
+    assert updated, "a setpoint change must publish an update"
+    # Physical action is discharging (covers the load) ...
+    assert updated[-1]["control_action"]["action_mode"] == "discharging"
+    # ... but the reported control mode stays zero_grid.
+    assert updated[-1]["optimal_mode"] == "zero_grid"
 
 
 @pytest.mark.asyncio

--- a/tests/test_zero_grid_controller.py
+++ b/tests/test_zero_grid_controller.py
@@ -315,6 +315,31 @@ class TestCreateZeroGridController:
         assert controller.config.deadband_w == 50.0
 
 
+class TestSetpointMemory:
+    """Tests for the internal setpoint memory accessor and reset."""
+
+    def test_last_target_w_reflects_last_action(self, controller):
+        controller.get_control_action(
+            current_grid_w=1000,
+            current_soc_kwh=5.0,
+            current_battery_w=0,
+            dp_schedule_w=0,
+            mode="zero_grid",
+        )
+        # Importing 1 kW -> discharge ~1 kW; memory tracks the applied target.
+        assert controller.last_target_w == pytest.approx(-1000, abs=10)
+
+    def test_reset_setpoint_forces_memory(self, controller):
+        controller._last_target_w = -1500.0
+        controller.reset_setpoint(-200.0)
+        assert controller.last_target_w == pytest.approx(-200.0)
+
+    def test_reset_setpoint_defaults_to_zero(self, controller):
+        controller._last_target_w = 1234.0
+        controller.reset_setpoint()
+        assert controller.last_target_w == 0.0
+
+
 class TestZeroDeadband:
     """T7: deadband_w=0 must not cause division or crash."""
 


### PR DESCRIPTION
## Description

Fixes a critical self-locking issue in the zero_grid real-time control loop when the grid power sensor becomes stale (stops updating). Previously, any stale sensor would cause the entire real-time update to be skipped, which could freeze the battery in an over-committed discharge state (e.g., after a Quooker/kettle spike). This required waiting for the next full optimizer run to recover.

The fix implements a nuanced stale-sensor strategy:
- **For non-zero_grid modes** (follow_schedule, manual, idle): Skip the update as before, since the setpoint comes from the DP schedule or user input, not the live grid.
- **For zero_grid mode**: Allow the real-time loop to continue, but add a runaway protection: only accept setpoint changes that move **toward zero**. This allows the controller to unwind over-commitments (which naturally changes the grid and wakes on-change sensors) while rejecting moves that would increase discharge/charge or flip direction (protecting against genuinely dead/frozen sensors).

Additionally, the `optimal_mode` field in real-time updates now correctly reports the effective control mode (e.g., "zero_grid") rather than the instantaneous physical action, preventing the "Optimal Mode" sensor from flickering between "discharging"/"charging" and "zero_grid" between optimizer runs.

## Changes

### `coordinator_optimization.py`
- Refactored stale sensor detection to set a flag rather than early-return
- Added per-mode stale handling: skip for non-zero_grid, apply runaway protection for zero_grid
- Implemented "toward zero" validation: reject setpoint changes that increase magnitude or flip sign when sensor is stale
- Changed `optimal_mode` to report `rt_effective_mode` (the control mode) instead of `action_mode` (the physical action)
- Added detailed logging for stale sensor decisions

### `zero_grid_controller.py`
- Added `last_target_w` property to expose internal setpoint memory
- Added `reset_setpoint(value_w)` method to force integrator state consistency when a computed setpoint is rejected

### Tests
- Added `test_stale_zero_grid_unwinds_toward_zero`: verifies the controller can reduce an over-committed discharge when the sensor is stale
- Added `test_realtime_zero_grid_reports_zero_grid_mode`: verifies `optimal_mode` stays "zero_grid" even when the physical action is "discharging"/"charging"
- Added `test_stale_zero_grid_rejects_runaway`: verifies a frozen sensor cannot drive the battery into a larger discharge
- Added unit tests for `last_target_w` property and `reset_setpoint()` method

## Type of change

- [x] `fix:` Bug fix (patch version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added (3 integration tests + 3 unit tests)
- [x] CI is green (all tests pass)
- [x] PR targets the `dev` branch

## Test Coverage

The fix is covered by three new integration tests in `test_coordinator_optimization.py`:
1. `test_stale_zero_grid_unwinds_toward_zero` — validates the core fix (unwinding over-commitments)
2. `test_realtime_zero_grid_reports_zero_grid_mode` — validates the `optimal_mode` fix
3. `test_stale_zero_grid_rejects_runaway` — validates runaway protection

Plus three unit tests in `test_zero_grid_controller.py` for the new `last_target_w` and `reset_setpoint()` API.