### PR TITLE
fix: apply entry-level DC-PV coupling to the optimizer battery config

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -43,6 +43,7 @@ from .const import (
     DEFAULT_MANUAL_POWER_SETPOINT_W,
     DEFAULT_MIN_PRICE_SPREAD,
     CONF_PV_DC_COUPLED,
+    CONF_PV_DC_PEAK_POWER_KWP,
     CONF_ZERO_GRID_DEADBAND_W,
     CONF_ZERO_GRID_RESPONSE_TIME_S,
     DEFAULT_ZERO_GRID_DEADBAND_W,
@@ -132,6 +133,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self.battery_config = aggregate_battery_configs(
             [cfg for _, cfg in self._individual_battery_configs]
         )
+        self._apply_dc_pv_config()
 
         # Per-battery state cache (updated by get_current_battery_state)
         self._per_battery_states: dict[str, BatteryState] = {}
@@ -1404,6 +1406,22 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         ]
         self.battery_config = aggregate_battery_configs(
             [cfg for _, cfg in self._individual_battery_configs]
+        )
+        self._apply_dc_pv_config()
+
+    def _apply_dc_pv_config(self) -> None:
+        """Overlay entry-level DC-PV configuration onto the aggregated battery config.
+
+        DC coupling is configured on the PV-array subentries, not on the battery
+        subentries, so BatteryConfig.from_subentry can never set pv_dc_coupled.
+        Without this overlay the optimizer always sees pv_dc_coupled=False and
+        never models passive DC MPPT charging.
+        """
+        if not self.config.get(CONF_PV_DC_COUPLED):
+            return
+        self.battery_config.pv_dc_coupled = True
+        self.battery_config.pv_dc_peak_power_kwp = float(
+            self.config.get(CONF_PV_DC_PEAK_POWER_KWP, 0.0)
         )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -21,6 +21,8 @@ from custom_components.battery_controller.const import (
     CONF_POWER_CONSUMPTION_SENSORS,
     CONF_POWER_PRODUCTION_SENSORS,
     CONF_PRICE_SENSOR,
+    CONF_PV_DC_COUPLED,
+    CONF_PV_DC_PEAK_POWER_KWP,
     CONF_ROUND_TRIP_EFFICIENCY,
     CONF_ZERO_GRID_DEADBAND_W,
     MODE_FOLLOW_SCHEDULE,
@@ -1958,6 +1960,80 @@ def test_refresh_battery_config_no_entry(hass, monkeypatch):
 
     # Should not raise — just return
     coord._refresh_battery_config()
+
+
+def _make_dc_coordinator(hass):
+    """Build a coordinator whose entry-level config declares DC-coupled PV."""
+    weather_coordinator = MagicMock()
+    weather_coordinator.data = {}
+    forecast_coordinator = MagicMock()
+    forecast_coordinator.data = None
+    forecast_coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    config = {
+        "entry_id": "test-entry",
+        CONF_PRICE_SENSOR: "sensor.test_price",
+        CONF_CONTROL_MODE: MODE_FOLLOW_SCHEDULE,
+        CONF_PV_DC_COUPLED: True,
+        CONF_PV_DC_PEAK_POWER_KWP: 3.5,
+        "battery_subentries": [
+            (
+                "bat1",
+                {
+                    CONF_MAX_CHARGE_POWER_KW: 1.2,
+                    CONF_MAX_DISCHARGE_POWER_KW: 1.2,
+                    CONF_ROUND_TRIP_EFFICIENCY: 0.92,
+                    CONF_MIN_SOC_PERCENT: 10.0,
+                    CONF_MAX_SOC_PERCENT: 100.0,
+                    CONF_BATTERY_SOC_SENSOR: "sensor.test_soc",
+                },
+            )
+        ],
+    }
+    return OptimizationCoordinator(
+        hass, weather_coordinator, forecast_coordinator, config
+    )
+
+
+def test_dc_pv_config_applied_to_battery_config(hass):
+    """Entry-level DC-PV settings must reach the aggregated battery config.
+
+    DC coupling lives on the PV-array subentries; battery subentries carry no
+    DC-PV keys, so without the overlay pv_dc_coupled would always be False and
+    the DP would never model passive DC MPPT charging.
+    """
+    coord = _make_dc_coordinator(hass)
+    assert coord.battery_config.pv_dc_coupled is True
+    assert coord.battery_config.pv_dc_peak_power_kwp == pytest.approx(3.5)
+
+
+def test_dc_pv_config_not_applied_when_ac_only(hass):
+    """Without entry-level DC coupling the battery config stays AC-only."""
+    coord = _make_coordinator(hass)
+    assert coord.battery_config.pv_dc_coupled is False
+    assert coord.battery_config.pv_dc_peak_power_kwp == pytest.approx(0.0)
+
+
+def test_refresh_battery_config_preserves_dc_pv_overlay(hass, monkeypatch):
+    """_refresh_battery_config must re-apply the DC-PV overlay after rebuilding."""
+    coord = _make_dc_coordinator(hass)
+
+    mock_subentry = MagicMock()
+    mock_subentry.data = {
+        CONF_MAX_CHARGE_POWER_KW: 2.0,
+        CONF_MAX_DISCHARGE_POWER_KW: 2.0,
+        CONF_ROUND_TRIP_EFFICIENCY: 0.90,
+        CONF_MIN_SOC_PERCENT: 10.0,
+        CONF_MAX_SOC_PERCENT: 90.0,
+    }
+    mock_entry = MagicMock()
+    mock_entry.subentries = {"bat1": mock_subentry}
+    monkeypatch.setattr(hass.config_entries, "async_get_entry", lambda eid: mock_entry)
+
+    coord._refresh_battery_config()
+
+    assert coord.battery_config.max_charge_power_kw == pytest.approx(2.0)
+    assert coord.battery_config.pv_dc_coupled is True
+    assert coord.battery_config.pv_dc_peak_power_kwp == pytest.approx(3.5)
 
 
 def test_get_manual_setpoint_w_with_entry(hass, monkeypatch):


### PR DESCRIPTION
## Description

The optimizer's `BatteryConfig` is built from **battery** subentries via `BatteryConfig.from_subentry()`, but DC coupling is configured on the **PV-array** subentries. `from_subentry()` never sets `pv_dc_coupled` / `pv_dc_peak_power_kwp`, and `BatteryConfig.from_config()` (which does read `CONF_PV_DC_COUPLED`) is never called anywhere. As a result the aggregated battery config always had `pv_dc_coupled=False`.

Impact for DC-coupled installations: the DP received the DC PV forecast (`forecast_data["pv_dc_coupled"]` comes from the PV arrays and is correct), but with `battery_config.pv_dc_coupled=False` every passive-DC-charging branch in `calculate_step_cost` and the SoC transitions was skipped. DC PV was modelled as pure AC export through the inverter (96%), passive MPPT charging never happened in the plan, and `pv_dc_efficiency` (97%) was never used — contrary to the documented model in `ALGORITHM.md`.

Fix: overlay the entry-level `CONF_PV_DC_COUPLED` / `CONF_PV_DC_PEAK_POWER_KWP` (derived from PV-array subentries in `async_setup_entry`) onto the aggregated battery config, both in `OptimizationCoordinator.__init__` and in `_refresh_battery_config()` (which rebuilds the config at the start of every optimizer run).

No DP-algorithm change, so `analyzer.js` / `simulate_diagnostics.py` need no sync.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [ ] Documentation updated if needed
- [x] CI is green (local: full pytest suite + pre-commit + mypy pass)
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

New tests: `test_dc_pv_config_applied_to_battery_config`, `test_dc_pv_config_not_applied_when_ac_only`, `test_refresh_battery_config_preserves_dc_pv_overlay`.