### PR TITLE
fix: weather coordinator stopped polling after startup + zero-grid non-happy-flow hardening

### DIFF
--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -99,7 +99,6 @@ CONF_MANUAL_POWER_SETPOINT_W = "manual_power_setpoint_w"
 CONF_ZERO_GRID_ENABLED = "zero_grid_enabled"
 CONF_ZERO_GRID_DEADBAND_W = "zero_grid_deadband_w"
 CONF_ZERO_GRID_RESPONSE_TIME_S = "zero_grid_response_time_s"
-CONF_ZERO_GRID_PRIORITY = "zero_grid_priority"
 
 # Configuration keys - Control mode (persisted)
 CONF_CONTROL_MODE = "control_mode"
@@ -147,7 +146,6 @@ DEFAULT_MANUAL_POWER_SETPOINT_W = 0.0
 DEFAULT_ZERO_GRID_ENABLED = True
 DEFAULT_ZERO_GRID_DEADBAND_W = 50.0
 DEFAULT_ZERO_GRID_RESPONSE_TIME_S = 10.0
-DEFAULT_ZERO_GRID_PRIORITY = "schedule"
 
 # Default values - Fixed prices
 DEFAULT_FIXED_FEED_IN_PRICE = 0.04  # EUR/kWh (post-salderingsregeling NL, 2025+)

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -191,6 +191,7 @@ PRICE_CHANGE_REOPTIMIZE_ABS_EUR = (
 STALE_SENSOR_MULTIPLIER = (
     2.0  # x response_time_s — age limit before sensor is treated as stale
 )
+WEATHER_STALE_AFTER_MINUTES = 120.0  # minutes — weather data older than this is treated as stale (4 missed updates)
 SOC_UNCERTAINTY_RESERVE_FRACTION = (
     0.10  # max fraction of capacity reserved for solar forecast uncertainty
 )

--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -17,6 +17,7 @@ from .const import (
     CONF_ELECTRICITY_PRODUCTION_SENSORS,
     CONF_PV_PRODUCTION_SENSORS,
     DOMAIN,
+    WEATHER_STALE_AFTER_MINUTES,
 )
 from .coordinator_weather import WeatherDataCoordinator
 from .forecast_models import (
@@ -107,11 +108,27 @@ class ForecastCoordinator(DataUpdateCoordinator):
 
         # Unsubscribe handle for the daily pattern-refresh timer
         self._unsub_pattern_refresh: Any | None = None
+        # Unsubscribe handle for the weather-coordinator listener
+        self._unsub_weather: Any | None = None
 
     async def async_setup(self) -> None:
         """Set up the forecast coordinator."""
         # Update consumption pattern from history on startup
         await self.consumption_model.async_update_pattern()
+
+        # Subscribe to the weather coordinator. A DataUpdateCoordinator only
+        # keeps polling while it has listeners, and no entity subscribes to the
+        # weather coordinator directly — without this listener it would fetch
+        # exactly once at startup and then serve the same (aging) snapshot
+        # forever. The listener also recomputes the forecasts as soon as fresh
+        # weather data arrives instead of waiting for the next 15-min cycle.
+        @callback
+        def _on_weather_update() -> None:
+            self.hass.async_create_task(self.async_request_refresh())
+
+        self._unsub_weather = self.weather_coordinator.async_add_listener(
+            _on_weather_update
+        )
 
         # Re-learn the consumption pattern every 24 h so that seasonal changes
         # and new appliances are picked up automatically without an integration
@@ -132,6 +149,10 @@ class ForecastCoordinator(DataUpdateCoordinator):
         if self._unsub_pattern_refresh:
             self._unsub_pattern_refresh()
             self._unsub_pattern_refresh = None
+        if self._unsub_weather:
+            self._unsub_weather()
+            self._unsub_weather = None
+        await super().async_shutdown()
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Calculate PV and consumption forecasts."""
@@ -155,8 +176,41 @@ class ForecastCoordinator(DataUpdateCoordinator):
             wind_speed_forecast: list[float] = []
             temperature_forecast: list[float] = []
             forecast_start = None
+            ir.async_delete_issue(self.hass, DOMAIN, "weather_data_stale")
         else:
             ir.async_delete_issue(self.hass, DOMAIN, "weather_data_unavailable")
+            # Stale weather detection: the shifted forecast degrades gracefully,
+            # but the user should know the weather source has stopped updating.
+            weather_ts = weather_data.get("timestamp")
+            weather_age_min = (
+                (dt_util.utcnow() - weather_ts).total_seconds() / 60
+                if weather_ts is not None
+                else None
+            )
+            if (
+                weather_age_min is not None
+                and weather_age_min > WEATHER_STALE_AFTER_MINUTES
+            ):
+                _LOGGER.warning(
+                    "Weather data is stale (%.0f min old, limit %.0f min); "
+                    "PV forecast quality degrades until open-meteo updates resume",
+                    weather_age_min,
+                    WEATHER_STALE_AFTER_MINUTES,
+                )
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    "weather_data_stale",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="weather_data_stale",
+                    # Whole hours: keeps issue-registry rewrites to once per hour
+                    translation_placeholders={
+                        "age_hours": f"{weather_age_min / 60:.0f}"
+                    },
+                )
+            else:
+                ir.async_delete_issue(self.hass, DOMAIN, "weather_data_stale")
             radiation_forecast = weather_data.get("radiation_forecast", [])
             dni_forecast = weather_data.get("dni_forecast", [])
             diffuse_forecast = weather_data.get("diffuse_forecast", [])

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -653,27 +653,25 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             )
             return
 
-        # Stale sensor detection (P4.1): if the first grid sensor has not updated
-        # recently, treat its reading as unreliable and skip the zero_grid correction.
+        # Stale sensor detection (P4.1): if any contributing grid sensor has not
+        # reported recently, treat the combined reading as unreliable and skip
+        # the zero_grid correction.
         stale_limit_s = STALE_SENSOR_MULTIPLIER * float(
             self.config.get(
                 CONF_ZERO_GRID_RESPONSE_TIME_S, DEFAULT_ZERO_GRID_RESPONSE_TIME_S
             )
         )
-        if self._power_consumption_sensors:
-            first_sensor = self._power_consumption_sensors[0]
-            state = self.hass.states.get(first_sensor)
-            if state is not None and state.last_updated is not None:
-                age_s = (dt_util.utcnow() - state.last_updated).total_seconds()
-                if age_s > stale_limit_s:
-                    _LOGGER.debug(
-                        "Grid power sensor '%s' is stale (%.0f s old, limit %.0f s); "
-                        "skipping zero_grid correction",
-                        first_sensor,
-                        age_s,
-                        stale_limit_s,
-                    )
-                    return
+        stale_sensor = self._find_stale_power_sensor(stale_limit_s)
+        if stale_sensor is not None:
+            sensor_id, age_s = stale_sensor
+            _LOGGER.debug(
+                "Grid power sensor '%s' is stale (%.0f s old, limit %.0f s); "
+                "skipping zero_grid correction",
+                sensor_id,
+                age_s,
+                stale_limit_s,
+            )
+            return
 
         # Read current battery state
         battery_state = self.get_current_battery_state()
@@ -889,6 +887,35 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             return "follow_schedule"
         return self._control_mode
 
+    def _find_stale_power_sensor(
+        self, stale_limit_s: float
+    ) -> tuple[str, float] | None:
+        """Return the first available-but-stale realtime power sensor, or None.
+
+        Only sensors that currently report a value are checked: an unavailable
+        sensor is already excluded from the grid sum, but an available sensor
+        that silently stopped reporting keeps feeding an outdated value into it.
+
+        Uses last_reported rather than last_updated: a live push sensor (e.g.
+        DSMR) keeps reporting even when the value is constant — such as a
+        production sensor reading 0 W all night — and last_updated only
+        advances when the value actually changes, which would flag every
+        steady sensor as stale.
+        """
+        now = dt_util.utcnow()
+        for sensor_id in (
+            *self._power_consumption_sensors,
+            *self._power_production_sensors,
+        ):
+            state = self.hass.states.get(sensor_id)
+            if state is None or state.state in ("unknown", "unavailable"):
+                continue
+            reported = state.last_reported or state.last_updated
+            age_s = (now - reported).total_seconds()
+            if age_s > stale_limit_s:
+                return sensor_id, age_s
+        return None
+
     def _get_realtime_grid_w(self) -> float | None:
         """Read current grid power from DSMR power sensors.
 
@@ -901,25 +928,34 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         We don't need to subtract battery_power separately.
 
         Returns:
-            Grid power in W (positive = import), or None if no sensors configured.
+            Grid power in W (positive = import), or None if no sensors are
+            configured or none of the configured sensors has a usable reading
+            (callers then fall back to the forecast-based estimate instead of
+            acting on a fictitious 0 W).
         """
         if not (self._power_consumption_sensors or self._power_production_sensors):
             return None
 
         total_consumption = 0.0
         total_production = 0.0
+        got_reading = False
 
         # Sum all consumption sensors
         for sensor_id in self._power_consumption_sensors:
             value = self._read_power_sensor_w(sensor_id)
             if value is not None:
                 total_consumption += value
+                got_reading = True
 
         # Sum all production sensors
         for sensor_id in self._power_production_sensors:
             value = self._read_power_sensor_w(sensor_id)
             if value is not None:
                 total_production += value
+                got_reading = True
+
+        if not got_reading:
+            return None
 
         return total_consumption - total_production
 

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -977,6 +977,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if self._unsub_realtime:
             self._unsub_realtime()
             self._unsub_realtime = None
+        await super().async_shutdown()
 
     def _read_battery_state(
         self,

--- a/custom_components/battery_controller/coordinator_weather.py
+++ b/custom_components/battery_controller/coordinator_weather.py
@@ -145,7 +145,3 @@ class WeatherDataCoordinator(DataUpdateCoordinator):
         )
 
         return result
-
-    async def async_shutdown(self) -> None:
-        """Cancel the periodic update timer."""
-        pass

--- a/custom_components/battery_controller/diagnostics.py
+++ b/custom_components/battery_controller/diagnostics.py
@@ -8,6 +8,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_BATTERY_POWER_SENSOR,
@@ -16,6 +17,7 @@ from .const import (
     CONF_ELECTRICITY_PRODUCTION_SENSORS,
     CONF_FEED_IN_PRICE_SENSOR,
     CONF_PRICE_SENSOR,
+    WEATHER_STALE_AFTER_MINUTES,
 )
 
 # Sensor entity IDs may be considered private; redact them
@@ -38,6 +40,20 @@ def _subentry_name_map(entry: ConfigEntry) -> dict[str, str]:
 def _remap_keys(d: dict[str, Any], name_map: dict[str, str]) -> dict[str, Any]:
     """Replace subentry ID keys with their human-readable titles."""
     return {name_map.get(k, k): v for k, v in d.items()}
+
+
+def _data_age_minutes(data: dict[str, Any] | None) -> float | None:
+    """Return the age of coordinator data in minutes, from its timestamp."""
+    if not data:
+        return None
+    timestamp = data.get("timestamp")
+    if isinstance(timestamp, str):
+        timestamp = dt_util.parse_datetime(timestamp)
+    if timestamp is None:
+        return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=dt_util.UTC)
+    return round((dt_util.utcnow() - timestamp).total_seconds() / 60, 1)
 
 
 async def async_get_config_entry_diagnostics(
@@ -76,8 +92,15 @@ async def async_get_config_entry_diagnostics(
     # Weather coordinator data
     weather_data = {}
     if weather_coord and weather_coord.data:
+        weather_age = _data_age_minutes(weather_coord.data)
         weather_data = {
             "last_update_success": weather_coord.last_update_success,
+            # Age + staleness computed at dump time: last_update_success alone
+            # stays True when polling silently stops, hiding a dead coordinator.
+            "age_minutes": weather_age,
+            "stale": (
+                weather_age is not None and weather_age > WEATHER_STALE_AFTER_MINUTES
+            ),
             "radiation_forecast": weather_coord.data.get("radiation_forecast"),
             "wind_speed_forecast": weather_coord.data.get("wind_speed_forecast"),
             "temperature_forecast": weather_coord.data.get("temperature_forecast"),
@@ -90,6 +113,7 @@ async def async_get_config_entry_diagnostics(
     if forecast_coord and forecast_coord.data:
         forecast_data = {
             "last_update_success": forecast_coord.last_update_success,
+            "age_minutes": _data_age_minutes(forecast_coord.data),
             "pv_forecast_kw": forecast_coord.data.get("pv_forecast_kw"),
             "pv_dc_forecast_kw": forecast_coord.data.get("pv_dc_forecast_kw"),
             "consumption_forecast_kw": forecast_coord.data.get(

--- a/custom_components/battery_controller/diagnostics.py
+++ b/custom_components/battery_controller/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -49,11 +50,12 @@ def _data_age_minutes(data: dict[str, Any] | None) -> float | None:
     timestamp = data.get("timestamp")
     if isinstance(timestamp, str):
         timestamp = dt_util.parse_datetime(timestamp)
-    if timestamp is None:
+    if not isinstance(timestamp, datetime):
         return None
     if timestamp.tzinfo is None:
         timestamp = timestamp.replace(tzinfo=dt_util.UTC)
-    return round((dt_util.utcnow() - timestamp).total_seconds() / 60, 1)
+    age_minutes: float = (dt_util.utcnow() - timestamp).total_seconds() / 60
+    return round(age_minutes, 1)
 
 
 async def async_get_config_entry_diagnostics(

--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -99,6 +99,10 @@
     "weather_data_unavailable": {
       "title": "Weather data unavailable (open-meteo)",
       "description": "The battery controller cannot reach the open-meteo weather API. PV production is assumed to be zero until the connection is restored. Check your internet connection or open-meteo service status."
+    },
+    "weather_data_stale": {
+      "title": "Weather data is stale (open-meteo)",
+      "description": "The weather data is {age_hours} hours old and is no longer being refreshed. The PV forecast quality degrades as the data ages. Check your internet connection or open-meteo service status; reload the integration if the problem persists."
     }
   },
   "options": {

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -99,6 +99,10 @@
     "weather_data_unavailable": {
       "title": "Weather data unavailable (open-meteo)",
       "description": "The battery controller cannot reach the open-meteo weather API. PV production is assumed to be zero until the connection is restored. Check your internet connection or open-meteo service status."
+    },
+    "weather_data_stale": {
+      "title": "Weather data is stale (open-meteo)",
+      "description": "The weather data is {age_hours} hours old and is no longer being refreshed. The PV forecast quality degrades as the data ages. Check your internet connection or open-meteo service status; reload the integration if the problem persists."
     }
   },
   "options": {

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -330,5 +330,19 @@
         "name": "Gebruik Maximale Energie Voorgesteld"
       }
     }
+  },
+  "issues": {
+    "price_sensor_unavailable": {
+      "title": "Elektriciteitsprijssensor niet beschikbaar",
+      "description": "De prijssensor **{sensor}** is niet beschikbaar en er bestaat nog geen historisch prijsmodel. De batterij-optimalisatie kan niet draaien zonder prijsdata. Controleer of de sensor werkt en forecast-attributen heeft."
+    },
+    "weather_data_unavailable": {
+      "title": "Weerdata niet beschikbaar (open-meteo)",
+      "description": "De batterijcontroller kan de open-meteo weer-API niet bereiken. PV-productie wordt op nul verondersteld totdat de verbinding is hersteld. Controleer je internetverbinding of de status van open-meteo."
+    },
+    "weather_data_stale": {
+      "title": "Weerdata is verouderd (open-meteo)",
+      "description": "De weerdata is {age_hours} uur oud en wordt niet meer ververst. De kwaliteit van de PV-voorspelling neemt af naarmate de data veroudert. Controleer je internetverbinding of de status van open-meteo; herlaad de integratie als het probleem aanhoudt."
+    }
   }
 }

--- a/custom_components/battery_controller/zero_grid_controller.py
+++ b/custom_components/battery_controller/zero_grid_controller.py
@@ -24,7 +24,6 @@ class ZeroGridControllerConfig:
 
     deadband_w: float = 50.0  # Hysteresis to prevent oscillation
     response_time_s: float = 5.0  # Update interval
-    priority: str = "schedule"  # 'zero_grid' or 'schedule' when in conflict
 
 
 class ZeroGridController:
@@ -282,10 +281,8 @@ def create_zero_grid_controller(
     from .const import (
         CONF_ZERO_GRID_DEADBAND_W,
         CONF_ZERO_GRID_RESPONSE_TIME_S,
-        CONF_ZERO_GRID_PRIORITY,
         DEFAULT_ZERO_GRID_DEADBAND_W,
         DEFAULT_ZERO_GRID_RESPONSE_TIME_S,
-        DEFAULT_ZERO_GRID_PRIORITY,
     )
 
     controller_config = ZeroGridControllerConfig(
@@ -297,7 +294,6 @@ def create_zero_grid_controller(
                 CONF_ZERO_GRID_RESPONSE_TIME_S, DEFAULT_ZERO_GRID_RESPONSE_TIME_S
             )
         ),
-        priority=config.get(CONF_ZERO_GRID_PRIORITY, DEFAULT_ZERO_GRID_PRIORITY),
     )
 
     return ZeroGridController(controller_config, battery_config)

--- a/docs/index.html
+++ b/docs/index.html
@@ -789,8 +789,23 @@ function renderDiagnostics(raw) {
   // ── Coordinator status
   const failureHtml = opt.failure_reason
     ? `<div class="mt-1 p-2 bg-red-50 border border-red-200 rounded text-xs text-red-700">⚠ ${opt.failure_reason}</div>` : '';
+  // Weather staleness: prefer the stale/age_minutes fields written at dump time;
+  // for older diagnostics files fall back to comparing the weather timestamp
+  // against the optimization timestamp (≈ dump time). last_update_success alone
+  // stays true when polling silently stops, so "OK" would hide a dead coordinator.
+  const WEATHER_STALE_MIN = 120;
+  let wxAgeMin = wx.age_minutes;
+  if (wxAgeMin === undefined && wx.timestamp && opt.timestamp) {
+    wxAgeMin = (new Date(opt.timestamp) - new Date(wx.timestamp)) / 60000;
+  }
+  const wxStale = wx.stale !== undefined ? wx.stale : (wxAgeMin !== undefined && wxAgeMin > WEATHER_STALE_MIN);
+  const wxBadge = !wx.last_update_success
+    ? `<span class="badge badge-fail">Failed</span>`
+    : wxStale
+      ? `<span class="badge badge-fail">Stale (${(wxAgeMin/60).toFixed(1)} h old)</span>`
+      : `<span class="badge badge-ok">OK</span>`;
   document.getElementById('coord-status').innerHTML = `
-    ${kv('Weather coordinator', `<span class="badge ${wx.last_update_success?'badge-ok':'badge-fail'}">${wx.last_update_success?'OK':'Failed'}</span>`)}
+    ${kv('Weather coordinator', wxBadge)}
     ${kv('Weather timestamp', wx.timestamp ? new Date(wx.timestamp).toLocaleString() : '—')}
     ${kv('Forecast coordinator', `<span class="badge ${fc.last_update_success?'badge-ok':'badge-fail'}">${fc.last_update_success?'OK':'Failed'}</span>`)}
     ${kv('Forecast timestamp', fc.timestamp ? new Date(fc.timestamp).toLocaleString() : '—')}

--- a/tests/test_coordinator_forecast.py
+++ b/tests/test_coordinator_forecast.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -502,11 +502,149 @@ async def test_async_update_data_weather_recovery_deletes_issue(hass):
 
         await coord._async_update_data()
 
-    mock_delete_issue.assert_called_once_with(
+    mock_delete_issue.assert_any_call(
         hass,
         "battery_controller",
         "weather_data_unavailable",
     )
+    # Fresh (non-stale) weather data also clears the stale issue
+    mock_delete_issue.assert_any_call(
+        hass,
+        "battery_controller",
+        "weather_data_stale",
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_subscribes_weather_coordinator(hass):
+    """async_setup must register a listener on the weather coordinator.
+
+    A DataUpdateCoordinator only keeps polling while it has listeners; without
+    this subscription the weather coordinator fetches once at startup and then
+    serves the same aging snapshot forever (while last_update_success stays
+    True, so diagnostics report 'OK' on half-a-day-old data).
+    """
+    config = _minimal_config()
+    weather_coord = MagicMock()
+    weather_unsub = MagicMock()
+    weather_coord.async_add_listener = MagicMock(return_value=weather_unsub)
+    mock_consumption = _make_mock_consumption()
+
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+            return_value=mock_consumption,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.async_track_time_interval",
+            return_value=MagicMock(),
+        ),
+    ):
+        coord = ForecastCoordinator(hass, weather_coord, config)
+        await coord.async_setup()
+
+    weather_coord.async_add_listener.assert_called_once()
+    assert coord._unsub_weather is weather_unsub
+
+    # The listener triggers a forecast refresh when new weather data arrives
+    listener = weather_coord.async_add_listener.call_args[0][0]
+    with patch.object(coord, "async_request_refresh", AsyncMock()) as mock_refresh:
+        listener()
+        await hass.async_block_till_done()
+    mock_refresh.assert_awaited_once()
+
+    # And shutdown unsubscribes again
+    await coord.async_shutdown()
+    weather_unsub.assert_called_once()
+    assert coord._unsub_weather is None
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_stale_weather_creates_issue(hass):
+    """Weather data older than the stale limit should raise a repair issue."""
+    now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    weather_coord = MagicMock()
+    weather_coord.data = {
+        "radiation_forecast": [100.0] * 24,
+        "dni_forecast": [50.0] * 24,
+        "diffuse_forecast": [20.0] * 24,
+        "wind_speed_forecast": [3.0] * 24,
+        "temperature_forecast": [20.0] * 24,
+        "forecast_start_utc": now - timedelta(hours=12),
+        "timestamp": now - timedelta(hours=12),  # half a day old
+    }
+    mock_consumption = _make_mock_consumption()
+
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+            return_value=mock_consumption,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.utcnow",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.now",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ir.async_create_issue"
+        ) as mock_create_issue,
+    ):
+        coord = ForecastCoordinator(hass, weather_coord, _minimal_config())
+        coord.net_load_model = MagicMock()
+        coord.net_load_model.forecast = MagicMock(return_value=(None, [0.5] * 12, None))
+
+        result = await coord._async_update_data()
+
+    assert result is not None
+    mock_create_issue.assert_called_once()
+    assert mock_create_issue.call_args[0][2] == "weather_data_stale"
+    placeholders = mock_create_issue.call_args[1]["translation_placeholders"]
+    assert placeholders == {"age_hours": "12"}
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_fresh_weather_no_stale_issue(hass):
+    """Fresh weather data must not raise the stale-weather issue."""
+    now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    weather_coord = MagicMock()
+    weather_coord.data = {
+        "radiation_forecast": [100.0] * 24,
+        "dni_forecast": [50.0] * 24,
+        "diffuse_forecast": [20.0] * 24,
+        "wind_speed_forecast": [3.0] * 24,
+        "temperature_forecast": [20.0] * 24,
+        "forecast_start_utc": now,
+        "timestamp": now - timedelta(minutes=20),
+    }
+    mock_consumption = _make_mock_consumption()
+
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+            return_value=mock_consumption,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.utcnow",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.now",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ir.async_create_issue"
+        ) as mock_create_issue,
+    ):
+        coord = ForecastCoordinator(hass, weather_coord, _minimal_config())
+        coord.net_load_model = MagicMock()
+        coord.net_load_model.forecast = MagicMock(return_value=(None, [0.5] * 24, None))
+
+        await coord._async_update_data()
+
+    mock_create_issue.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -910,6 +910,85 @@ def test_get_realtime_grid_w_kw_unit_conversion(hass):
     assert result == pytest.approx(300.0)
 
 
+def test_get_realtime_grid_w_all_sensors_unavailable_returns_none(hass):
+    """All configured sensors unavailable must yield None, not a fictitious 0 W.
+
+    Callers (realtime loop, full optimizer run) treat None as "no live
+    reading" and fall back appropriately; 0.0 would be acted upon as a real
+    balanced-grid measurement.
+    """
+    coord = _make_coordinator(hass)
+    coord._power_consumption_sensors = ["sensor.consumption"]
+    coord._power_production_sensors = ["sensor.production"]
+
+    hass.states.async_set("sensor.consumption", "unavailable")
+    hass.states.async_set("sensor.production", "unknown")
+
+    assert coord._get_realtime_grid_w() is None
+
+
+def test_get_realtime_grid_w_partial_unavailable_uses_available(hass):
+    """One readable sensor is enough for a (partial) grid reading."""
+    coord = _make_coordinator(hass)
+    coord._power_consumption_sensors = ["sensor.consumption"]
+    coord._power_production_sensors = ["sensor.production"]
+
+    hass.states.async_set("sensor.consumption", "unavailable")
+    hass.states.async_set("sensor.production", "200", {"unit_of_measurement": "W"})
+
+    assert coord._get_realtime_grid_w() == pytest.approx(-200.0)
+
+
+def test_find_stale_power_sensor_fresh_sensors(hass):
+    """Fresh sensors are not reported as stale."""
+    coord = _make_coordinator(hass)
+    coord._power_consumption_sensors = ["sensor.consumption"]
+    coord._power_production_sensors = ["sensor.production"]
+
+    hass.states.async_set("sensor.consumption", "500", {"unit_of_measurement": "W"})
+    hass.states.async_set("sensor.production", "200", {"unit_of_measurement": "W"})
+
+    assert coord._find_stale_power_sensor(20.0) is None
+
+
+def test_find_stale_power_sensor_detects_stale_production(hass, monkeypatch):
+    """Production sensors are also covered by the staleness check."""
+    coord = _make_coordinator(hass)
+    coord._power_consumption_sensors = []
+    coord._power_production_sensors = ["sensor.production"]
+
+    hass.states.async_set("sensor.production", "200", {"unit_of_measurement": "W"})
+    state_time = hass.states.get("sensor.production").last_reported
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
+        lambda: state_time + timedelta(seconds=30),
+    )
+
+    stale = coord._find_stale_power_sensor(20.0)
+    assert stale is not None
+    sensor_id, age_s = stale
+    assert sensor_id == "sensor.production"
+    assert age_s == pytest.approx(30.0, abs=1.0)
+
+
+def test_find_stale_power_sensor_skips_unavailable(hass, monkeypatch):
+    """Unavailable sensors are excluded from the grid sum, so an old
+    unavailable state must not flag the reading as stale (that would block
+    every realtime update e.g. overnight)."""
+    coord = _make_coordinator(hass)
+    coord._power_consumption_sensors = []
+    coord._power_production_sensors = ["sensor.production"]
+
+    hass.states.async_set("sensor.production", "unavailable")
+    prod_time = hass.states.get("sensor.production").last_reported
+    monkeypatch.setattr(
+        "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
+        lambda: prod_time + timedelta(seconds=30),
+    )
+
+    assert coord._find_stale_power_sensor(20.0) is None
+
+
 def test_resolve_controller_mode(hass):
     """_resolve_controller_mode returns correct mode string (lines 616-634)."""
     from custom_components.battery_controller.const import MODE_ZERO_GRID
@@ -1335,8 +1414,8 @@ def test_get_realtime_grid_w_value_error_skipped(hass):
     hass.states.async_set("sensor.bad_production", "also_bad")
 
     result = coord._get_realtime_grid_w()
-    # Should return 0.0 - 0.0 = 0.0 (both sensors skipped, defaults to 0)
-    assert result == 0.0
+    # Both sensors unreadable → no live reading (None), not a fictitious 0 W
+    assert result is None
 
 
 def test_read_battery_state_kwh_soc_unit(hass):

--- a/tests/test_coordinator_weather.py
+++ b/tests/test_coordinator_weather.py
@@ -180,8 +180,8 @@ async def test_async_update_data_no_radiation(hass):
 
 
 @pytest.mark.asyncio
-async def test_async_shutdown_is_noop(hass):
-    """async_shutdown is a no-op (no exception)."""
+async def test_async_shutdown_stops_polling(hass):
+    """async_shutdown uses the base-class implementation (cancels the timer)."""
     with patch(
         "custom_components.battery_controller.coordinator_weather.async_get_clientsession",
         return_value=MagicMock(),
@@ -189,6 +189,7 @@ async def test_async_shutdown_is_noop(hass):
         coord = WeatherDataCoordinator(hass)
 
     await coord.async_shutdown()  # Should not raise
+    assert coord._shutdown_requested is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -118,6 +118,10 @@ async def test_diagnostics_dataclass_access(
     # Verification
     assert diagnostics["config_entry"]["entry_id"] == "test_entry_id"
     assert diagnostics["weather"]["last_update_success"] is True
+    # Data age is reported so stale-but-"successful" coordinators are visible
+    assert diagnostics["weather"]["age_minutes"] is not None
+    assert diagnostics["weather"]["stale"] is True  # 2024 timestamp is long stale
+    assert diagnostics["forecast"]["age_minutes"] is not None
     assert diagnostics["forecast"]["consumption_hourly_pattern"] == {"12_0": 0.5}
     assert diagnostics["optimization"]["control_mode"] == "hybrid"
     assert diagnostics["optimization"]["control_action"]["target_power_kw"] == 0.0

--- a/tests/test_zero_grid_controller.py
+++ b/tests/test_zero_grid_controller.py
@@ -303,7 +303,6 @@ class TestCreateZeroGridController:
         config = {
             "zero_grid_deadband_w": 100.0,
             "zero_grid_response_time_s": 10.0,
-            "zero_grid_priority": "zero_grid",
         }
         controller = create_zero_grid_controller(config, battery_config)
         assert isinstance(controller, ZeroGridController)


### PR DESCRIPTION
## Description

Fixes the reported issue that the weather coordinator keeps showing "OK" while its data is half a day old, plus three non-happy-flow findings from a review of the zero-grid controller.

**Weather coordinator (root cause of the stale-data report):** a `DataUpdateCoordinator` only keeps polling while it has listeners, and nothing subscribed to the `WeatherDataCoordinator` — so it fetched open-meteo data exactly once at startup and then served the same aging snapshot forever, while `last_update_success` stayed `True` ("OK" in diagnostics and the simulator).

- `ForecastCoordinator` now subscribes to the weather coordinator, which (re)starts its 30-min polling and recomputes forecasts as soon as fresh weather data arrives
- Removed the no-op `async_shutdown` override in `WeatherDataCoordinator` so the polling timer is properly cancelled on unload; Forecast- and OptimizationCoordinator now also call `super().async_shutdown()`
- New repair issue `weather_data_stale` (en+nl) when weather data is older than 2 h, cleared automatically on recovery; nl.json also gained the previously missing issue translations
- Diagnostics now include `age_minutes` + `stale` for the weather block and `age_minutes` for the forecast block
- Simulator coordinator-status badge shows "Stale (x h old)" instead of "OK", with a timestamp fallback for older diagnostics dumps

**Zero-grid controller non-happy flows:**

- `_get_realtime_grid_w` returns `None` when all configured power sensors are unavailable/unreadable, instead of a fictitious 0 W (realtime loop holds the setpoint; the 15-min run falls back to the forecast-based grid estimate)
- Stale-sensor detection now covers all configured consumption and production power sensors (previously only the first consumption sensor) and uses `last_reported` instead of `last_updated`, so a live push sensor with a constant value (e.g. production at 0 W overnight) is not misclassified as stale; unavailable sensors are skipped since they are already excluded from the grid sum
- Removed dead `ZeroGridControllerConfig.priority` and the unused `CONF/DEFAULT_ZERO_GRID_PRIORITY` constants

Note: the stale-detection change touches the same block that #94 restructures; whichever merges second needs a trivial rebase (#94's flag can be set via `self._find_stale_power_sensor(stale_limit_s) is not None`). The two changes are complementary: `last_reported` fixes false staleness for push sensors, #94's toward-zero guard covers on-change-only sources.

## Type of change

- [x] `fix:` Bug fix (patch version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable (8 new tests, 3 updated)
- [x] Documentation updated if needed (docs/index.html simulator badge)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

—