### PR TITLE
fix: count DC-coupled PV in the net load forecast

### DIFF
--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_ELECTRICITY_PRODUCTION_SENSORS,
     CONF_PV_FORECAST_SENSORS,
     CONF_PV_PRODUCTION_SENSORS,
+    DC_TO_AC_INVERTER_EFFICIENCY,
     DOMAIN,
     FORECAST_INTERVAL_MINUTES,
     WEATHER_STALE_AFTER_MINUTES,
@@ -404,8 +405,6 @@ class ForecastCoordinator(DataUpdateCoordinator):
         # Clamp PV values: a faulty sensor/model must not produce negative output (P1.3)
         pv_forecast = [max(0.0, v) for v in pv_forecast]
 
-        net_load_forecast = [c - p for c, p in zip(consumption_forecast, pv_forecast)]
-
         # Sum DC PV forecast across all DC subentry models, applying temperature derating
         has_dc = bool(self.pv_dc_models)
         pv_dc_forecast = [0.0] * n
@@ -431,9 +430,24 @@ class ForecastCoordinator(DataUpdateCoordinator):
         # Clamp DC PV values as well
         pv_dc_forecast = [max(0.0, v) for v in pv_dc_forecast]
 
+        # Net load = consumption minus all PV that reaches the AC side.
+        # DC-coupled PV gets there through the inverter, the same path the
+        # optimizer's baseline uses (_calculate_baseline_cost). Counting only
+        # the AC series reported a DC-coupled system as importing its entire
+        # household load while the sun was in fact covering it — the AC series
+        # is legitimately zero when every array is DC-coupled.
+        total_pv_forecast = [
+            p + dc * DC_TO_AC_INVERTER_EFFICIENCY
+            for p, dc in zip(pv_forecast, pv_dc_forecast)
+        ]
+        net_load_forecast = [
+            c - p for c, p in zip(consumption_forecast, total_pv_forecast)
+        ]
+
         # Derive current values from forecast (first element = current step)
         current_pv = pv_forecast[0] if pv_forecast else 0.0
         current_dc_pv = pv_dc_forecast[0] if pv_dc_forecast else 0.0
+        current_total_pv = current_pv + current_dc_pv * DC_TO_AC_INVERTER_EFFICIENCY
         current_consumption = self.consumption_model.get_current_consumption()
 
         result = {
@@ -445,7 +459,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
             "current_pv_kw": round(current_pv, 3),
             "current_dc_pv_kw": round(current_dc_pv, 3),
             "current_consumption_kw": round(current_consumption, 3),
-            "current_net_load_kw": round(current_consumption - current_pv, 3),
+            "current_net_load_kw": round(current_consumption - current_total_pv, 3),
             "current_ghi_wm2": round(radiation_steps[0], 1) if radiation_steps else 0.0,
             "current_wind_speed_ms": round(wind_speed_steps[0], 1)
             if wind_speed_steps

--- a/tests/test_coordinator_forecast.py
+++ b/tests/test_coordinator_forecast.py
@@ -1090,3 +1090,110 @@ async def test_async_update_data_volcast_5min_data_averaged_per_step(hass):
     # Last 5-min entry (10:25) covers 5 minutes: step 10:30 is past the
     # sensor horizon and falls back to the (zero-radiation) internal model
     assert result["pv_forecast_kw"][2] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_net_load_accounts_for_dc_coupled_pv(hass):
+    """Net load must count DC PV, which reaches AC through the inverter.
+
+    A DC-coupled system has pv_forecast_kw legitimately at zero with all
+    production in pv_dc_forecast_kw. Subtracting only the AC series reported
+    the household as importing its full load while the sun was covering it.
+    """
+    from custom_components.battery_controller.const import (
+        DC_TO_AC_INVERTER_EFFICIENCY,
+    )
+
+    pv_arrays = [
+        {
+            "subentry_id": "pv_dc_1",
+            "peak_power_kwp": 10.0,
+            "dc_coupled": True,
+        }
+    ]
+    config = _minimal_config(pv_arrays=pv_arrays)
+
+    now = datetime(2026, 7, 27, 12, 0, 0, tzinfo=timezone.utc)
+    weather_coord = MagicMock()
+    weather_coord.data = None  # zero-radiation fallback; DC comes from the mock
+
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+            return_value=_make_mock_consumption(),
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.utcnow",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.now",
+            return_value=now,
+        ),
+    ):
+        coord = ForecastCoordinator(hass, weather_coord, config)
+        coord.net_load_model = MagicMock()
+        coord.net_load_model.forecast = MagicMock(
+            return_value=(None, [4.0] * 192, None)
+        )
+        # 10 kW of DC production, no AC array at all
+        coord.pv_dc_models[0].forecast_from_radiation = MagicMock(
+            return_value=[10.0] * 192
+        )
+
+        result = await coord._async_update_data()
+
+    # The series uses the forecast (4.0 kW); the current_* values use
+    # get_current_consumption() (0.5 kW from the mock) — existing behaviour.
+    expected_series = 4.0 - 10.0 * DC_TO_AC_INVERTER_EFFICIENCY
+    expected_current = 0.5 - 10.0 * DC_TO_AC_INVERTER_EFFICIENCY
+    assert result["pv_forecast_kw"][0] == 0.0
+    assert result["pv_dc_forecast_kw"][0] == pytest.approx(10.0)
+    # A surplus, not a full-load import
+    assert result["net_load_forecast_kw"][0] == pytest.approx(expected_series, abs=1e-3)
+    assert result["current_net_load_kw"] == pytest.approx(expected_current, abs=1e-3)
+    assert result["current_net_load_kw"] < 0
+
+
+@pytest.mark.asyncio
+async def test_net_load_unchanged_for_ac_only_system(hass):
+    """AC-only systems keep the previous behaviour exactly."""
+    pv_arrays = [
+        {
+            "subentry_id": "pv_ac_1",
+            "peak_power_kwp": 4.0,
+            "dc_coupled": False,
+        }
+    ]
+    config = _minimal_config(pv_arrays=pv_arrays)
+
+    now = datetime(2026, 7, 27, 12, 0, 0, tzinfo=timezone.utc)
+    weather_coord = MagicMock()
+    weather_coord.data = None
+
+    with (
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+            return_value=_make_mock_consumption(),
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.utcnow",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.battery_controller.coordinator_forecast.dt_util.now",
+            return_value=now,
+        ),
+    ):
+        coord = ForecastCoordinator(hass, weather_coord, config)
+        coord.net_load_model = MagicMock()
+        coord.net_load_model.forecast = MagicMock(
+            return_value=(None, [2.0] * 192, None)
+        )
+        coord.pv_ac_models[0].forecast_from_radiation = MagicMock(
+            return_value=[3.0] * 192
+        )
+
+        result = await coord._async_update_data()
+
+    assert result["net_load_forecast_kw"][0] == pytest.approx(2.0 - 3.0)


### PR DESCRIPTION
Ze## Description

From #106, on v2.8.3 diagnostics. The **Net Grid Forecast** sensor subtracted only the AC PV series from consumption, ignoring `pv_dc_forecast_kw` entirely:

```python
net_load_forecast = [c - p for c, p in zip(consumption_forecast, pv_forecast)]
...
"current_net_load_kw": round(current_consumption - current_pv, 3),
```

On a DC-coupled system the AC series is legitimately zero, so the sensor reported the household as importing its **full load** while the sun was covering it.

From the reporter's diagnostics:

| field | value |
|---|---|
| `current_consumption_kw` | 4.237 kW |
| `current_pv_kw` | 0.0 kW |
| `current_dc_pv_kw` | **9.73 kW** |
| `current_net_load_kw` | **4.237 kW** ← equals consumption exactly |

9.7 kW of production silently discarded; the true position was a large surplus.

### Fix

DC PV reaches the AC side through the inverter, which is exactly how the optimizer's own baseline already treats it (`_calculate_baseline_cost`: `total_pv_w = pv_w + pv_dc_w * DC_TO_AC_INVERTER_EFFICIENCY`). Net load now uses the same path, so the sensor and the optimizer agree.

Net load is also computed after the DC series is summed, since it now depends on it.

**This is a reporting fix, not a scheduling one.** The DP receives `pv_forecast` and `pv_dc_forecast` as separate inputs and was never affected, so no schedule changes — worth stating explicitly, since the reporter asked whether this was "cosmetic or going to scramble the math".

Same defect class as #113, which fixed it in the analyzer's chart; this is the integration side feeding the sensor.

### Tests

- DC-coupled system: asserts a surplus rather than a full-load import, for both the series and the `current_*` value.
- AC-only system: asserts the previous behaviour is unchanged.

### Not included

The same diagnostics show `control_action.current_grid_w = 3800` while the reporter states his grid is at zero. That value comes from his own configured real-time grid sensor (`power_consumption_sensors`), not from a calculation — the estimate branch already accounts for DC PV correctly. That looks like a sensor-side question rather than an integration bug, so it is left out of this PR.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (754 passing; 2 new)
- [x] Documentation updated if needed (n/a)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a