### PR TITLE
fix(analyzer): count DC-coupled PV in the net line and report PV volume

### DIFF
--- a/docs/__tests__/analyzer.test.js
+++ b/docs/__tests__/analyzer.test.js
@@ -2,7 +2,10 @@
 
 const {
   SOC_RES_WH,
+  DC_TO_AC_EFF,
   calculateStepCost,
+  totalPvSeries,
+  netPvSeries,
   findNearestSocIdx,
   runDP,
   forwardPass,
@@ -306,6 +309,43 @@ describe('computeShadowPrice', () => {
   });
 });
 
+// ─── totalPvSeries / netPvSeries ────────────────────────────────────────────
+
+describe('totalPvSeries / netPvSeries', () => {
+  test('AC-only system is unchanged', () => {
+    expect(totalPvSeries([1, 2, 3], [])).toEqual([1, 2, 3]);
+  });
+
+  test('DC PV is counted through the inverter', () => {
+    const out = totalPvSeries([0, 0], [2, 4]);
+    expect(out[0]).toBeCloseTo(2 * DC_TO_AC_EFF);
+    expect(out[1]).toBeCloseTo(4 * DC_TO_AC_EFF);
+  });
+
+  test('AC and DC are summed', () => {
+    const out = totalPvSeries([1, 1], [2, 0]);
+    expect(out[0]).toBeCloseTo(1 + 2 * DC_TO_AC_EFF);
+    expect(out[1]).toBeCloseTo(1);
+  });
+
+  test('handles missing/undefined series and unequal lengths', () => {
+    expect(totalPvSeries(undefined, undefined)).toEqual([]);
+    expect(totalPvSeries([1], [1, 1]).length).toBe(2);
+  });
+
+  test('net line reflects DC PV instead of showing no solar', () => {
+    // DC-coupled system: AC series all zeros, DC carries production
+    const net = netPvSeries([0, 0], [4, 4], [1, 1]);
+    expect(net[0]).toBeCloseTo(4 * DC_TO_AC_EFF - 1);
+    expect(net[0]).toBeGreaterThan(0); // surplus, not a deficit
+  });
+
+  test('net line is a deficit when consumption exceeds PV', () => {
+    const net = netPvSeries([0], [1], [3]);
+    expect(net[0]).toBeLessThan(0);
+  });
+});
+
 // ─── generateTips ───────────────────────────────────────────────────────────
 
 describe('generateTips', () => {
@@ -514,6 +554,46 @@ describe('generateTips', () => {
     const d = makeDiag();
     const tips = generateTips(d);
     expect(tips.some(t => t.title.toLowerCase().includes('consumption pattern'))).toBe(false);
+  });
+
+  test('info tip reports an all-DC PV forecast', () => {
+    const d = makeDiag();
+    d.forecast.pv_forecast_kw = [0, 0, 0, 0];
+    d.forecast.pv_dc_forecast_kw = [2, 2, 2, 2];
+    d.forecast.forecast_interval_minutes = 15;
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.includes('all DC-coupled'));
+    expect(tip).toBeDefined();
+    expect(tip.t).toBe('info');
+    // 4 steps x 2 kW x 0.25 h = 2.0 kWh
+    expect(tip.title).toContain('2.0 kWh');
+  });
+
+  test('warn tip when the PV forecast is zero everywhere', () => {
+    const d = makeDiag();
+    d.forecast.pv_forecast_kw = [0, 0];
+    d.forecast.pv_dc_forecast_kw = [0, 0];
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.toLowerCase().includes('pv forecast is zero'));
+    expect(tip).toBeDefined();
+    expect(tip.t).toBe('warn');
+  });
+
+  test('info tip reports the AC/DC split when both produce', () => {
+    const d = makeDiag();
+    d.forecast.pv_forecast_kw = [1, 1];
+    d.forecast.pv_dc_forecast_kw = [1, 1];
+    d.forecast.forecast_interval_minutes = 60;
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.includes('over the horizon'));
+    expect(tip).toBeDefined();
+    expect(tip.text).toContain('DC-coupled');
+  });
+
+  test('no PV forecast tip when the arrays are absent', () => {
+    const d = makeDiag();
+    const tips = generateTips(d);
+    expect(tips.some(t => t.title.toLowerCase().includes('pv forecast'))).toBe(false);
   });
 
   test('ok tip included in clean configuration', () => {

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -74,6 +74,26 @@ function calculateStepCost(stepH, socWh, actionW, gridPrice, feedInPrice,
   return gridCost + degradCost;
 }
 
+// Total PV available on the AC side, per step. DC-coupled PV reaches the
+// house through the inverter at DC_TO_AC_EFF — the same path the optimizer's
+// baseline uses. Charts that only summed the AC series showed a DC-coupled
+// system as having no solar at all.
+function totalPvSeries(pvFc, pvDcFc) {
+  const ac = pvFc || [];
+  const dc = pvDcFc || [];
+  const n = Math.max(ac.length, dc.length);
+  const out = [];
+  for (let i = 0; i < n; i++) out.push((ac[i] || 0) + (dc[i] || 0) * DC_TO_AC_EFF);
+  return out;
+}
+
+// Net position per step: total PV minus consumption (positive = surplus).
+function netPvSeries(pvFc, pvDcFc, consumFc) {
+  const total = totalPvSeries(pvFc, pvDcFc);
+  const consum = consumFc || [];
+  return total.map((v, i) => v - (consum[i] || 0));
+}
+
 function findNearestSocIdx(socWh, socStates) {
   if (socStates.length <= 1) return 0;
   const step = socStates[1] - socStates[0];
@@ -841,6 +861,42 @@ function generateTips(d) {
     }
   }
 
+  // 8b. PV forecast volume. Reported explicitly because a DC-coupled system
+  // has pv_forecast_kw all zeros with everything in pv_dc_forecast_kw, which
+  // otherwise looks like "no PV forecast" in the charts.
+  const pvAcFcT  = fc.pv_forecast_kw    || [];
+  const pvDcFcT  = fc.pv_dc_forecast_kw || [];
+  if (pvAcFcT.length || pvDcFcT.length) {
+    const fcStepH = (fc.forecast_interval_minutes || 60) / 60;
+    const sum = arr => arr.reduce((a, b) => a + (b || 0), 0);
+    const acKwh = sum(pvAcFcT) * fcStepH;
+    const dcKwh = sum(pvDcFcT) * fcStepH;
+    const totKwh = acKwh + dcKwh;
+    if (totKwh <= 0.01) {
+      tips.push({ t:'warn', title:'PV forecast is zero over the whole horizon',
+        text:`Neither the AC nor the DC PV forecast contains any production.
+        If you have solar, check that a PV array subentry is configured with the right
+        peak power, orientation and tilt, and that the weather coordinator is reaching
+        open-meteo.com. The optimizer will plan as if there is no solar at all.`});
+    } else if (acKwh <= 0.01) {
+      tips.push({ t:'info', title:`PV forecast: ${dcKwh.toFixed(1)} kWh, all DC-coupled`,
+        text:`All forecast production is on the DC side (<code>pv_dc_forecast_kw</code>);
+        <code>pv_forecast_kw</code> is zero, which is expected when every array is
+        DC-coupled. The "PV AC" series in the chart is flat at zero by design — the
+        orange "PV DC" line carries your production, and the net line accounts for it
+        through the inverter at ${(DC_TO_AC_EFF*100).toFixed(0)}%.`});
+    } else {
+      const dcTxt = dcKwh > 0.01
+        ? ` (${acKwh.toFixed(1)} kWh AC + ${dcKwh.toFixed(1)} kWh DC-coupled)`
+        : '';
+      tips.push({ t:'info', title:`PV forecast: ${totKwh.toFixed(1)} kWh over the horizon`,
+        text:`Total forecast solar production over the planning horizon${dcTxt}.
+        Compare this with what your inverter actually produces on a comparable day —
+        a large mismatch points at the array configuration (peak power, orientation, tilt)
+        rather than at the optimizer.`});
+    }
+  }
+
   // 9. DC-coupled PV
   if (bc.pv_dc_coupled) {
     const dcEff = bc.pv_dc_efficiency || 0;
@@ -925,6 +981,8 @@ if (typeof module !== 'undefined') {
   module.exports = {
     SOC_RES_WH, POWER_STEP_W, DC_TO_AC_EFF, MIN_PV_SURPLUS_KW, MIN_CYCLE_KWH,
     calculateStepCost,
+    totalPvSeries,
+    netPvSeries,
     findNearestSocIdx,
     runDP,
     forwardPass,

--- a/docs/index.html
+++ b/docs/index.html
@@ -545,14 +545,24 @@ function resampleSeries(data, fromMin, toMin) {
 }
 
 function chartPv(id, pvFc, consumFc, pvDcFc, labels) {
-  const net = pvFc.map((v,i) => v - (consumFc[i]||0));
-  const datasets = [
-    { label:'PV AC (kW)',      data:pvFc,   borderColor:'#eab308', backgroundColor:'rgba(234,179,8,0.1)', fill:true, borderWidth:2, pointRadius:0, tension:0.3 },
+  const hasDc = pvDcFc && pvDcFc.some(v => v > 0);
+  const hasAc = pvFc.some(v => v > 0);
+  // netPvSeries (analyzer.js) counts DC-coupled PV through the inverter, the
+  // same path the optimizer's baseline uses. Summing only the AC series showed
+  // a DC-coupled system as if it had no solar at all.
+  const net = netPvSeries(pvFc, pvDcFc, consumFc);
+  const datasets = [];
+  // A flat zero "PV AC" band is pure noise when every array is DC-coupled;
+  // keep it when there is no DC series either, so a system without any PV
+  // still renders the zero line for context.
+  if (hasAc || !hasDc)
+    datasets.push({ label:'PV AC (kW)', data:pvFc, borderColor:'#eab308', backgroundColor:'rgba(234,179,8,0.1)', fill:true, borderWidth:2, pointRadius:0, tension:0.3 });
+  if (hasDc)
+    datasets.push({ label:'PV DC (kW)', data:pvDcFc, borderColor:'#f97316', backgroundColor:'rgba(249,115,22,0.1)', fill:true, borderWidth:2, pointRadius:0, tension:0.3 });
+  datasets.push(
     { label:'Consumption (kW)',data:consumFc,borderColor:'#ef4444', borderWidth:2, pointRadius:0, tension:0.3 },
     { label:'Net (PV−consump)',data:net,    borderColor:'#3b82f6', borderWidth:1.5, pointRadius:0, borderDash:[4,2], tension:0.3 },
-  ];
-  if (pvDcFc && pvDcFc.some(v => v > 0))
-    datasets.push({ label:'PV DC (kW)', data:pvDcFc, borderColor:'#f97316', borderWidth:1.5, pointRadius:0, borderDash:[2,2], tension:0.3 });
+  );
   mkChart(id, {
     type:'line', data:{ labels, datasets },
     options:{ responsive:true, maintainAspectRatio:false,


### PR DESCRIPTION
## Description

From #106: *"Battery controller analyser does not mention PV forecast at all, perhaps because there's only data in `pv_dc_forecast_kw`, but `pv_forecast_kw` is all zeroed."*

Investigating turned up two separate problems for DC-coupled systems.

### 1. The net line was wrong, not just missing

`chartPv` computed the net line as `pv_forecast − consumption`, ignoring `pv_dc_forecast_kw` completely:

```js
const net = pvFc.map((v,i) => v - (consumFc[i]||0));
```

For a DC-coupled system — where the AC series is legitimately all zeros — that renders the household as if it had **no solar at all**, showing a permanent deficit even at midday. This is a correctness bug, and it affects every DC-coupled user, not only the reporter.

The net line now goes through the same path as the optimizer's own baseline (`_calculate_baseline_cost`): DC PV reaches the AC side through the inverter at `DC_TO_AC_EFF` (96%).

### 2. Nothing reported how much PV was forecast

There was no tip about PV production volume, so a user with a zero AC series had no confirmation that PV was being forecast at all. `generateTips` now reports:

- **info** — total forecast kWh over the horizon, with the AC/DC split when both contribute.
- **info** — dedicated text for the all-DC case, naming the total and explaining that the flat-zero "PV AC" series is expected and that the net line accounts for DC through the inverter.
- **warn** — when both series are zero across the whole horizon, pointing at array configuration or weather-coordinator problems.
- silent when neither key is present, so older diagnostics can't produce a false positive.

### Structure

The net calculation moved out of the DOM code into two pure functions in `analyzer.js` (`totalPvSeries`, `netPvSeries`), following the file's stated split — *"pure functions are in analyzer.js"* — so the fix is unit-testable instead of living only in an untested chart callback.

`chartPv` additionally fills the DC series the way the AC one is filled, and drops the flat-zero "PV AC" band when every array is DC-coupled (kept when there is no DC series either, so a system without PV still shows the zero line for context).

### Tests

10 new Jest tests (55 passing): the series helpers across AC-only, DC-only, mixed, missing and unequal-length inputs, including an explicit assertion that a DC-coupled midday step yields a **surplus** rather than a deficit; plus the three tip branches and the silent case. The inline script in `index.html` isn't covered by Jest, so it was syntax-checked separately with `node --check`.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (55 Jest tests passing; 10 new)
- [x] Documentation updated if needed (n/a)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a