### PR TITLE
feat: emit PV/consumption forecasts at 15-minute resolution

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -478,10 +478,12 @@ Because primary runs fire at period boundaries, step 0 is always (or nearly alwa
 
 ### PV and consumption resampling
 
-PV production and household consumption forecasts are always computed at 60-minute resolution (the open-meteo weather API delivers hourly data). When the price interval is finer, these are resampled to match:
+PV production and household consumption forecasts are emitted by the forecast coordinator at `FORECAST_INTERVAL_MINUTES` (15-minute) resolution, aligned to quarter-hour boundaries starting at the current step. The weather input (open-meteo) is hourly; hourly series are expanded to 15-minute steps by repetition (mean-preserving), while the solar-geometry model is evaluated per 15-minute timestamp, so dawn/dusk ramps gain sub-hourly shape even from hourly radiation data. Consumption comes from hourly pattern buckets and is expanded by repetition too.
 
-- `resample_forecast(pv_forecast_kw, 60, price_interval)` — weighted-average downsampling
-- Each 15-min slot within an hour gets the same kW value as the parent hour
+The optimization coordinator resamples from the pipeline's native interval (published as `forecast_interval_minutes` in the coordinator data; 60 is assumed for data from older versions) to the price interval:
+
+- `resample_forecast(pv_forecast_kw, forecast_interval_minutes, price_interval)` — repetition when upsampling, weighted-average when downsampling
+- Because the forecast series starts at the current quarter-hour (not the current hour), step k of the forecast aligns with price period k for 15-minute price intervals — previously hourly-based series could be misaligned by up to 45 minutes at hour boundaries
 
 ### Past-entry exclusion for timestamp-bearing sensors
 

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -153,6 +153,15 @@ DEFAULT_FIXED_FEED_IN_PRICE = 0.04  # EUR/kWh (post-salderingsregeling NL, 2025+
 # Default values - Control mode
 DEFAULT_CONTROL_MODE = "hybrid"
 
+# Base resolution of the PV/consumption forecast pipeline.
+# Weather input (open-meteo) is hourly, but forecasts are emitted at
+# 15-minute steps aligned to quarter-hour boundaries so they map 1:1 onto
+# 15-minute price intervals without the up-to-45-minute misalignment that
+# hourly series had at hour boundaries. Hourly inputs are expanded by
+# repetition (mean-preserving); solar geometry is evaluated per step, so
+# dawn/dusk ramps gain sub-hourly shape even from hourly radiation data.
+FORECAST_INTERVAL_MINUTES = 15
+
 # DP resolution constants
 # 10 Wh SoC states: fine enough that the post-discharge SoC maps accurately
 # (coarse states systematically undervalue concentrating discharge at the

--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_ELECTRICITY_PRODUCTION_SENSORS,
     CONF_PV_PRODUCTION_SENSORS,
     DOMAIN,
+    FORECAST_INTERVAL_MINUTES,
     WEATHER_STALE_AFTER_MINUTES,
 )
 from .coordinator_weather import WeatherDataCoordinator
@@ -239,29 +240,65 @@ class ForecastCoordinator(DataUpdateCoordinator):
                     hours_elapsed,
                 )
 
-        # Build UTC timestamps for each forecast hour (needed for solar geometry)
+        # Emit all forecasts at FORECAST_INTERVAL_MINUTES resolution, aligned
+        # to the current step boundary (quarter hour). Hourly weather series
+        # are expanded by repetition — mean-preserving, unlike interpolation —
+        # while solar geometry is evaluated per step, giving dawn/dusk ramps
+        # sub-hourly shape. Starting at the current step (not the current
+        # hour) keeps step k aligned with price period k for sub-hourly
+        # price intervals.
+        step_min = FORECAST_INTERVAL_MINUTES
+        steps_per_hour = 60 // step_min
+        now_utc = dt_util.utcnow()
+        current_step = now_utc.replace(
+            minute=(now_utc.minute // step_min) * step_min, second=0, microsecond=0
+        )
+        offset_steps = int(
+            (current_step - current_hour).total_seconds() // (step_min * 60)
+        )
+        n_hours = len(radiation_forecast)
+        n = max(0, n_hours * steps_per_hour - offset_steps)
+
+        # Build UTC timestamps for each forecast step (needed for solar geometry)
         lat = self.hass.config.latitude
         lon = self.hass.config.longitude
         timestamps_utc = [
-            current_hour + timedelta(hours=i) for i in range(len(radiation_forecast))
+            current_step + timedelta(minutes=step_min * k) for k in range(n)
         ]
 
-        # Consumption forecast via net_load_model (dummy PV so result = pure consumption)
-        _, consumption_forecast, _ = self.net_load_model.forecast(radiation_forecast)
-        n = len(consumption_forecast)
+        def _expand(hourly: list[float]) -> list[float]:
+            """Expand an hourly series (index 0 = current hour) to step values."""
+            if not hourly:
+                return []
+            out: list[float] = []
+            for ts in timestamps_utc:
+                idx = int((ts - current_hour).total_seconds() // 3600)
+                out.append(hourly[idx] if 0 <= idx < len(hourly) else 0.0)
+            return out
+
+        radiation_steps = _expand(radiation_forecast)
+        dni_steps = _expand(dni_forecast)
+        diffuse_steps = _expand(diffuse_forecast)
+        wind_speed_steps = _expand(wind_speed_forecast)
+        temperature_steps = _expand(temperature_forecast)
+
+        # Consumption forecast via net_load_model (dummy PV so result = pure
+        # consumption); the model works in hourly buckets, expanded to steps.
+        _, consumption_hourly, _ = self.net_load_model.forecast(radiation_forecast)
+        consumption_forecast = _expand(consumption_hourly)
 
         # Temperature forecast for PV derating (P2.2): pass if available
-        temp_for_pv = temperature_forecast if temperature_forecast else None
+        temp_for_pv = temperature_steps if temperature_steps else None
 
-        poa_dni: list[float] | None = dni_forecast or None
-        poa_diffuse: list[float] | None = diffuse_forecast or None
+        poa_dni: list[float] | None = dni_steps or None
+        poa_diffuse: list[float] | None = diffuse_steps or None
 
         # Sum AC PV forecast across all AC subentry models, applying temperature derating
         pv_forecast = [0.0] * n
         per_pv_array_forecasts: dict[str, list[float]] = {}
         for sid, model in zip(self.pv_ac_subentry_ids, self.pv_ac_models):
             extra = model.forecast_from_radiation(
-                radiation_forecast,
+                radiation_steps,
                 temp_for_pv,
                 dni_forecast=poa_dni,
                 diffuse_forecast=poa_diffuse,
@@ -285,7 +322,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
         pv_dc_forecast = [0.0] * n
         for sid, dc_model in zip(self.pv_dc_subentry_ids, self.pv_dc_models):
             extra_dc = dc_model.forecast_from_radiation(
-                radiation_forecast,
+                radiation_steps,
                 temp_for_pv,
                 dni_forecast=poa_dni,
                 diffuse_forecast=poa_diffuse,
@@ -302,7 +339,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
         # Clamp DC PV values as well
         pv_dc_forecast = [max(0.0, v) for v in pv_dc_forecast]
 
-        # Derive current values from forecast (first element = current hour)
+        # Derive current values from forecast (first element = current step)
         current_pv = pv_forecast[0] if pv_forecast else 0.0
         current_dc_pv = pv_dc_forecast[0] if pv_dc_forecast else 0.0
         current_consumption = self.consumption_model.get_current_consumption()
@@ -317,13 +354,13 @@ class ForecastCoordinator(DataUpdateCoordinator):
             "current_dc_pv_kw": round(current_dc_pv, 3),
             "current_consumption_kw": round(current_consumption, 3),
             "current_net_load_kw": round(current_consumption - current_pv, 3),
-            "current_ghi_wm2": round(radiation_forecast[0], 1)
-            if radiation_forecast
-            else 0.0,
-            "current_wind_speed_ms": round(wind_speed_forecast[0], 1)
-            if wind_speed_forecast
+            "current_ghi_wm2": round(radiation_steps[0], 1) if radiation_steps else 0.0,
+            "current_wind_speed_ms": round(wind_speed_steps[0], 1)
+            if wind_speed_steps
             else 0.0,
             "pv_dc_coupled": has_dc,
+            "forecast_interval_minutes": step_min,
+            "forecast_start_utc": current_step,
             "timestamp": dt_util.utcnow(),
         }
 

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -2090,12 +2090,17 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 )
                 resampled_feed_in = [fixed_price] * len(resampled_prices)
 
-        # Resample hourly PV / consumption forecasts to the price sensor's native interval
+        # Resample PV / consumption forecasts from the forecast pipeline's
+        # native interval (15 min; 60 for data produced by older versions)
+        # to the price sensor's native interval.
+        fc_interval = int(forecast_data.get("forecast_interval_minutes", 60))
         pv_forecast = resample_forecast(
-            forecast_data.get("pv_forecast_kw", []), 60, price_interval
+            forecast_data.get("pv_forecast_kw", []), fc_interval, price_interval
         )
         consumption_forecast = resample_forecast(
-            forecast_data.get("consumption_forecast_kw", []), 60, price_interval
+            forecast_data.get("consumption_forecast_kw", []),
+            fc_interval,
+            price_interval,
         )
 
         # Horizon = length of price forecast (the binding constraint)
@@ -2106,7 +2111,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if forecast_data.get("pv_dc_coupled"):
             raw_dc = forecast_data.get("pv_dc_forecast_kw", [])
             if raw_dc and any(v > 0 for v in raw_dc):
-                pv_dc_forecast = resample_forecast(raw_dc, 60, price_interval)
+                pv_dc_forecast = resample_forecast(raw_dc, fc_interval, price_interval)
 
         # PV curtailment override: zero out all PV when the switch is active.
         # The optimizer then plans charging from the grid instead of relying on

--- a/custom_components/battery_controller/diagnostics.py
+++ b/custom_components/battery_controller/diagnostics.py
@@ -132,6 +132,10 @@ async def async_get_config_entry_diagnostics(
             "per_pv_array_forecasts": _remap_keys(
                 forecast_coord.data.get("per_pv_array_forecasts") or {}, name_map
             ),
+            "forecast_interval_minutes": forecast_coord.data.get(
+                "forecast_interval_minutes", 60
+            ),
+            "forecast_start_utc": str(forecast_coord.data.get("forecast_start_utc")),
             "timestamp": str(forecast_coord.data.get("timestamp")),
         }
         # Include learned consumption pattern

--- a/custom_components/battery_controller/sensor.py
+++ b/custom_components/battery_controller/sensor.py
@@ -398,6 +398,9 @@ class PVForecastSensor(BatteryForecastSensor):
             return {}
         attrs: dict[str, Any] = {
             "forecast_kw": self.coordinator.data.get("pv_forecast_kw", []),
+            "forecast_interval_minutes": self.coordinator.data.get(
+                "forecast_interval_minutes", 60
+            ),
         }
         dc_forecast = self.coordinator.data.get("pv_dc_forecast_kw", [])
         if dc_forecast and any(v > 0 for v in dc_forecast):
@@ -434,7 +437,12 @@ class ConsumptionForecastSensor(BatteryForecastSensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         if self.coordinator.data is None:
             return {}
-        return {"forecast_kw": self.coordinator.data.get("consumption_forecast_kw", [])}
+        return {
+            "forecast_kw": self.coordinator.data.get("consumption_forecast_kw", []),
+            "forecast_interval_minutes": self.coordinator.data.get(
+                "forecast_interval_minutes", 60
+            ),
+        }
 
 
 class NetGridForecastSensor(BatteryForecastSensor):
@@ -461,7 +469,12 @@ class NetGridForecastSensor(BatteryForecastSensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         if self.coordinator.data is None:
             return {}
-        return {"forecast_kw": self.coordinator.data.get("net_load_forecast_kw", [])}
+        return {
+            "forecast_kw": self.coordinator.data.get("net_load_forecast_kw", []),
+            "forecast_interval_minutes": self.coordinator.data.get(
+                "forecast_interval_minutes", 60
+            ),
+        }
 
 
 class SolarIrradianceSensor(BatteryForecastSensor):
@@ -801,7 +814,12 @@ class PVArrayForecastSensor(BatteryForecastSensor):
         if self.coordinator.data is None:
             return {}
         forecasts = self.coordinator.data.get("per_pv_array_forecasts", {})
-        return {"forecast_kw": forecasts.get(self._subentry_id, [])}
+        return {
+            "forecast_kw": forecasts.get(self._subentry_id, []),
+            "forecast_interval_minutes": self.coordinator.data.get(
+                "forecast_interval_minutes", 60
+            ),
+        }
 
 
 class BatteryControlModeSensor(BatteryControllerSensor):

--- a/docs/index.html
+++ b/docs/index.html
@@ -520,6 +520,30 @@ function chartPrices(id, priceFc, feedInFc, shadowPrice, modeArr, labels, priceM
   });
 }
 
+// Convert a forecast series between step intervals (minutes): repeat when
+// upsampling, average when downsampling. Mirrors helpers.resample_forecast.
+// Forecast-coordinator arrays are emitted at fc.forecast_interval_minutes
+// (15 for current integration versions, hourly in older diagnostics) and
+// must be converted to the schedule's step interval before charting.
+function resampleSeries(data, fromMin, toMin) {
+  if (!data || !data.length || !fromMin || !toMin || fromMin === toMin) return data || [];
+  if (fromMin % toMin === 0) {
+    const f = fromMin / toMin, out = [];
+    for (const v of data) for (let i = 0; i < f; i++) out.push(v);
+    return out;
+  }
+  if (toMin % fromMin === 0) {
+    const f = toMin / fromMin, out = [];
+    for (let i = 0; i + f <= data.length; i += f) {
+      let s = 0;
+      for (let j = 0; j < f; j++) s += data[i + j];
+      out.push(s / f);
+    }
+    return out;
+  }
+  return data;
+}
+
 function chartPv(id, pvFc, consumFc, pvDcFc, labels) {
   const net = pvFc.map((v,i) => v - (consumFc[i]||0));
   const datasets = [
@@ -835,9 +859,8 @@ function renderDiagnostics(raw) {
   // ── Charts
   const prices    = sched.price_forecast || [];
   const feedInFc  = sched.feed_in_price_forecast || null; // new field; null = use buy price
-  const pvFc      = sched.pv_forecast_kw || sched.pv_forecast || fc.pv_forecast_kw || [];
-  const consumFc  = sched.consumption_forecast_kw || sched.consumption_forecast || fc.consumption_forecast_kw || [];
-  const pvDcFc    = fc.pv_dc_forecast_kw || [];
+  const pvFcSched     = sched.pv_forecast_kw || sched.pv_forecast || [];
+  const consumFcSched = sched.consumption_forecast_kw || sched.consumption_forecast || [];
   const powerKw   = sched.power_schedule_kw || [];
   const modes     = sched.mode_schedule    || [];
   const socKwh    = sched.soc_schedule_kwh || [];
@@ -860,6 +883,18 @@ function renderDiagnostics(raw) {
   const labels   = resolvedStepTimes.length > 0
     ? resolvedStepTimes.map(t => t.includes('T') ? t.slice(5,16).replace('T',' ') : t)
     : timeLabels(prices.length, startIso, stepH);
+
+  // Forecast-coordinator series come at fc.forecast_interval_minutes (15 min
+  // for current versions, hourly in older diagnostics); convert them to the
+  // schedule's step interval so they index 1:1 with the chart labels.
+  const fcIntervalMin = fc.forecast_interval_minutes || 60;
+  const chartStepMin  = sched.price_interval
+    || Math.round((resolvedStepDurs[1] || resolvedStepDurs[0] || 0.25) * 60);
+  const pvFc     = pvFcSched.length     ? pvFcSched
+    : resampleSeries(fc.pv_forecast_kw || [], fcIntervalMin, chartStepMin);
+  const consumFc = consumFcSched.length ? consumFcSched
+    : resampleSeries(fc.consumption_forecast_kw || [], fcIntervalMin, chartStepMin);
+  const pvDcFc   = resampleSeries(fc.pv_dc_forecast_kw || [], fcIntervalMin, chartStepMin);
 
   if (powerKw.length > 0) chartSchedule('chart-schedule', powerKw, modes, socKwh, labels);
   if (prices.length   > 0) {
@@ -1158,8 +1193,11 @@ function prefillSim(d) {
       if (prices.length && pvFc.length && consumFc.length) break;
     }
   }
-  if (!pvFc.length)     pvFc     = fc.pv_forecast_kw  || [];
-  if (!consumFc.length) consumFc = fc.consumption_forecast_kw || [];
+  // Forecast-coordinator fallbacks are at fc.forecast_interval_minutes
+  // (15 min for current versions); convert to the simulator step interval.
+  const fcIntMin = fc.forecast_interval_minutes || 60;
+  if (!pvFc.length)     pvFc     = resampleSeries(fc.pv_forecast_kw || [], fcIntMin, Math.round(stepH * 60));
+  if (!consumFc.length) consumFc = resampleSeries(fc.consumption_forecast_kw || [], fcIntMin, Math.round(stepH * 60));
 
   const fixedFeedIn = opts.fixed_feed_in_price || 0.04;
   const feedInFcSim = sched.feed_in_price_forecast || null;

--- a/tests/test_coordinator_forecast.py
+++ b/tests/test_coordinator_forecast.py
@@ -209,10 +209,14 @@ async def test_async_update_data_no_weather_data(hass):
 
     result = await coord._async_update_data()
 
-    # Should succeed with zero PV forecast
+    # Should succeed with zero PV forecast at 15-min resolution: 48 hours of
+    # fallback radiation minus the steps already elapsed in the current hour.
     assert result is not None
-    assert result["pv_forecast_kw"] == [0.0] * 48
-    assert result["consumption_forecast_kw"] == [0.5] * 48
+    n = len(result["pv_forecast_kw"])
+    assert 48 * 4 - 3 <= n <= 48 * 4
+    assert result["pv_forecast_kw"] == [0.0] * n
+    assert result["consumption_forecast_kw"] == [0.5] * n
+    assert result["forecast_interval_minutes"] == 15
 
 
 @pytest.mark.asyncio
@@ -325,9 +329,9 @@ async def test_async_update_data_time_shifted_forecast(hass):
 
         result = await coord._async_update_data()
 
-    # Forecast was shifted by 2 hours, so 48-2=46 hours remain
+    # Forecast was shifted by 2 hours, so 48-2=46 hours remain (at 15-min steps)
     assert "pv_forecast_kw" in result
-    assert len(result["pv_forecast_kw"]) == 46
+    assert len(result["pv_forecast_kw"]) == 46 * 4
 
 
 @pytest.mark.asyncio
@@ -460,7 +464,8 @@ async def test_async_update_data_missing_weather_creates_issue(hass):
 
         result = await coord._async_update_data()
 
-    assert result["pv_forecast_kw"] == [0.0] * 48
+    assert result["pv_forecast_kw"] == [0.0] * len(result["pv_forecast_kw"])
+    assert len(result["pv_forecast_kw"]) >= 48 * 4 - 3
     mock_create_issue.assert_called_once()
 
 
@@ -689,14 +694,15 @@ async def test_async_update_data_clamps_negative_pv_outputs(hass):
         coord = ForecastCoordinator(hass, weather_coord, _minimal_config(pv_arrays))
         coord.net_load_model = MagicMock()
         coord.net_load_model.forecast = MagicMock(return_value=(None, [0.5, 0.5], None))
+        # 2 weather hours × 4 steps/hour = 8 forecast steps
         coord.pv_ac_models[0].forecast_from_radiation = MagicMock(
-            return_value=[-1.0, 0.2]
+            return_value=[-1.0] + [0.2] * 7
         )
 
         result = await coord._async_update_data()
 
-    assert result["pv_forecast_kw"] == [0.0, 0.2]
-    assert result["per_pv_array_forecasts"]["pv_ac_1"] == [0.0, 0.2]
+    assert result["pv_forecast_kw"] == [0.0] + [0.2] * 7
+    assert result["per_pv_array_forecasts"]["pv_ac_1"] == [0.0] + [0.2] * 7
 
 
 @pytest.mark.asyncio
@@ -740,11 +746,62 @@ async def test_async_update_data_without_subentry_id_omits_per_array_key(hass):
         coord = ForecastCoordinator(hass, weather_coord, _minimal_config(pv_arrays))
         coord.net_load_model = MagicMock()
         coord.net_load_model.forecast = MagicMock(return_value=(None, [0.5, 0.5], None))
+        # 2 weather hours × 4 steps/hour = 8 forecast steps
         coord.pv_ac_models[0].forecast_from_radiation = MagicMock(
-            return_value=[0.1, 0.2]
+            return_value=[0.1] * 4 + [0.2] * 4
         )
 
         result = await coord._async_update_data()
 
-    assert result["pv_forecast_kw"] == [0.1, 0.2]
+    assert result["pv_forecast_kw"] == [0.1] * 4 + [0.2] * 4
     assert result["per_pv_array_forecasts"] == {}
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_quarter_hour_alignment(hass):
+    """Forecast starts at the current quarter and expands hourly data per step."""
+    config = _minimal_config()
+
+    # 10:37 -> forecast must start at 10:30 (2 steps into the hour)
+    now = datetime(2024, 6, 15, 10, 37, 0, tzinfo=timezone.utc)
+    weather_data = {
+        "radiation_forecast": [100.0, 200.0],
+        "dni_forecast": [],
+        "diffuse_forecast": [],
+        "wind_speed_forecast": [3.0, 5.0],
+        "temperature_forecast": [],
+        "forecast_start_utc": datetime(2024, 6, 15, 10, 0, 0, tzinfo=timezone.utc),
+    }
+    weather_coord = MagicMock()
+    weather_coord.data = weather_data
+
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+            return_value=_make_mock_consumption(),
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.utcnow",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.now",
+            return_value=now,
+        ),
+    ):
+        coord = ForecastCoordinator(hass, weather_coord, config)
+        coord.net_load_model = MagicMock()
+        coord.net_load_model.forecast = MagicMock(return_value=(None, [0.4, 0.8], None))
+
+        result = await coord._async_update_data()
+
+    # 2 weather hours x 4 steps - 2 elapsed steps = 6 steps: 10:30..11:45
+    assert result["forecast_interval_minutes"] == 15
+    assert result["forecast_start_utc"] == datetime(
+        2024, 6, 15, 10, 30, 0, tzinfo=timezone.utc
+    )
+    assert len(result["consumption_forecast_kw"]) == 6
+    # First 2 steps belong to hour 10 (0.4), remaining 4 to hour 11 (0.8)
+    assert result["consumption_forecast_kw"] == [0.4, 0.4, 0.8, 0.8, 0.8, 0.8]
+    # current GHI reflects the current hour's radiation value
+    assert result["current_ghi_wm2"] == 100.0


### PR DESCRIPTION
## Description

The forecast pipeline previously produced hourly PV/consumption series that the optimization coordinator stretched to the price interval by repetition. With 15-minute price intervals this had two drawbacks:

1. **Misalignment**: forecast series started at the current *hour* while price steps start at the current *quarter*, shifting PV/consumption by up to 45 minutes at hour boundaries.
2. **No sub-hourly structure**: PV was flat within each hour, even though prices can differ per quarter.

This PR moves the forecast pipeline to a 15-minute base resolution (`FORECAST_INTERVAL_MINUTES = 15`), aligned to quarter-hour boundaries starting at the current step:

- Hourly weather input (open-meteo) is expanded by repetition (mean-preserving); solar geometry is evaluated per 15-minute timestamp, so dawn/dusk ramps gain sub-hourly shape even from hourly radiation data.
- Hourly consumption-pattern buckets are expanded the same way.
- Coordinator data gains `forecast_interval_minutes` and `forecast_start_utc`; the optimization coordinator resamples from the published interval (defaulting to 60 for data produced by older versions) to the price interval.
- Forecast sensors expose `forecast_interval_minutes` as an attribute; diagnostics include it; the analyzer (`docs/index.html`) converts forecast arrays to the schedule step interval before charting.
- `ALGORITHM.md` resampling section updated. The DP algorithm itself is unchanged (it is already interval-agnostic), so `analyzer.js` and `simulate_diagnostics.py` need no algorithmic changes.

This also lays the groundwork for consuming external PV forecast sources (e.g. Solcast, 30-minute data) at their native resolution — see the stacked follow-up PR.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [x] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable (704 passing, incl. new quarter-hour alignment test)
- [x] Documentation updated if needed (ALGORITHM.md, analyzer)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a