### PR TITLE
fix: learn consumption pattern from float statistics timestamps

### DIFF
--- a/custom_components/battery_controller/forecast_models.py
+++ b/custom_components/battery_controller/forecast_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -199,34 +199,44 @@ class ConsumptionForecastModel:
 
             # Build per-hour net consumption: sum(consumption) - sum(production)
             # Each stat entry's "change" = kWh in that hour = avg kW
-            hourly_net: dict[str, float] = {}  # key: ISO timestamp -> net kWh
+            hourly_net: dict[datetime, float] = {}  # key: UTC hour -> net kWh
 
-            # Normalise a stat entry to (ts_key, value) regardless of whether
-            # the recorder returns the "start" field as a string or datetime.
-            def _ts_and_value(stat: Any, field: str) -> tuple[str, float] | None:
+            # Normalise a stat entry to (start_dt, value).  The recorder returns
+            # "start" as a Unix timestamp (float) on current Home Assistant
+            # versions, and as a datetime or ISO string on older ones — all
+            # three must be handled.  Keying on the datetime itself avoids a
+            # string round-trip: formatting a float as "1753617600.0" and
+            # parsing it back yields None, which silently dropped every bucket
+            # and left the learned pattern empty.
+            def _ts_and_value(stat: Any, field: str) -> tuple[datetime, float] | None:
                 value = stat.get(field)
                 if value is None:
                     return None
                 start = stat.get("start")
                 if isinstance(start, datetime):
-                    ts_key = start.isoformat()
+                    start_dt = start
+                elif isinstance(start, (int, float)):
+                    start_dt = datetime.fromtimestamp(start, tz=UTC)
                 else:
-                    ts_key = str(start or "")
-                return ts_key, float(value)
+                    parsed = dt_util.parse_datetime(str(start or ""))
+                    if parsed is None:
+                        return None
+                    start_dt = parsed
+                return start_dt, float(value)
 
             for sensor_id in self.consumption_sensors:
                 for stat in stats.get(sensor_id, []):
                     result = _ts_and_value(stat, "change")
                     if result:
-                        ts_key, val = result
-                        hourly_net[ts_key] = hourly_net.get(ts_key, 0.0) + val
+                        stat_dt, val = result
+                        hourly_net[stat_dt] = hourly_net.get(stat_dt, 0.0) + val
 
             for sensor_id in self.production_sensors:
                 for stat in stats.get(sensor_id, []):
                     result = _ts_and_value(stat, "change")
                     if result:
-                        ts_key, val = result
-                        hourly_net[ts_key] = hourly_net.get(ts_key, 0.0) - val
+                        stat_dt, val = result
+                        hourly_net[stat_dt] = hourly_net.get(stat_dt, 0.0) - val
 
             # PV correction: add back historical PV production so that the
             # stored pattern represents gross household consumption.
@@ -248,8 +258,8 @@ class ConsumptionForecastModel:
                     for stat in pv_stats.get(sensor_id, []):
                         result = _ts_and_value(stat, "change")
                         if result:
-                            ts_key, val = result
-                            hourly_net[ts_key] = hourly_net.get(ts_key, 0.0) + max(
+                            stat_dt, val = result
+                            hourly_net[stat_dt] = hourly_net.get(stat_dt, 0.0) + max(
                                 0.0, val
                             )
                 pv_corrected = True
@@ -282,11 +292,11 @@ class ConsumptionForecastModel:
                         for stat in pv_stats.get(pv_entity_id, []):
                             result = _ts_and_value(stat, "mean")
                             if result:
-                                ts_key, val = result
+                                stat_dt, val = result
                                 # mean kW over 1 h = kWh for that hour
-                                hourly_net[ts_key] = hourly_net.get(ts_key, 0.0) + max(
-                                    0.0, val
-                                )
+                                hourly_net[stat_dt] = hourly_net.get(
+                                    stat_dt, 0.0
+                                ) + max(0.0, val)
                         pv_corrected = True
                         _LOGGER.debug(
                             "PV correction applied from own pv_forecast sensor (%s)",
@@ -312,11 +322,8 @@ class ConsumptionForecastModel:
             # season: 0=winter(DJF), 1=spring(MAM), 2=summer(JJA), 3=autumn(SON)
             hourly_values: dict[tuple[int, int], list[float]] = {}
             seasonal_values: dict[tuple[int, int, int], list[float]] = {}
-            for ts_key, net_kwh in hourly_net.items():
-                dt = dt_util.parse_datetime(ts_key)
-                if dt is None:
-                    continue
-                dt_local = dt_util.as_local(dt)
+            for stat_dt, net_kwh in hourly_net.items():
+                dt_local = dt_util.as_local(stat_dt)
                 val = max(0.0, net_kwh)
                 key = (dt_local.hour, dt_local.weekday())
                 hourly_values.setdefault(key, []).append(val)

--- a/tests/test_forecast_models.py
+++ b/tests/test_forecast_models.py
@@ -1281,3 +1281,63 @@ class TestPriceForecastModelUnitScaling:
             await model.async_update_pattern()
 
         assert model._overall_avg == pytest.approx(0.25)
+
+
+class TestAsyncUpdatePatternStartFormats:
+    """The recorder's "start" field must be handled in every form it takes.
+
+    Current Home Assistant returns statistics rows with "start" as a Unix
+    timestamp (float); older versions used a datetime or an ISO string.
+    A float used to be stringified to "1704106800.0" and parsed back with
+    parse_datetime(), which returns None — silently dropping every bucket
+    and leaving the learned pattern empty while statistics were present.
+    """
+
+    # 2024-01-01 10:00 UTC (a Monday)
+    _DT = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+    @staticmethod
+    def _expected_key():
+        from homeassistant.util import dt as dt_util
+
+        local = dt_util.as_local(TestAsyncUpdatePatternStartFormats._DT)
+        return (local.hour, local.weekday())
+
+    async def _run(self, start_value):
+        hass = MagicMock()
+        model = ConsumptionForecastModel(
+            hass=hass, consumption_sensors=["sensor.consumption"]
+        )
+        stats = {"sensor.consumption": [{"start": start_value, "change": 2.5}]}
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(return_value=stats)
+
+        with patch(
+            "homeassistant.components.recorder.util.get_instance",
+            return_value=mock_instance,
+        ):
+            await model.async_update_pattern()
+        return model
+
+    async def test_float_unix_timestamp_start(self):
+        """Regression: float timestamps must not be dropped."""
+        model = await self._run(self._DT.timestamp())
+        assert model._hourly_pattern, "pattern must not be empty for float timestamps"
+        assert model._hourly_pattern[self._expected_key()] == pytest.approx(2.5)
+
+    async def test_int_unix_timestamp_start(self):
+        model = await self._run(int(self._DT.timestamp()))
+        assert model._hourly_pattern[self._expected_key()] == pytest.approx(2.5)
+
+    async def test_datetime_start(self):
+        model = await self._run(self._DT)
+        assert model._hourly_pattern[self._expected_key()] == pytest.approx(2.5)
+
+    async def test_iso_string_start(self):
+        model = await self._run(self._DT.isoformat())
+        assert model._hourly_pattern[self._expected_key()] == pytest.approx(2.5)
+
+    async def test_unparseable_start_is_skipped(self):
+        """Garbage timestamps are dropped without raising."""
+        model = await self._run("not-a-timestamp")
+        assert model._hourly_pattern == {}


### PR DESCRIPTION
## Description

**The consumption pattern is never learned on current Home Assistant versions.** Found while working through #106, where the reporter's forecast looked far too low — his sensors turned out to be configured correctly all along.

`statistics_during_period` returns each row's `start` as a **Unix timestamp (float)** on current HA. `_ts_and_value` only special-cased `datetime` and otherwise stringified the value, so a float became `"1704106800.0"` — which `dt_util.parse_datetime()` cannot parse, returning `None`. The downstream `if dt is None: continue` then dropped **every** bucket:

```python
start = stat.get("start")
if isinstance(start, datetime):
    ts_key = start.isoformat()
else:
    ts_key = str(start or "")     # 1704106800.0 -> "1704106800.0"
...
dt = dt_util.parse_datetime(ts_key)   # -> None
if dt is None:
    continue                           # every row skipped
```

The failure is completely silent and reads like a user misconfiguration: statistics exist, the sensors are valid, no exception is raised, and the routine logs `Updated consumption pattern from 1 energy sensors, 0 hourly buckets, 0 seasonal buckets`. The forecast then falls back to the built-in cold-start curve (~0.4 kW, typical household) — for every user, regardless of their setup.

Notably, `PriceForecastModel._stat_dt` in the same file **already handles** int/float starts. Only the consumption model was missing it, which is why price learning works while consumption learning does not.

### Fix

- `_ts_and_value` now returns a `datetime`, handling `datetime`, `int`/`float` Unix timestamps and ISO strings; `hourly_net` is keyed on that datetime, removing the string round-trip entirely (the price model's own comment already warns about exactly this: *"stores (datetime, price) to avoid string round-trip issues"*).
- Unparseable timestamps are skipped explicitly instead of silently producing an unusable key.

### Tests

New `TestAsyncUpdatePatternStartFormats` covers all four `start` formats plus the garbage case. The existing tests all used ISO strings, which is why this was never caught — that path always worked.

Verified the test actually catches the bug:

```
--- without fix ---
FAILED tests/test_forecast_models.py::TestAsyncUpdatePatternStartFormats::test_float_unix_timestamp_start
--- with fix ---
5 passed
```

### Impact

Anyone whose consumption forecast looked implausibly flat or low should see a real pattern within one refresh cycle after upgrading — the recorder history was always there, it was just being discarded. Pairs with the diagnosis docs in #110 and the analyzer tip in #111, which now catch the *symptom*; this removes the cause.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (746 passing; 5 new)
- [x] Documentation updated if needed (n/a — behaviour now matches what the docs already describe)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a