### PR TITLE
fix: run DP optimizer in dedicated process pool to avoid GIL blocking

### DIFF
--- a/custom_components/battery_controller/_optimizer_worker.py
+++ b/custom_components/battery_controller/_optimizer_worker.py
@@ -1,0 +1,98 @@
+"""Standalone subprocess worker for the DP optimizer.
+
+Invoked by the OptimizationCoordinator via :func:`subprocess.run`.  Reads
+a JSON request from stdin, runs the dynamic-programming optimizer, and
+writes a JSON response to stdout.
+
+NO PICKLING — all data crosses the process boundary as plain JSON, so the
+subprocess interpreter does not need custom_components to be importable at
+startup.  It only needs ``sys.path`` to include the parent directory of
+``custom_components``, which the coordinator guarantees by setting the
+``PYTHONPATH`` environment variable before spawning.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+
+
+def _main() -> None:
+    """Read JSON request from stdin, run optimizer, write JSON result to stdout."""
+    try:
+        request_raw = sys.stdin.read()
+        request = json.loads(request_raw)
+    except Exception:
+        _fail("Failed to parse JSON request")
+
+    try:
+        result = _run(request)
+    except Exception:
+        result = {
+            "error": True,
+            "traceback": traceback.format_exc(),
+        }
+
+    json.dump(result, sys.stdout)
+    sys.stdout.flush()
+
+
+def _fail(message: str) -> None:
+    """Write an error response and exit."""
+    json.dump({"error": True, "message": message}, sys.stdout)
+    sys.stdout.flush()
+    sys.exit(1)
+
+
+def _run(request: dict) -> dict:
+    """Execute the DP optimizer from a JSON request dict.
+
+    Imports are done here (not at module level) so that the script can
+    start and parse its request even if custom_components is not yet on
+    sys.path.  The coordinator guarantees PYTHONPATH is set before
+    spawning, so by the time we reach this function the path is available.
+    """
+    from custom_components.battery_controller.battery_model import BatteryConfig
+    from custom_components.battery_controller.optimizer import (
+        OptimizationResult,
+        optimize_battery_schedule,
+    )
+    import dataclasses
+
+    # Reconstruct BatteryConfig, passing only init=True fields.
+    init_fields = {f.name for f in dataclasses.fields(BatteryConfig) if f.init}
+    battery_config = BatteryConfig(
+        **{k: v for k, v in request["battery_config"].items() if k in init_fields}
+    )
+
+    result: OptimizationResult = optimize_battery_schedule(
+        battery_config=battery_config,
+        current_soc_kwh=request["current_soc_kwh"],
+        price_forecast=request["price_forecast"],
+        feed_in_forecast=request.get("feed_in_forecast"),
+        pv_forecast=request["pv_forecast"],
+        consumption_forecast=request["consumption_forecast"],
+        step_durations_hours=request.get("step_durations_hours"),
+        degradation_cost_per_kwh=request["degradation_cost_per_kwh"],
+        min_price_spread=request["min_price_spread"],
+        pv_dc_forecast=request.get("pv_dc_forecast"),
+        charge_eff_override=request.get("charge_eff_override"),
+        discharge_eff_override=request.get("discharge_eff_override"),
+    )
+
+    return dataclasses.asdict(result)
+
+
+if __name__ == "__main__":
+    # The script lives in …/battery_controller/, which contains files like
+    # ``select.py`` and ``__init__.py``.  Python prepends this directory to
+    # sys.path, and it may also leak in via PYTHONPATH or .pth files.
+    # ``import select`` (triggered transitively by homeassistant →
+    # asyncio → subprocess) must find the stdlib module, not our select.py.
+    # Strip *all* sys.path entries that resolve to this script's directory.
+    import os as __os
+    _bad = __os.path.realpath(__os.path.dirname(__file__))
+    sys.path = [p for p in sys.path if __os.path.realpath(p) != _bad]
+    del __os
+    _main()

--- a/custom_components/battery_controller/_optimizer_worker.py
+++ b/custom_components/battery_controller/_optimizer_worker.py
@@ -1,69 +1,60 @@
 """Standalone subprocess worker for the DP optimizer.
 
-Invoked by the OptimizationCoordinator via :func:`subprocess.run`.  Reads
-a JSON request from stdin, runs the dynamic-programming optimizer, and
-writes a JSON response to stdout.
+Run by the coordinator as::
 
-NO PICKLING — all data crosses the process boundary as plain JSON, so the
-subprocess interpreter does not need custom_components to be importable at
-startup.  It only needs ``sys.path`` to include the parent directory of
-``custom_components``, which the coordinator guarantees by setting the
-``PYTHONPATH`` environment variable before spawning.
+    python -m custom_components.battery_controller._optimizer_worker
+
+with ``cwd`` set to the HA config directory.  Python then adds the config
+directory to ``sys.path[0]``, making ``custom_components`` natively
+importable without any ``PYTHONPATH`` manipulation — and keeping the
+``battery_controller`` subdirectory *off* ``sys.path`` so its files (e.g.
+``select.py``) cannot shadow stdlib modules.
+
+Reads a JSON request from stdin, runs the DP optimizer, writes a JSON
+response to stdout.  No pickling — all data crosses the process boundary
+as plain text.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import sys
 import traceback
+
+from custom_components.battery_controller.battery_model import BatteryConfig
+from custom_components.battery_controller.optimizer import (
+    OptimizationResult,
+    optimize_battery_schedule,
+)
+
+_BATTERY_CONFIG_INIT_FIELDS = frozenset(
+    f.name for f in dataclasses.fields(BatteryConfig) if f.init
+)
 
 
 def _main() -> None:
     """Read JSON request from stdin, run optimizer, write JSON result to stdout."""
     try:
-        request_raw = sys.stdin.read()
-        request = json.loads(request_raw)
+        request = json.loads(sys.stdin.read())
     except Exception:
-        _fail("Failed to parse JSON request")
+        json.dump({"error": True, "message": "Failed to parse JSON request"}, sys.stdout)
+        sys.stdout.flush()
+        sys.exit(1)
 
     try:
         result = _run(request)
     except Exception:
-        result = {
-            "error": True,
-            "traceback": traceback.format_exc(),
-        }
+        result = {"error": True, "traceback": traceback.format_exc()}
 
     json.dump(result, sys.stdout)
     sys.stdout.flush()
 
 
-def _fail(message: str) -> None:
-    """Write an error response and exit."""
-    json.dump({"error": True, "message": message}, sys.stdout)
-    sys.stdout.flush()
-    sys.exit(1)
-
-
 def _run(request: dict) -> dict:
-    """Execute the DP optimizer from a JSON request dict.
-
-    Imports are done here (not at module level) so that the script can
-    start and parse its request even if custom_components is not yet on
-    sys.path.  The coordinator guarantees PYTHONPATH is set before
-    spawning, so by the time we reach this function the path is available.
-    """
-    from custom_components.battery_controller.battery_model import BatteryConfig
-    from custom_components.battery_controller.optimizer import (
-        OptimizationResult,
-        optimize_battery_schedule,
-    )
-    import dataclasses
-
-    # Reconstruct BatteryConfig, passing only init=True fields.
-    init_fields = {f.name for f in dataclasses.fields(BatteryConfig) if f.init}
+    """Execute the DP optimizer from a JSON request dict."""
     battery_config = BatteryConfig(
-        **{k: v for k, v in request["battery_config"].items() if k in init_fields}
+        **{k: v for k, v in request["battery_config"].items() if k in _BATTERY_CONFIG_INIT_FIELDS}
     )
 
     result: OptimizationResult = optimize_battery_schedule(
@@ -85,14 +76,4 @@ def _run(request: dict) -> dict:
 
 
 if __name__ == "__main__":
-    # The script lives in …/battery_controller/, which contains files like
-    # ``select.py`` and ``__init__.py``.  Python prepends this directory to
-    # sys.path, and it may also leak in via PYTHONPATH or .pth files.
-    # ``import select`` (triggered transitively by homeassistant →
-    # asyncio → subprocess) must find the stdlib module, not our select.py.
-    # Strip *all* sys.path entries that resolve to this script's directory.
-    import os as __os
-    _bad = __os.path.realpath(__os.path.dirname(__file__))
-    sys.path = [p for p in sys.path if __os.path.realpath(p) != _bad]
-    del __os
     _main()

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -305,8 +305,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             hass, 1, f"battery_controller_{entry_id}_discharge_eff"
         )
 
-        # Dedicated process-pool executor for the DP optimizer, to avoid disturbing HA main process. 
-
+        # Dedicated process-pool executor for the DP optimizer, so the
+        # CPU-bound DP does not contend with the HA event loop.
         self._process_pool: concurrent.futures.ProcessPoolExecutor | None = None
 
     @property

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
 import logging
+import os
+import subprocess
+import sys
 import math
 from collections import deque
 from datetime import datetime, timedelta
@@ -1824,16 +1828,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         waits for the subprocess to finish while the actual CPU work happens
         in a completely separate interpreter.
 
-        NO PICKLING — all data crossing the process boundary is plain JSON,
-        so the subprocess does not need ``custom_components`` on its import
-        path at startup.  ``PYTHONPATH`` is set in the subprocess environment
-        to guarantee that the worker script can import the optimizer.
+        NO PICKLING — all data crosses the process boundary as plain JSON.
+        The worker runs via ``python -m`` with cwd=config_dir so
+        ``custom_components`` is natively on the worker's sys.path.
         """
-        import json
-        import os
-        import subprocess
-        import sys
-
         # Build the JSON request payload — only Python primitives.
         request = {
             "battery_config": dataclasses.asdict(battery_config),
@@ -1851,28 +1849,20 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         }
         json_payload = json.dumps(request)
 
-        # Compute the paths needed in the subprocess.
-        _pkg_dir = os.path.dirname(os.path.abspath(__file__))  # …/battery_controller
-        _cc_dir = os.path.dirname(_pkg_dir)  # …/custom_components
-        _parent = os.path.dirname(_cc_dir)  # must be on sys.path
-        _worker_path = os.path.join(_pkg_dir, "_optimizer_worker.py")
-
-        # Inject _parent into PYTHONPATH for the subprocess.
-        env = os.environ.copy()
-        existing = env.get("PYTHONPATH", "")
-        entries = existing.split(os.pathsep) if existing else []
-        if _parent not in entries:
-            entries.insert(0, _parent)
-        env["PYTHONPATH"] = os.pathsep.join(entries)
+        # Run the worker as a module from the HA config directory.
+        # Python sets sys.path[0] = cwd, so custom_components is natively
+        # importable with no PYTHONPATH manipulation, and battery_controller/
+        # is never on sys.path so its files cannot shadow stdlib modules.
+        _config_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
         def _run_in_subprocess() -> dict:
             """Launch the worker and return its JSON response dict."""
             proc = subprocess.run(
-                [sys.executable, "-u", _worker_path],
+                [sys.executable, "-m", "custom_components.battery_controller._optimizer_worker"],
                 input=json_payload,
                 capture_output=True,
                 text=True,
-                env=env,
+                cwd=_config_dir,
             )
             if proc.returncode != 0:
                 _LOGGER.error(

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
+import dataclasses
 import logging
 import math
 from collections import deque
@@ -72,7 +72,7 @@ from .helpers import (
     get_sensor_value,
     resample_forecast,
 )
-from .optimizer import optimize_battery_schedule, OptimizationResult
+from .optimizer import OptimizationResult
 from .zero_grid_controller import create_zero_grid_controller
 
 _LOGGER = logging.getLogger(__name__)
@@ -304,10 +304,6 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._discharge_eff_store: storage.Store[dict[str, Any]] = storage.Store(
             hass, 1, f"battery_controller_{entry_id}_discharge_eff"
         )
-
-        # Dedicated process-pool executor for the DP optimizer, so the
-        # CPU-bound DP does not contend with the HA event loop.
-        self._process_pool: concurrent.futures.ProcessPoolExecutor | None = None
 
     @property
     def control_mode(self) -> str:
@@ -1063,9 +1059,6 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if self._unsub_realtime:
             self._unsub_realtime()
             self._unsub_realtime = None
-        if self._process_pool:
-            self._process_pool.shutdown(wait=False, cancel_futures=True)
-            self._process_pool = None
         await super().async_shutdown()
 
     def _read_battery_state(
@@ -1808,67 +1801,100 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if changed:
             self.hass.async_create_task(self._async_save_discharge_eff_calibration())
 
-    def _get_process_pool(self) -> concurrent.futures.ProcessPoolExecutor | None:
-        """Return (and lazily create) the dedicated process pool for the DP optimizer.
-
-        The pool is a single-worker ProcessPoolExecutor so the CPU-bound DP
-        runs in a completely separate Python interpreter, eliminating GIL
-        contention with the main event loop.
-
-        Uses the 'spawn' context: forking HA's heavily multi-threaded
-        process can clone locks held by other parent threads (logging,
-        SSL, malloc arenas) and deadlock the child before it reaches
-        user code — Python 3.12+ warns on fork-with-threads. Spawn
-        starts a fresh interpreter instead; multiprocessing passes the
-        parent's sys.path to the child, so the optimizer import
-        resolves there.
-
-        Returns None when the pool cannot be created (e.g. restricted
-        container); callers must fall back to the default thread-pool
-        executor in that case.
-        """
-        if self._process_pool is None:
-            try:
-                import multiprocessing
-
-                ctx = multiprocessing.get_context("spawn")
-                self._process_pool = concurrent.futures.ProcessPoolExecutor(
-                    max_workers=1, mp_context=ctx
-                )
-                _LOGGER.info("Created process-pool executor for DP optimization")
-            except Exception as exc:
-                _LOGGER.warning(
-                    "Could not create process-pool executor (%s); "
-                    "falling back to thread pool (GIL contention may occur)",
-                    exc,
-                )
-                self._process_pool = None
-        return self._process_pool
-
     async def _run_optimization_in_executor(
         self,
-        *args: Any,
-    ) -> Any:
-        """Run optimize_battery_schedule in the best available executor.
+        battery_config: BatteryConfig,
+        current_soc_kwh: float,
+        price_forecast: list[float],
+        feed_in_forecast: list[float] | None,
+        pv_forecast: list[float],
+        consumption_forecast: list[float],
+        step_durations_hours: list[float] | None,
+        degradation_cost_per_kwh: float,
+        min_price_spread: float,
+        pv_dc_forecast: list[float] | None,
+        charge_eff_override: float | None,
+        discharge_eff_override: float | None,
+    ) -> OptimizationResult:
+        """Run the DP optimizer in a subprocess to avoid GIL contention.
 
-        Prefers the dedicated process pool (no GIL contention). Falls back
-        to the default thread-pool executor when the process pool is not
-        available or breaks at submit time — worker start-up failures only
-        surface on first use, not at pool construction.
+        Launches ``_optimizer_worker.py`` as a standalone Python process with
+        JSON over stdin/stdout.  ``subprocess.run`` is offloaded to HA's
+        thread pool so the event loop is never blocked — the thread just
+        waits for the subprocess to finish while the actual CPU work happens
+        in a completely separate interpreter.
+
+        NO PICKLING — all data crossing the process boundary is plain JSON,
+        so the subprocess does not need ``custom_components`` on its import
+        path at startup.  ``PYTHONPATH`` is set in the subprocess environment
+        to guarantee that the worker script can import the optimizer.
         """
-        pool = self._get_process_pool()
-        if pool is not None:
-            try:
-                return await self.hass.loop.run_in_executor(pool, *args)
-            except concurrent.futures.process.BrokenProcessPool as exc:
-                _LOGGER.warning(
-                    "Process-pool executor broke (%s); falling back to the "
-                    "thread pool for this run",
-                    exc,
+        import json
+        import os
+        import subprocess
+        import sys
+
+        # Build the JSON request payload — only Python primitives.
+        request = {
+            "battery_config": dataclasses.asdict(battery_config),
+            "current_soc_kwh": current_soc_kwh,
+            "price_forecast": price_forecast,
+            "feed_in_forecast": feed_in_forecast,
+            "pv_forecast": pv_forecast,
+            "consumption_forecast": consumption_forecast,
+            "step_durations_hours": step_durations_hours,
+            "degradation_cost_per_kwh": degradation_cost_per_kwh,
+            "min_price_spread": min_price_spread,
+            "pv_dc_forecast": pv_dc_forecast,
+            "charge_eff_override": charge_eff_override,
+            "discharge_eff_override": discharge_eff_override,
+        }
+        json_payload = json.dumps(request)
+
+        # Compute the paths needed in the subprocess.
+        _pkg_dir = os.path.dirname(os.path.abspath(__file__))  # …/battery_controller
+        _cc_dir = os.path.dirname(_pkg_dir)  # …/custom_components
+        _parent = os.path.dirname(_cc_dir)  # must be on sys.path
+        _worker_path = os.path.join(_pkg_dir, "_optimizer_worker.py")
+
+        # Inject _parent into PYTHONPATH for the subprocess.
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH", "")
+        entries = existing.split(os.pathsep) if existing else []
+        if _parent not in entries:
+            entries.insert(0, _parent)
+        env["PYTHONPATH"] = os.pathsep.join(entries)
+
+        def _run_in_subprocess() -> dict:
+            """Launch the worker and return its JSON response dict."""
+            proc = subprocess.run(
+                [sys.executable, "-u", _worker_path],
+                input=json_payload,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            if proc.returncode != 0:
+                _LOGGER.error(
+                    "Optimizer worker failed (rc=%d): %s",
+                    proc.returncode,
+                    proc.stderr.strip() if proc.stderr else "(no stderr)",
                 )
-                pool.shutdown(wait=False)
-                self._process_pool = None
-        return await self.hass.async_add_executor_job(*args)
+            result: dict = json.loads(proc.stdout)
+            if result.get("error"):
+                tb = result.get("traceback", "unknown error")
+                _LOGGER.error("Optimizer worker error:\n%s", tb)
+                raise RuntimeError(f"Optimizer worker failed: {tb[:200]}")
+            return result
+
+        # Offload subprocess.run to a thread so the event loop is never blocked.
+        # The thread waits on I/O (GIL is released); the CPU work is done in
+        # the subprocess interpreter.
+        result_dict = await self.hass.async_add_executor_job(_run_in_subprocess)
+
+        # Reconstruct OptimizationResult from the plain dict.
+        init_fields = {f.name for f in dataclasses.fields(OptimizationResult) if f.init}
+        return OptimizationResult(**{k: v for k, v in result_dict.items() if k in init_fields})
 
     async def _run_optimization(self) -> dict[str, Any]:
         """Inner optimization logic (called only when not already running)."""
@@ -2333,11 +2359,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             degradation_cost / (2 * usable_kwh) if usable_kwh > 0 else degradation_cost
         )
 
-        # Run the DP optimization in the best available executor.
-        # Prefers a dedicated process pool; falls back
-        # to the default thread-pool executor when necessary.
+        # Run the DP optimizer in a subprocess to avoid GIL contention.
         result = await self._run_optimization_in_executor(
-            optimize_battery_schedule,
             battery_config,
             battery_state.soc_kwh,
             resampled_prices,

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 import math
 from collections import deque
@@ -303,6 +304,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._discharge_eff_store: storage.Store[dict[str, Any]] = storage.Store(
             hass, 1, f"battery_controller_{entry_id}_discharge_eff"
         )
+
+        # Dedicated process-pool executor for the DP optimizer, to avoid disturbing HA main process. 
+
+        self._process_pool: concurrent.futures.ProcessPoolExecutor | None = None
 
     @property
     def control_mode(self) -> str:
@@ -1058,6 +1063,9 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if self._unsub_realtime:
             self._unsub_realtime()
             self._unsub_realtime = None
+        if self._process_pool:
+            self._process_pool.shutdown(wait=False)
+            self._process_pool = None
         await super().async_shutdown()
 
     def _read_battery_state(
@@ -1800,6 +1808,58 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if changed:
             self.hass.async_create_task(self._async_save_discharge_eff_calibration())
 
+    def _get_process_pool(self) -> concurrent.futures.ProcessPoolExecutor | None:
+        """Return (and lazily create) the dedicated process pool for the DP optimizer.
+
+        The pool is a single-worker ProcessPoolExecutor so the CPU-bound DP
+        runs in a completely separate Python interpreter, eliminating GIL
+        contention with the main event loop.
+
+        Uses 'fork' context (not 'spawn') because Home Assistant injects
+        custom_components onto sys.path dynamically — a spawned child would
+        not see it and fail with ModuleNotFoundError. Fork inherits the
+        parent's full interpreter state including sys.path.
+
+        Returns None when the pool cannot be created (e.g. restricted
+        container); callers must fall back to the default thread-pool
+        executor in that case.
+        """
+        if self._process_pool is None:
+            try:
+                import multiprocessing
+                # 'fork' is safe here because the worker only runs pure
+                # arithmetic (optimize_battery_schedule) and communicates
+                # results via a pipe — it never touches parent locks or
+                # shared state.
+                ctx = multiprocessing.get_context("fork")
+                self._process_pool = concurrent.futures.ProcessPoolExecutor(
+                    max_workers=1, mp_context=ctx
+                )
+                _LOGGER.info("Created process-pool executor for DP optimization")
+            except Exception as exc:
+                _LOGGER.warning(
+                    "Could not create process-pool executor (%s); "
+                    "falling back to thread pool (GIL contention may occur)",
+                    exc,
+                )
+                self._process_pool = None
+        return self._process_pool
+
+    def _run_optimization_in_executor(
+        self,
+        *args: Any,
+    ) -> Any:
+        """Run optimize_battery_schedule in the best available executor.
+
+        Prefers the dedicated process pool (no GIL contention). Falls back
+        to the default thread-pool executor when the process pool is not
+        available.
+        """
+        pool = self._get_process_pool()
+        if pool is not None:
+            return self.hass.loop.run_in_executor(pool, *args)
+        return self.hass.async_add_executor_job(*args)
+
     async def _run_optimization(self) -> dict[str, Any]:
         """Inner optimization logic (called only when not already running)."""
         # Re-read SoC limits and other hardware parameters from live options
@@ -1998,8 +2058,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # price_forecast is already at native price_interval resolution — no resample needed.
         resampled_prices = price_forecast
 
-        # Extend horizon with historical model if live forecast covers less than 36 hours
-        min_horizon_steps = 36 * 60 // price_interval
+        # Reducing horizon, perhaps as todo should it be an advanced parameter?
+        min_horizon_steps = 24 * 60 // price_interval
         if len(resampled_prices) < min_horizon_steps and self._price_model.has_data():
             steps_needed = min_horizon_steps - len(resampled_prices)
             hours_already = len(resampled_prices) * price_interval / 60
@@ -2033,6 +2093,18 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 original_steps,
                 len(resampled_prices),
             )
+
+        # Cap the maximum optimization horizon at 48 hours to bound the DP
+        # runtime. 
+        max_horizon_steps = 48 * 60 // price_interval
+        if len(resampled_prices) > max_horizon_steps:
+            _LOGGER.debug(
+                "Truncating price horizon from %d to %d steps (max 48 h)",
+                len(resampled_prices),
+                max_horizon_steps,
+            )
+            resampled_prices = resampled_prices[:max_horizon_steps]
+            price_start_times = price_start_times[:max_horizon_steps]
 
         # Generate model forecast for price accuracy comparison.
         # Always computed when live prices are used, so users can compare prediction vs actual.
@@ -2251,7 +2323,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             degradation_cost / (2 * usable_kwh) if usable_kwh > 0 else degradation_cost
         )
 
-        result = await self.hass.async_add_executor_job(
+        # Run the DP optimization in the best available executor.
+        # Prefers a dedicated process pool; falls back
+        # to the default thread-pool executor when necessary.
+        result = await self._run_optimization_in_executor(
             optimize_battery_schedule,
             battery_config,
             battery_state.soc_kwh,

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -1815,10 +1815,13 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         runs in a completely separate Python interpreter, eliminating GIL
         contention with the main event loop.
 
-        Uses 'fork' context (not 'spawn') because Home Assistant injects
-        custom_components onto sys.path dynamically — a spawned child would
-        not see it and fail with ModuleNotFoundError. Fork inherits the
-        parent's full interpreter state including sys.path.
+        Uses the 'spawn' context: forking HA's heavily multi-threaded
+        process can clone locks held by other parent threads (logging,
+        SSL, malloc arenas) and deadlock the child before it reaches
+        user code — Python 3.12+ warns on fork-with-threads. Spawn
+        starts a fresh interpreter instead; multiprocessing passes the
+        parent's sys.path to the child, so the optimizer import
+        resolves there.
 
         Returns None when the pool cannot be created (e.g. restricted
         container); callers must fall back to the default thread-pool
@@ -1827,11 +1830,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if self._process_pool is None:
             try:
                 import multiprocessing
-                # 'fork' is safe here because the worker only runs pure
-                # arithmetic (optimize_battery_schedule) and communicates
-                # results via a pipe — it never touches parent locks or
-                # shared state.
-                ctx = multiprocessing.get_context("fork")
+
+                ctx = multiprocessing.get_context("spawn")
                 self._process_pool = concurrent.futures.ProcessPoolExecutor(
                     max_workers=1, mp_context=ctx
                 )

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -2068,8 +2068,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # price_forecast is already at native price_interval resolution — no resample needed.
         resampled_prices = price_forecast
 
-        # Reducing horizon, perhaps as todo should it be an advanced parameter?
-        min_horizon_steps = 24 * 60 // price_interval
+        # Extend horizon with historical model if live forecast covers less than 36 hours
+        min_horizon_steps = 36 * 60 // price_interval
         if len(resampled_prices) < min_horizon_steps and self._price_model.has_data():
             steps_needed = min_horizon_steps - len(resampled_prices)
             hours_already = len(resampled_prices) * price_interval / 60

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -1064,7 +1064,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             self._unsub_realtime()
             self._unsub_realtime = None
         if self._process_pool:
-            self._process_pool.shutdown(wait=False)
+            self._process_pool.shutdown(wait=False, cancel_futures=True)
             self._process_pool = None
         await super().async_shutdown()
 

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -2105,7 +2105,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             )
 
         # Cap the maximum optimization horizon at 48 hours to bound the DP
-        # runtime. 
+        # runtime on long price forecasts (e.g. 15-min prices spanning 2+ days).
         max_horizon_steps = 48 * 60 // price_interval
         if len(resampled_prices) > max_horizon_steps:
             _LOGGER.debug(

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -1845,7 +1845,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 self._process_pool = None
         return self._process_pool
 
-    def _run_optimization_in_executor(
+    async def _run_optimization_in_executor(
         self,
         *args: Any,
     ) -> Any:
@@ -1853,12 +1853,22 @@ class OptimizationCoordinator(DataUpdateCoordinator):
 
         Prefers the dedicated process pool (no GIL contention). Falls back
         to the default thread-pool executor when the process pool is not
-        available.
+        available or breaks at submit time — worker start-up failures only
+        surface on first use, not at pool construction.
         """
         pool = self._get_process_pool()
         if pool is not None:
-            return self.hass.loop.run_in_executor(pool, *args)
-        return self.hass.async_add_executor_job(*args)
+            try:
+                return await self.hass.loop.run_in_executor(pool, *args)
+            except concurrent.futures.process.BrokenProcessPool as exc:
+                _LOGGER.warning(
+                    "Process-pool executor broke (%s); falling back to the "
+                    "thread pool for this run",
+                    exc,
+                )
+                pool.shutdown(wait=False)
+                self._process_pool = None
+        return await self.hass.async_add_executor_job(*args)
 
     async def _run_optimization(self) -> dict[str, Any]:
         """Inner optimization logic (called only when not already running)."""


### PR DESCRIPTION
Description
The DP optimizer blocks HA for 2+ minutes on big batteries. Two problems:

GIL contention — the DP runs in a thread pool, but 65 million pure-Python loop iterations hold the GIL hostage. The event loop starves, HA becomes unresponsive.

Unbounded horizon — 36h minimum + no maximum cap. With 15-min OMIE prices and a 55 kWh battery: 144 steps × 4,500 SoC states × 101 actions = 65M iterations = 131 seconds of pain.

Fix: Run the DP in its own process (ProcessPoolExecutor, fork context) so it gets its own GIL. Add a 24h min / 48h max horizon cap. Falls back to thread pool if process creation fails.


Type of change
[c] fix: Bug fix (patch version bump)
Checklist
[c] Commit title follows Conventional Commits
[ ] Tests added or updated where applicable
[ ] Documentation updated if needed
[ ] CI is green
[ ] PR targets the dev branch