### PR TITLE
fix: skip discharge-calibration samples that cross the low-SoC derating threshold

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -1734,6 +1734,24 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             # Too small to measure reliably; skip.
             return
 
+        # Skip if the step crosses the low-SoC discharge derating threshold.
+        # The DP plans at the start-SoC limit for the whole step, but the
+        # inverter throttles once the threshold is reached mid-step.  The
+        # resulting actual/planned ratio reflects the derating, not real
+        # efficiency losses, so including it would corrupt the calibration
+        # (same guard as the high-SoC check in the charge calibration).
+        bc = self.battery_config
+        if bc.low_soc_max_discharge_kw > 0:
+            threshold_kwh = bc.low_soc_discharge_threshold_pct / 100 * bc.capacity_kwh
+            if planned_next_soc < threshold_kwh <= prev_soc:
+                _LOGGER.debug(
+                    "Discharge efficiency calibration: skipping sample — step crosses "
+                    "low-SoC derating threshold (%.1f%% / %.2f kWh)",
+                    bc.low_soc_discharge_threshold_pct,
+                    threshold_kwh,
+                )
+                return
+
         actual_delta = prev_soc - battery_state.soc_kwh  # positive: SoC went down
         # Cap upward to 1.2× planned to filter out unexpected external discharge
         # (e.g. grid outage, SoC sensor noise causing apparent over-discharge).

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -3479,6 +3479,55 @@ def test_discharge_calibration_samples_when_plan_executed(hass):
     assert coord._discharge_eff_correction == pytest.approx(0.8)
 
 
+def test_discharge_calibration_skips_when_crossing_low_soc_derating(hass):
+    """No sample when the planned step crosses the low-SoC derating threshold.
+
+    The BMS throttles discharge power mid-step once the threshold is reached,
+    so actual < planned reflects derating, not efficiency. Sampling it would
+    corrupt the persisted calibration (mirror of the high-SoC charge guard).
+    """
+    coord = _make_coordinator(hass)
+    coord.battery_config.low_soc_discharge_threshold_pct = 50.0
+    coord.battery_config.low_soc_max_discharge_kw = 0.5
+
+    # capacity 10 kWh → threshold at 5.0 kWh; plan 6.0 → 4.0 crosses it
+    coord._last_result = _make_fake_result(
+        mode_schedule=["discharging"],
+        soc_schedule_kwh=[6.0, 4.0],
+    )
+    _mark_plan_executed(coord)
+
+    battery_state = BatteryState(
+        soc_kwh=5.2, soc_percent=52.0, power_kw=-1.0, mode="discharging"
+    )
+    coord._update_discharge_eff_calibration(battery_state)
+
+    assert len(coord._discharge_eff_samples) == 0
+    assert coord._discharge_eff_correction == pytest.approx(1.0)
+
+
+def test_discharge_calibration_samples_above_low_soc_derating(hass):
+    """Sampling continues when derating is configured but the step stays above it."""
+    coord = _make_coordinator(hass)
+    coord.battery_config.low_soc_discharge_threshold_pct = 20.0
+    coord.battery_config.low_soc_max_discharge_kw = 0.5
+
+    # threshold at 2.0 kWh; plan 6.0 → 4.0 stays well above it
+    coord._last_result = _make_fake_result(
+        mode_schedule=["discharging"],
+        soc_schedule_kwh=[6.0, 4.0],
+    )
+    _mark_plan_executed(coord)
+
+    battery_state = BatteryState(
+        soc_kwh=4.4, soc_percent=44.0, power_kw=-1.0, mode="discharging"
+    )
+    coord._update_discharge_eff_calibration(battery_state)
+
+    assert len(coord._discharge_eff_samples) == 1
+    assert coord._discharge_eff_samples[0] == pytest.approx(0.8)
+
+
 # Feed-in interval handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

The charge-efficiency calibration skips samples whose planned step crosses the **high-SoC charge derating** threshold, because the BMS throttles power mid-step and the actual/planned ratio then reflects derating rather than real efficiency. The discharge-efficiency calibration was missing the mirrored guard for the **low-SoC discharge derating** threshold.

Impact: on batteries with low-SoC discharge derating configured (e.g. Marstek Venus), every discharge step that crosses the threshold produces a spuriously low actual/planned ratio. The rolling 20-sample average drags the *persisted* discharge correction down (surviving restarts), making the DP plan systematically less discharge than the battery can actually deliver — even far away from the derating region.

Fix: add the symmetric skip in `_update_discharge_eff_calibration` (`planned_next_soc < threshold_kwh <= prev_soc` → no sample), identical in structure to the existing high-SoC guard in `_update_charge_eff_calibration`.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [ ] Documentation updated if needed
- [x] CI is green (local: pytest + pre-commit + mypy pass)
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

New tests: `test_discharge_calibration_skips_when_crossing_low_soc_derating`, `test_discharge_calibration_samples_above_low_soc_derating`.