### PR TITLE
fix: reject implausible samples when learning the consumption pattern

### DIFF
--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -218,6 +218,15 @@ STALE_SENSOR_MULTIPLIER = (
     2.0  # x response_time_s — age limit before sensor is treated as stale
 )
 WEATHER_STALE_AFTER_MINUTES = 120.0  # minutes — weather data older than this is treated as stale (4 missed updates)
+# Plausibility ceiling for a learned hourly consumption sample, in kW.
+# An hourly statistics "change" equals the average power over that hour, so a
+# household hour above this is a meter artefact (a total_increasing sensor that
+# jumped or was replaced, a unit change, or a spurious reading), not real load:
+# even a 3x80 A connection at full load for a whole hour stays near 55 kW.
+# Such a sample is unbounded in magnitude — observed values reach 10^8 kW — and
+# a single one poisons its (hour, weekday) bucket and wrecks the DP cost.
+MAX_PLAUSIBLE_CONSUMPTION_KW = 50.0
+
 SOC_UNCERTAINTY_RESERVE_FRACTION = (
     0.10  # max fraction of capacity reserved for solar forecast uncertainty
 )

--- a/custom_components/battery_controller/forecast_models.py
+++ b/custom_components/battery_controller/forecast_models.py
@@ -9,7 +9,11 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .const import DEFAULT_PV_ORIENTATION_DEG, DEFAULT_PV_TILT_DEG
+from .const import (
+    DEFAULT_PV_ORIENTATION_DEG,
+    DEFAULT_PV_TILT_DEG,
+    MAX_PLAUSIBLE_CONSUMPTION_KW,
+)
 from .helpers import (
     calculate_consumption_pattern,
     calculate_pv_forecast,
@@ -322,15 +326,38 @@ class ConsumptionForecastModel:
             # season: 0=winter(DJF), 1=spring(MAM), 2=summer(JJA), 3=autumn(SON)
             hourly_values: dict[tuple[int, int], list[float]] = {}
             seasonal_values: dict[tuple[int, int, int], list[float]] = {}
+            dropped_outliers = 0
             for stat_dt, net_kwh in hourly_net.items():
                 dt_local = dt_util.as_local(stat_dt)
                 val = max(0.0, net_kwh)
+                # Reject meter artefacts. An hourly "change" equals the average
+                # power over that hour, so a value above the plausibility
+                # ceiling cannot be household load — it is a sensor that jumped,
+                # was replaced, or briefly reported nonsense. Such a sample is
+                # unbounded, and with only ~2 samples per (hour, weekday) bucket
+                # over 14 days a single one dominates the average and propagates
+                # into the DP cost.
+                if val > MAX_PLAUSIBLE_CONSUMPTION_KW:
+                    dropped_outliers += 1
+                    continue
                 key = (dt_local.hour, dt_local.weekday())
                 hourly_values.setdefault(key, []).append(val)
                 season = _get_season(dt_local.month)
                 seasonal_values.setdefault(
                     (dt_local.hour, dt_local.weekday(), season), []
                 ).append(val)
+
+            if dropped_outliers:
+                _LOGGER.warning(
+                    "Ignored %d implausible hourly sample(s) above %.0f kW while "
+                    "learning the consumption pattern. This points at a meter "
+                    "artefact in one of the configured energy sensors (a "
+                    "total_increasing sensor that jumped or was replaced). Check "
+                    "the statistics of your consumption/production/PV sensors "
+                    "around the affected hours in Developer Tools -> Statistics.",
+                    dropped_outliers,
+                    MAX_PLAUSIBLE_CONSUMPTION_KW,
+                )
 
             for h_key, values in hourly_values.items():
                 if values:

--- a/tests/test_forecast_models.py
+++ b/tests/test_forecast_models.py
@@ -1,11 +1,12 @@
 """Tests for forecast_models.py."""
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.battery_controller.const import MAX_PLAUSIBLE_CONSUMPTION_KW
 from custom_components.battery_controller.forecast_models import (
     PVForecastModel,
     ConsumptionForecastModel,
@@ -1341,3 +1342,73 @@ class TestAsyncUpdatePatternStartFormats:
         """Garbage timestamps are dropped without raising."""
         model = await self._run("not-a-timestamp")
         assert model._hourly_pattern == {}
+
+
+class TestConsumptionOutlierRejection:
+    """Meter artefacts must not poison the learned pattern.
+
+    A total_increasing sensor that jumps (device replaced, unit change,
+    spurious reading) yields an enormous hourly "change". With ~2 samples
+    per (hour, weekday) bucket over 14 days, one such sample dominates the
+    average and propagates into the DP cost function.
+    """
+
+    _DT = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+    @staticmethod
+    def _key():
+        from homeassistant.util import dt as dt_util
+
+        local = dt_util.as_local(TestConsumptionOutlierRejection._DT)
+        return (local.hour, local.weekday())
+
+    async def _run(self, changes):
+        """Run the learner over a list of (hour_offset, change_kwh)."""
+        hass = MagicMock()
+        model = ConsumptionForecastModel(
+            hass=hass, consumption_sensors=["sensor.consumption"]
+        )
+        rows = [
+            {"start": (self._DT + timedelta(days=7 * i)).timestamp(), "change": v}
+            for i, v in enumerate(changes)
+        ]
+        stats = {"sensor.consumption": rows}
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(return_value=stats)
+        with patch(
+            "homeassistant.components.recorder.util.get_instance",
+            return_value=mock_instance,
+        ):
+            await model.async_update_pattern()
+        return model
+
+    async def test_absurd_sample_is_rejected(self):
+        """A 94 GW 'hour' must not reach the pattern."""
+        model = await self._run([0.4, 93972250.55])
+        # Only the sane sample survives — not the average of the two
+        assert model._hourly_pattern[self._key()] == pytest.approx(0.4)
+
+    async def test_all_samples_absurd_leaves_bucket_empty(self):
+        model = await self._run([5816382.577, 28419810.183])
+        assert self._key() not in model._hourly_pattern
+
+    async def test_plausible_high_load_is_kept(self):
+        """A genuinely heavy hour (EV + heat pump) is still learned."""
+        model = await self._run([11.5, 12.5])
+        assert model._hourly_pattern[self._key()] == pytest.approx(12.0)
+
+    async def test_value_just_below_ceiling_is_kept(self):
+        model = await self._run([MAX_PLAUSIBLE_CONSUMPTION_KW - 0.1])
+        assert model._hourly_pattern[self._key()] == pytest.approx(
+            MAX_PLAUSIBLE_CONSUMPTION_KW - 0.1
+        )
+
+    async def test_value_just_above_ceiling_is_rejected(self):
+        model = await self._run([MAX_PLAUSIBLE_CONSUMPTION_KW + 0.1])
+        assert self._key() not in model._hourly_pattern
+
+    async def test_warning_names_the_dropped_count(self, caplog):
+        with caplog.at_level("WARNING"):
+            await self._run([0.4, 93972250.55])
+        assert "implausible" in caplog.text.lower()
+        assert "1 " in caplog.text


### PR DESCRIPTION
## Description

Follow-up to #112. That fix made the consumption pattern actually get learned; this one makes the learning robust to bad source data, which was previously masked because the pattern was always empty.

An hourly statistics `change` equals the average power over that hour. A `total_increasing` sensor that jumps — device replaced, unit change, spurious reading — produces an unbounded one. With only ~2 samples per `(hour, weekday)` bucket over 14 days, a single artefact dominates the bucket average outright.

**Observed on a real 2.8.2 system:** 8 of 168 buckets held values up to **9.4 × 10⁷ kW**:

| bucket | learned value |
|---|---|
| `14_4` | 93,972,250 kW |
| `14_6` | 73,643,045 kW |
| `17_4` | 55,430,517 kW |
| `17_3` | 28,419,810 kW |
| `16_3` | 15,450,175 kW |
| `09_1` | 5,816,383 kW |
| `21_5` | 174,003 kW |
| `06_2` | 57 kW |

The other 160 buckets were entirely sane — median 0.18 kW, peak 3.08 kW. Those 8 propagated into `consumption_forecast_kw` and blew the DP cost function up to **€1,516,828** (baseline €1,516,831), making the whole optimisation meaningless.

### Fix

- `MAX_PLAUSIBLE_CONSUMPTION_KW = 50.0` in `const.py`. Chosen above what a 3×80 A connection draws at full load for an entire hour (~55 kW peak), so no real household hour crosses it, while every artefact of this class is orders of magnitude beyond it.
- Samples above the ceiling are dropped instead of averaged in, and a **warning** names how many were ignored and points at Developer Tools → Statistics to locate the offending sensor — the artefact is in the user's data, so silently discarding it would hide a real problem.

Verified against the reporting system's diagnostics: 160 of 168 buckets kept, 8 rejected, average daily consumption becomes a plausible **10.5 kWh** instead of 39 million kWh, peak 3.08 kW.

No migration needed — the pattern is recomputed from recorder history on every refresh, so affected users recover on the next cycle after upgrading.

### Tests

Cover rejection of an absurd sample, a bucket where every sample is an artefact (stays empty rather than falling back to nonsense), a genuinely heavy hour (11.5/12.5 kW, EV plus heat pump) that must survive, both sides of the ceiling, and the warning text.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (752 passing; 6 new)
- [x] Documentation updated if needed (n/a)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a