### PR TITLE
docs(analyzer): flag an unlearned consumption pattern

### DIFF
--- a/docs/__tests__/analyzer.test.js
+++ b/docs/__tests__/analyzer.test.js
@@ -473,6 +473,49 @@ describe('generateTips', () => {
     expect(tips.some(t => t.title.toLowerCase().includes('soc limit blocked'))).toBe(false);
   });
 
+  test('err tip when consumption pattern is empty', () => {
+    const d = makeDiag();
+    d.forecast.consumption_hourly_pattern = {};
+    d.forecast.current_consumption_kw = 0.5;
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.toLowerCase().includes('no consumption pattern learned'));
+    expect(tip).toBeDefined();
+    expect(tip.t).toBe('err');
+    // Should tell the user that waiting does not help
+    expect(tip.text.toLowerCase()).toContain('not');
+    expect(tip.text).toContain('0.5 kW');
+  });
+
+  test('warn tip when consumption pattern is only partly learned', () => {
+    const d = makeDiag();
+    d.forecast.consumption_hourly_pattern = { '08_0': 0.4, '09_0': 0.5, '10_0': 0.6 };
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.toLowerCase().includes('partly learned'));
+    expect(tip).toBeDefined();
+    expect(tip.t).toBe('warn');
+    expect(tip.title).toContain('3 of 168');
+  });
+
+  test('no consumption pattern tip when the pattern is well populated', () => {
+    const d = makeDiag();
+    const pattern = {};
+    for (let h = 0; h < 24; h++) {
+      for (let dow = 0; dow < 7; dow++) {
+        pattern[`${String(h).padStart(2, '0')}_${dow}`] = 1.2;
+      }
+    }
+    d.forecast.consumption_hourly_pattern = pattern;
+    const tips = generateTips(d);
+    expect(tips.some(t => t.title.toLowerCase().includes('consumption pattern'))).toBe(false);
+  });
+
+  test('no consumption pattern tip for diagnostics without the key', () => {
+    // Older diagnostics files have no consumption_hourly_pattern at all
+    const d = makeDiag();
+    const tips = generateTips(d);
+    expect(tips.some(t => t.title.toLowerCase().includes('consumption pattern'))).toBe(false);
+  });
+
   test('ok tip included in clean configuration', () => {
     // Only ok and info tips should result in a "well-tuned" message
     // Remove any triggers for warn/err

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -703,6 +703,38 @@ function generateTips(d) {
       This is normal for day-ahead prices before they publish (usually afternoon).`});
   }
 
+  // 0c. Consumption pattern learning. An empty pattern means the consumption
+  // forecast is the built-in cold-start curve (~0.4 kW average) rather than
+  // the actual household — the usual cause of "my forecast is far too low".
+  // Absent key = diagnostics from an older version: stay silent.
+  const consumPattern = fc.consumption_hourly_pattern;
+  if (consumPattern && typeof consumPattern === 'object') {
+    const nBuckets  = Object.keys(consumPattern).length;
+    const curConsum = fc.current_consumption_kw;
+    const curTxt = curConsum != null
+      ? ` Right now it forecasts <b>${curConsum} kW</b> — compare that with your actual household load.`
+      : '';
+    if (nBuckets === 0) {
+      tips.push({ t:'err', title:'No consumption pattern learned — forecast is a built-in default',
+        text:`The learned consumption pattern is empty, so the forecast is the built-in cold-start curve
+        for a typical household (≈3500 kWh/year, ~0.4 kW average).${curTxt}<br>
+        This is <b>not</b> fixed by waiting: the pattern is learned from the last 14 days of
+        <i>your own</i> kWh sensors in the recorder, not from how long the integration has run.
+        A correctly configured sensor fills the pattern on the next refresh.<br>
+        Most common cause: the sensor under <i>Electricity consumption sensors</i> has
+        <code>state_class: measurement</code> instead of <code>total_increasing</code>, so it produces
+        mean statistics and the hourly <code>change</code> the learner needs does not exist.
+        Check it under <b>Developer Tools → Statistics</b>.`});
+    } else if (nBuckets < 24) {
+      tips.push({ t:'warn', title:`Consumption pattern only partly learned (${nBuckets} of 168 slots)`,
+        text:`Only ${nBuckets} hour/weekday slots have been learned so far, so many hours still fall back
+        to the built-in default curve.${curTxt}<br>
+        This is normal in the first days after adding a new consumption sensor and resolves as the
+        recorder accumulates history. If it does not improve, verify the sensor produces sum-type
+        statistics (<code>state_class: total_increasing</code>).`});
+    }
+  }
+
   // 1. RTE
   if (rte < 0.82) {
     tips.push({ t:'err', title:'Very low round-trip efficiency (RTE)',


### PR DESCRIPTION
## Description

Companion to #110, which documented this in the README. This adds the same signal to the diagnostics analyzer.

The reporter in #106 had **already run his diagnostics through the analyzer** and it told him nothing — even though `consumption_hourly_pattern: {}` was sitting right there in the file. An empty pattern means the consumption forecast is the built-in cold-start curve (≈0.4 kW average, typical household) rather than the user's actual household, which is the usual cause of "my consumption forecast is far too low".

`generateTips` now checks it:

- **err** when the pattern is empty — explains that the forecast is a built-in default, names the likely cause (`state_class: measurement` instead of `total_increasing`, so no hourly `change` statistics exist), and states explicitly that waiting will not help, since the learner reads the user's own 14-day recorder history rather than the integration's uptime. Includes the current forecast value so the user can compare it against their real load.
- **warn** when fewer than 24 of the 168 hour/weekday slots are learned — normal shortly after adding a sensor.
- **silent** when the key is absent, so diagnostics files from older versions cannot produce a false positive.

Not included: a check for the PV double-counting configuration. `TO_REDACT` in `diagnostics.py` redacts both `electricity_consumption_sensors` and `electricity_production_sensors`, so the analyzer cannot tell whether the production field is filled — the key survives with a `**REDACTED**` value. That check would be unreliable, so it lives in the README only. Exporting a non-sensitive indicator (e.g. just the *count* of configured production sensors) would make it possible; happy to follow up if wanted.

Only `docs/` is touched — the integration itself is unchanged, so no version bump is implied.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (4 new Jest tests; 45 passing)
- [x] Documentation updated if needed (README side landed in #110)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a