### PR TITLE
feat: support OMIE price sensors (today_hours/tomorrow_hours, €/MWh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ forecast:
 
 **Dynamic Energy Contract Calculator** — exposes `prices_today` and `prices_tomorrow` as plain lists of floats (one per hour), or a combined `price_forecast` list.
 
+**OMIE (Spain/Portugal)** — the [OMIE integration](https://github.com/luuuis/hass_omie) exposes `today_hours` and `tomorrow_hours` as dicts mapping period-start times to prices in **€/MWh**:
+```yaml
+today_hours:
+  "2026-03-16T00:00:00+00:00": 96.9
+  "2026-03-16T01:00:00+00:00": 85.2
+  ...
+tomorrow_hours: null   # published around 13:30 CET
+```
+Prices are converted to €/kWh automatically (based on the sensor's `unit_of_measurement`), provisional `null` entries are skipped, and the self-learning price model applies the same conversion to historical data. Quarter-hourly OMIE data is detected and used at its native 15-minute interval.
+
 If your sensor's state is the current price but its attributes contain no forecast list, the optimizer will run with a flat price forecast and cannot perform meaningful arbitrage. In that case use a different sensor or add the [Dynamic Energy Contract Calculator](https://github.com/bvweerd/dynamic_energy_contract_calculator) on top of your existing sensor.
 
 ### Via HACS (Recommended)

--- a/custom_components/battery_controller/forecast_models.py
+++ b/custom_components/battery_controller/forecast_models.py
@@ -10,7 +10,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_PV_ORIENTATION_DEG, DEFAULT_PV_TILT_DEG
-from .helpers import calculate_pv_forecast, calculate_consumption_pattern
+from .helpers import (
+    calculate_consumption_pattern,
+    calculate_pv_forecast,
+    price_unit_scale_from_state,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -533,6 +537,19 @@ class PriceForecastModel:
                     list(price_stats.keys())[:5] if price_stats else "none",
                 )
                 return
+
+            # Recorder statistics are in the sensor's native unit. Sensors
+            # publishing €/MWh (e.g. OMIE) must be scaled to EUR/kWh so the
+            # learned pattern matches the live forecast fed to the optimizer.
+            unit_scale = price_unit_scale_from_state(
+                self.hass.states.get(self.price_sensor_id)
+            )
+            if unit_scale != 1.0:
+                price_hourly = [(dt, p * unit_scale) for dt, p in price_hourly]
+                _LOGGER.debug(
+                    "Price model: scaling recorder prices by %s (sensor unit per MWh)",
+                    unit_scale,
+                )
 
             # Query weather sensor statistics if GHI/wind sensors exist
             # Key: UTC datetime rounded to hour → value for bin lookup

--- a/custom_components/battery_controller/helpers.py
+++ b/custom_components/battery_controller/helpers.py
@@ -81,6 +81,90 @@ def _skip_index_since_local_midnight(now_local: datetime, interval_minutes: int)
     return int(elapsed_min // interval_minutes)
 
 
+def price_unit_scale_from_state(state: State | None) -> float:
+    """Return the factor converting the sensor's prices to EUR/kWh.
+
+    Based on the sensor's unit_of_measurement: per-MWh units (e.g. the OMIE
+    integration's €/MWh) yield 0.001; per-kWh or unknown units yield 1.0.
+    """
+    if state is None:
+        return 1.0
+    unit = str(state.attributes.get("unit_of_measurement") or "").lower()
+    if "mwh" in unit:
+        return 0.001
+    return 1.0
+
+
+def _extract_hours_dict_forecast(
+    state: State, now: datetime
+) -> tuple[list[float], list[datetime], int] | None:
+    """Extract prices from OMIE-style hour-keyed dict attributes.
+
+    The OMIE integration (hass_omie) exposes ``today_hours`` and
+    ``tomorrow_hours``: dicts mapping period-start datetimes (or ISO strings)
+    to prices in €/MWh. ``tomorrow_hours`` is None before publication and
+    values are None while provisional — both are skipped.
+
+    Prices are converted to EUR/kWh using the sensor's unit_of_measurement;
+    when no unit is available, values with magnitude > 5 are assumed €/MWh
+    (kWh prices never reach that, MWh prices practically always do).
+
+    Returns:
+        (prices_eur_kwh, start_times_utc, interval_minutes), or None when the
+        sensor has no hour-dict attributes with usable data.
+    """
+    entries: dict[datetime, float] = {}
+    found_attr = False
+    for attr_key in ("today_hours", "tomorrow_hours"):
+        hours = state.attributes.get(attr_key)
+        if not isinstance(hours, dict):
+            continue
+        found_attr = True
+        for raw_ts, raw_price in hours.items():
+            price = _normalize_price_value(raw_price)
+            if price is None:
+                continue
+            if isinstance(raw_ts, datetime):
+                ts = raw_ts
+            elif isinstance(raw_ts, str):
+                parsed = dt_util.parse_datetime(raw_ts)
+                if parsed is None:
+                    continue
+                ts = parsed
+            else:
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=dt_util.UTC)
+            entries[dt_util.as_utc(ts)] = price
+
+    if not found_attr or not entries:
+        return None
+
+    sorted_ts = sorted(entries)
+    interval = 60
+    if len(sorted_ts) >= 2:
+        minutes = int((sorted_ts[1] - sorted_ts[0]).total_seconds() / 60)
+        if minutes in (15, 30, 60):
+            interval = minutes
+
+    scale = price_unit_scale_from_state(state)
+    if scale == 1.0 and not state.attributes.get("unit_of_measurement"):
+        if any(abs(v) > 5.0 for v in entries.values()):
+            scale = 0.001
+
+    prices: list[float] = []
+    start_times: list[datetime] = []
+    for ts in sorted_ts:
+        if ts + timedelta(minutes=interval) <= now:
+            continue
+        prices.append(entries[ts] * scale)
+        start_times.append(ts)
+
+    if not prices:
+        return None
+    return prices, start_times, interval
+
+
 def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int]:
     """Extract price forecast and detected interval from a Home Assistant price state.
 
@@ -165,6 +249,12 @@ def extract_price_forecast_with_interval(state: State) -> tuple[list[float], int
         _extend_interval_forecast(raw_tomorrow_list)
         if interval_forecast:
             return interval_forecast, detected_interval
+
+    # Priority 2.5: OMIE-style hour-keyed dicts (today_hours/tomorrow_hours)
+    hours_result = _extract_hours_dict_forecast(state, now)
+    if hours_result is not None:
+        hours_prices, _, hours_interval = hours_result
+        return hours_prices, hours_interval
 
     # Priority 3: forecast_prices (skip elapsed periods when entries carry
     # timestamps; plain value lists are taken as-is)
@@ -379,6 +469,11 @@ def extract_price_forecast_with_timestamps(
                 interval_timestamps, detected_interval, now
             )
             return interval_forecast, filled, detected_interval
+
+    # Priority 2.5: OMIE-style hour-keyed dicts (today_hours/tomorrow_hours)
+    hours_result = _extract_hours_dict_forecast(state, now)
+    if hours_result is not None:
+        return hours_result
 
     # Priority 3: forecast_prices — skip elapsed periods and keep real
     # timestamps when entries carry them; plain value lists are taken as-is

--- a/tests/test_forecast_models.py
+++ b/tests/test_forecast_models.py
@@ -1228,3 +1228,56 @@ class TestNetLoadForecastConsumptionPadded:
         # Padded with base_consumption_kw
         assert consumption_fc[2] == pytest.approx(0.5)
         assert consumption_fc[3] == pytest.approx(0.5)
+
+
+class TestPriceForecastModelUnitScaling:
+    """Recorder prices in €/MWh (e.g. OMIE) are scaled to EUR/kWh."""
+
+    _TS = "2024-01-01T10:00:00+00:00"
+
+    async def test_mwh_unit_scales_learned_prices(self):
+        hass = MagicMock()
+        live_state = MagicMock()
+        live_state.attributes = {"unit_of_measurement": "€/MWh"}
+        hass.states.get = MagicMock(return_value=live_state)
+
+        model = PriceForecastModel(
+            hass=hass, price_sensor_id="sensor.omie_spot_price_pt", entry_id=None
+        )
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(
+            return_value={
+                "sensor.omie_spot_price_pt": [{"start": self._TS, "mean": 85.0}]
+            }
+        )
+
+        with patch(
+            "homeassistant.components.recorder.util.get_instance",
+            return_value=mock_instance,
+        ):
+            await model.async_update_pattern()
+
+        assert model.has_data() is True
+        assert model._overall_avg == pytest.approx(0.085)
+
+    async def test_kwh_unit_not_scaled(self):
+        hass = MagicMock()
+        live_state = MagicMock()
+        live_state.attributes = {"unit_of_measurement": "EUR/kWh"}
+        hass.states.get = MagicMock(return_value=live_state)
+
+        model = PriceForecastModel(
+            hass=hass, price_sensor_id="sensor.price", entry_id=None
+        )
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(
+            return_value={"sensor.price": [{"start": self._TS, "mean": 0.25}]}
+        )
+
+        with patch(
+            "homeassistant.components.recorder.util.get_instance",
+            return_value=mock_instance,
+        ):
+            await model.async_update_pattern()
+
+        assert model._overall_avg == pytest.approx(0.25)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,7 @@
 """Tests for helpers.py."""
 
 import pytest
-from datetime import timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from custom_components.battery_controller.helpers import (
@@ -305,7 +305,6 @@ class TestExtractPriceForecast:
 
     def test_raw_today_15min_detects_interval(self):
         """raw_today with 15-min timestamps returns interval=15."""
-        from datetime import datetime
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
         raw_today = self._make_15min_raw_today(midnight, count=96)
@@ -331,7 +330,6 @@ class TestExtractPriceForecast:
 
     def test_raw_today_15min_excludes_past_prices(self):
         """raw_today at 15-min interval must not include elapsed periods."""
-        from datetime import datetime
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
         raw_today = self._make_15min_raw_today(midnight, count=96)
@@ -358,7 +356,6 @@ class TestExtractPriceForecast:
 
     def test_raw_today_15min_with_tomorrow(self):
         """raw_today + raw_tomorrow at 15-min interval are combined."""
-        from datetime import datetime
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
         tomorrow_midnight = midnight.replace(day=16)
@@ -387,7 +384,6 @@ class TestExtractPriceForecast:
 
     def test_raw_today_no_timestamps_uses_index_skip(self):
         """raw_today without timestamps falls back to index-based hour skip."""
-        from datetime import datetime
 
         # 24 plain-dict entries without timestamps
         raw_today = [{"value": float(i) * 0.01} for i in range(24)]
@@ -414,7 +410,7 @@ class TestExtractPriceForecast:
 
     def test_forecast_prices_15min_detects_interval(self):
         """forecast_prices with 15-min timestamps returns interval=15."""
-        from datetime import datetime, timedelta
+        from datetime import timedelta
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
         entries = [
@@ -432,7 +428,7 @@ class TestExtractPriceForecast:
 
     def test_extract_with_timestamps_15min_returns_correct_durations(self):
         """extract_price_forecast_with_timestamps returns interval=15 for 15-min data."""
-        from datetime import datetime, timedelta
+        from datetime import timedelta
         from custom_components.battery_controller.helpers import (
             compute_step_durations_hours,
         )
@@ -493,7 +489,7 @@ class TestSolarPositionAndPOA:
 
     def test_solar_elevation_summer_noon(self):
         """Sun elevation at solar noon in summer should be positive."""
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         # June 21, solar noon UTC at 52°N, 0°E (longitude 0 → solar time ≈ UTC)
         dt = datetime(2024, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
@@ -502,7 +498,7 @@ class TestSolarPositionAndPOA:
 
     def test_solar_elevation_midnight_negative(self):
         """Sun elevation at midnight should be negative."""
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         dt = datetime(2024, 6, 21, 0, 0, 0, tzinfo=timezone.utc)
         elev, _ = self._solar_position(dt, 52.0, 0.0)
@@ -510,7 +506,7 @@ class TestSolarPositionAndPOA:
 
     def test_solar_afternoon_azimuth_west(self):
         """Afternoon sun should be west of south (azimuth > 180°)."""
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         # 15:00 UTC at 52°N, 0°E
         dt = datetime(2024, 6, 21, 15, 0, 0, tzinfo=timezone.utc)
@@ -520,7 +516,7 @@ class TestSolarPositionAndPOA:
 
     def test_solar_zenith_returns_180_azimuth(self):
         """When sun is near zenith, azimuth should be 180 (fallback)."""
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         # Near-zenith: latitude = declination ~ 23.5°N at summer solstice, local noon
         dt = datetime(2024, 6, 21, 11, 0, 0, tzinfo=timezone.utc)
@@ -565,7 +561,7 @@ class TestCalculatePvForecastWithPOA:
 
     def test_poa_model_used_when_all_params_provided(self):
         """POA path is used when dni, diffuse, timestamps, lat, lon all provided."""
-        from datetime import datetime, timedelta, timezone
+        from datetime import timedelta, timezone
 
         from custom_components.battery_controller.helpers import calculate_pv_forecast
 
@@ -594,7 +590,7 @@ class TestCalculatePvForecastWithPOA:
 
     def test_poa_model_out_of_bounds_appends_zero(self):
         """When timestamps list is shorter than radiation, zeros are appended."""
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         from custom_components.battery_controller.helpers import calculate_pv_forecast
 
@@ -683,7 +679,7 @@ class TestExtractPriceForecastWithTimestamps:
 
     def test_net_prices_today_with_timestamps(self):
         """net_prices_today with timestamps returns prices and timestamps."""
-        from datetime import datetime, timedelta, timezone
+        from datetime import timedelta, timezone
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
         entries = [
@@ -752,7 +748,6 @@ class TestExtractPriceForecastWithTimestamps:
 
     def test_raw_today_no_timestamps_index_skip(self):
         """raw_today without timestamps gets synthesized timestamps."""
-        from datetime import datetime
         from unittest.mock import patch
 
         raw_today = [{"value": float(i) * 0.01} for i in range(24)]
@@ -841,7 +836,7 @@ class TestDetectIntervalWithDatetimeStart:
 
     def test_datetime_start_in_entries_detects_15min(self):
         """Entries with datetime (not string) start fields are detected."""
-        from datetime import datetime, timedelta, timezone
+        from datetime import timedelta, timezone
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
         entries = [
@@ -868,7 +863,7 @@ class TestNetPricesTodayPath:
 
     def test_net_prices_today_with_datetime_start(self):
         """net_prices_today with datetime start hits lines 113-114 and returns via 129."""
-        from datetime import datetime, timedelta, timezone
+        from datetime import timedelta, timezone
         from unittest.mock import patch
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
@@ -901,7 +896,7 @@ class TestNetPricesTodayPath:
 
     def test_net_prices_today_only_string_timestamps(self):
         """net_prices_today with ISO string timestamps returns via line 129."""
-        from datetime import datetime, timedelta, timezone
+        from datetime import timedelta, timezone
         from unittest.mock import patch
 
         midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
@@ -991,7 +986,7 @@ class TestExtendWithTimestampsDatetimeBranch:
 
     def test_datetime_start_in_net_prices_today_with_timestamps(self):
         """net_prices_today with datetime start objects hits lines 304-305."""
-        from datetime import datetime, timedelta, timezone
+        from datetime import timedelta, timezone
         from unittest.mock import MagicMock, patch
         from custom_components.battery_controller.helpers import (
             extract_price_forecast_with_timestamps,
@@ -1031,7 +1026,7 @@ class TestRawTomorrowInPriority5WithTimestamps:
 
     def test_raw_tomorrow_appended_in_priority5(self):
         """raw_tomorrow without timestamps is appended in extract_price_forecast_with_timestamps."""
-        from datetime import datetime, timezone
+        from datetime import timezone
         from unittest.mock import MagicMock, patch
         from custom_components.battery_controller.helpers import (
             extract_price_forecast_with_timestamps,
@@ -1067,7 +1062,7 @@ class TestTodayTomorrowWithTimestamps:
 
     def test_today_tomorrow_combined_with_timestamps(self):
         """today + tomorrow attributes are combined in extract_price_forecast_with_timestamps."""
-        from datetime import datetime, timezone
+        from datetime import timezone
         from unittest.mock import MagicMock, patch
         from custom_components.battery_controller.helpers import (
             extract_price_forecast_with_timestamps,
@@ -1103,7 +1098,7 @@ class TestComputeStepDurationsSingleEntry:
 
     def test_single_start_time_returns_full_interval(self):
         """A single-entry start_times list returns [full_h]."""
-        from datetime import datetime, timezone
+        from datetime import timezone
         from custom_components.battery_controller.helpers import (
             compute_step_durations_hours,
         )
@@ -1114,7 +1109,7 @@ class TestComputeStepDurationsSingleEntry:
 
     def test_empty_start_times_returns_empty(self):
         """Empty start_times returns []."""
-        from datetime import datetime, timezone
+        from datetime import timezone
         from custom_components.battery_controller.helpers import (
             compute_step_durations_hours,
         )
@@ -1130,7 +1125,7 @@ class TestSolarPositionZenith:
     def test_zenith_azimuth_fallback(self):
         """When elevation = 90°, azimuth returns 180° (the undefined zenith fallback)."""
         import math
-        from datetime import datetime, timezone
+        from datetime import timezone
         from unittest.mock import patch
         import custom_components.battery_controller.helpers as helpers_mod
         from custom_components.battery_controller.helpers import _solar_position
@@ -1159,7 +1154,7 @@ class TestForecastSkipPast:
         ]
 
     def test_forecast_prices_skips_elapsed_periods(self, monkeypatch):
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         from custom_components.battery_controller import helpers as h
 
@@ -1179,7 +1174,7 @@ class TestForecastSkipPast:
         assert starts[0] == now
 
     def test_generic_forecast_skips_elapsed_periods(self, monkeypatch):
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         from custom_components.battery_controller import helpers as h
 
@@ -1194,7 +1189,7 @@ class TestForecastSkipPast:
         assert prices == [0.12, 0.13]
 
     def test_plain_value_lists_unchanged(self, monkeypatch):
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         from custom_components.battery_controller import helpers as h
 
@@ -1215,7 +1210,6 @@ class TestDstSafeSkipIndex:
     def test_25_hour_day_skips_correct_entries(self, monkeypatch):
         """On the DST fall-back day, raw_today has 25 entries; wall-clock 04:30
         is 5.5 elapsed hours, so 5 entries must be skipped (not 4)."""
-        from datetime import datetime
         from zoneinfo import ZoneInfo
 
         from custom_components.battery_controller import helpers as h
@@ -1237,7 +1231,6 @@ class TestDstSafeSkipIndex:
         assert forecast[0] == 5.0
 
     def test_skip_index_helper_normal_day(self):
-        from datetime import datetime
         from zoneinfo import ZoneInfo
 
         from custom_components.battery_controller.helpers import (
@@ -1248,3 +1241,170 @@ class TestDstSafeSkipIndex:
         now_local = datetime(2026, 6, 10, 15, 47, tzinfo=tz)
         assert _skip_index_since_local_midnight(now_local, 60) == 15
         assert _skip_index_since_local_midnight(now_local, 15) == 63
+
+
+class TestOmieHoursDictExtraction:
+    """Tests for OMIE-style today_hours/tomorrow_hours dict attributes."""
+
+    def _make_state(self, attributes=None, state_value="85.0"):
+        state = MagicMock()
+        state.state = state_value
+        state.attributes = attributes or {}
+        return state
+
+    def _hours(self, start, count, base_price, step_minutes=60):
+        """Build an OMIE-style dict: datetime keys -> €/MWh prices."""
+        return {
+            start + timedelta(minutes=step_minutes * i): base_price + i
+            for i in range(count)
+        }
+
+    def test_today_hours_mwh_converted_and_past_skipped(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        now_hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        # 2 past hours + current + 3 future hours, 100..105 €/MWh
+        state = self._make_state(
+            {
+                "unit_of_measurement": "€/MWh",
+                "today_hours": self._hours(now_hour - timedelta(hours=2), 6, 100.0),
+                "tomorrow_hours": None,
+            }
+        )
+        prices, interval = extract_price_forecast_with_interval(state)
+        assert interval == 60
+        # Past hours (100, 101 €/MWh) skipped; current hour first: 102 €/MWh
+        assert prices[0] == pytest.approx(0.102)
+        assert prices == pytest.approx([0.102, 0.103, 0.104, 0.105])
+
+    def test_tomorrow_hours_appended(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        now_hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        state = self._make_state(
+            {
+                "unit_of_measurement": "EUR/MWh",
+                "today_hours": self._hours(now_hour, 2, 50.0),
+                "tomorrow_hours": self._hours(now_hour + timedelta(hours=2), 2, 80.0),
+            }
+        )
+        prices, interval = extract_price_forecast_with_interval(state)
+        assert prices == pytest.approx([0.050, 0.051, 0.080, 0.081])
+
+    def test_none_values_skipped(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        now_hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        hours = self._hours(now_hour, 3, 60.0)
+        hours[now_hour + timedelta(hours=1)] = None  # provisional entry
+        state = self._make_state({"unit_of_measurement": "€/MWh", "today_hours": hours})
+        prices, _ = extract_price_forecast_with_interval(state)
+        assert prices == pytest.approx([0.060, 0.062])
+
+    def test_string_keys_parsed(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        now_hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        state = self._make_state(
+            {
+                "unit_of_measurement": "€/MWh",
+                "today_hours": {
+                    (now_hour + timedelta(hours=i)).isoformat(): 100.0 + i
+                    for i in range(3)
+                },
+            }
+        )
+        prices, _ = extract_price_forecast_with_interval(state)
+        assert prices == pytest.approx([0.100, 0.101, 0.102])
+
+    def test_quarter_hour_keys_detect_15min_interval(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_timestamps,
+        )
+
+        now = dt_util.utcnow()
+        now_quarter = now.replace(
+            minute=(now.minute // 15) * 15, second=0, microsecond=0
+        )
+        state = self._make_state(
+            {
+                "unit_of_measurement": "€/MWh",
+                "today_hours": self._hours(now_quarter, 4, 90.0, step_minutes=15),
+            }
+        )
+        prices, start_times, interval = extract_price_forecast_with_timestamps(state)
+        assert interval == 15
+        assert prices == pytest.approx([0.090, 0.091, 0.092, 0.093])
+        assert start_times[0] == now_quarter
+
+    def test_no_unit_heuristic_detects_mwh_scale(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        now_hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        state = self._make_state({"today_hours": self._hours(now_hour, 2, 100.0)})
+        prices, _ = extract_price_forecast_with_interval(state)
+        assert prices == pytest.approx([0.100, 0.101])
+
+    def test_no_unit_kwh_scale_values_unchanged(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        now_hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        state = self._make_state(
+            {
+                "today_hours": {
+                    now_hour: 0.10,
+                    now_hour + timedelta(hours=1): 0.25,
+                }
+            }
+        )
+        prices, _ = extract_price_forecast_with_interval(state)
+        assert prices == pytest.approx([0.10, 0.25])
+
+    def test_kwh_unit_never_scaled(self):
+        from homeassistant.util import dt as dt_util
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        now_hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        # Extreme kWh price spike must not trigger the MWh heuristic when
+        # the sensor explicitly declares a per-kWh unit
+        state = self._make_state(
+            {
+                "unit_of_measurement": "EUR/kWh",
+                "today_hours": {now_hour: 6.0},
+            }
+        )
+        prices, _ = extract_price_forecast_with_interval(state)
+        assert prices == pytest.approx([6.0])
+
+    def test_empty_dicts_fall_through_to_state(self):
+        from custom_components.battery_controller.helpers import (
+            extract_price_forecast_with_interval,
+        )
+
+        state = self._make_state(
+            {"today_hours": {}, "tomorrow_hours": None}, state_value="0.12"
+        )
+        prices, _ = extract_price_forecast_with_interval(state)
+        # Falls through to current-state fallback
+        assert prices == [0.12]


### PR DESCRIPTION
## Description

The [OMIE integration](https://github.com/luuuis/hass_omie) exposes Iberian day-ahead prices as `today_hours`/`tomorrow_hours` dict attributes (period-start datetime → price in **€/MWh**) — a format the price parser did not recognise. OMIE users therefore silently fell back to the historical price model or a flat current-price forecast (visible as `price_forecast_source: historical_model`/`current_only` on the Optimization Status sensor).

This PR adds first-class OMIE support, independent of the PV forecast work (#104/#105):

- **Parser**: a new priority in both `extract_price_forecast_with_interval` and `extract_price_forecast_with_timestamps` reads hour-keyed dict attributes. Datetime and ISO-string keys are accepted, provisional `None` values and an unpublished `tomorrow_hours` are skipped, the 15/30/60-minute interval is detected from key spacing (OMIE is quarter-hourly since the SDAC 15-minute switch), and elapsed periods are excluded.
- **Unit handling**: prices are converted to €/kWh based on the sensor's `unit_of_measurement` (per-MWh → ×0.001). When no unit is available, a magnitude heuristic applies (|price| > 5 → assume €/MWh); an explicit per-kWh unit always disables scaling.
- **Historical price model**: `PriceForecastModel` applies the same unit conversion to recorder statistics, so the pre-day-ahead fallback and horizon extension stay in the same unit as the live forecast — without this, mixing model-extended hours with live OMIE prices would be off by a factor 1000.
- **README**: documents the OMIE sensor format and the automatic conversion.

How to verify ingestion after this change: the Optimization Status sensor's `price_forecast_source` attribute should read `live` (or `live+historical_model`), and the Schedule sensor's `grid_price_forecast` should show €/kWh values matching OMIE ÷ 1000.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [x] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable (714 passing; 9 new parser tests + 2 price-model unit-scaling tests)
- [x] Documentation updated if needed (README)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a