### PR TITLE
ci: honour the previous tag selected when publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Create Release
 
+# Triggered by publishing the release, not by the tag push, so the workflow
+# can read the release you created and honour the "Previous tag" you picked
+# there. GitHub does not expose that choice as a field — the only durable
+# trace is the compare link in the notes it generates — so it is recovered
+# from the release body below.
 on:
-  push:
-    tags: ["v*.*.*"]
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -13,12 +18,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Get version from tag
         id: version
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          TAG="${{ github.event.release.tag_name }}"
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Resolve previous tag from the release notes
+        id: prev
+        env:
+          # Quoted via env rather than inlined, so a body containing quotes or
+          # backticks cannot break out of the script.
+          BODY: ${{ github.event.release.body }}
+        run: |
+          # "Generate release notes" appends a line of the form:
+          #   **Full Changelog**: https://github.com/OWNER/REPO/compare/v2.8.2...v2.8.3
+          # The tag before "..." is exactly the previous release that was
+          # selected in the UI. Take the last occurrence, in case the body
+          # quotes other compare links above it.
+          FROM_TAG=$(printf '%s\n' "$BODY" \
+            | sed -nE 's#.*/compare/([^/[:space:]]+)\.\.\.[^[:space:])]+.*#\1#p' \
+            | tail -1)
+          if [ -n "$FROM_TAG" ]; then
+            echo "Using previous tag from the release notes: $FROM_TAG"
+          else
+            echo "No compare link in the release body; letting the changelog"
+            echo "builder fall back to the most recent tag."
+          fi
+          echo "from_tag=$FROM_TAG" >> $GITHUB_OUTPUT
 
       - name: Update version in manifest.json
         run: |
@@ -34,6 +64,9 @@ jobs:
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v6
         with:
+          # Empty fromTag = keep the action's own "most recent tag" detection.
+          fromTag: ${{ steps.prev.outputs.from_tag }}
+          toTag: ${{ github.event.release.tag_name }}
           commitMode: true
           configuration: |
             {
@@ -61,6 +94,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          # The release already exists (this runs on publish); naming the tag
+          # makes it update that one instead of guessing from the ref.
+          tag_name: ${{ github.event.release.tag_name }}
           files: battery_controller.zip
           body: |
             ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
## Description

The release workflow rebuilds the notes with `mikepenz/release-changelog-builder-action`, which picked the previous tag on its own. The **Previous tag** chosen when creating the release was therefore ignored — selecting an older reference changed nothing in the resulting notes.

The action does support this: it has a `fromTag` input, *"Defines the previous tag to compare against"*. The missing piece is getting the selection to the workflow.

**GitHub does not expose that choice.** It is used only to render the generated notes; the release object has no `previous_tag_name` field. The one durable trace is the line GitHub appends to the generated body:

```
**Full Changelog**: https://github.com/bvweerd/battery_controller/compare/v2.8.2...v2.8.3
```

The tag before `...` is exactly what was picked. So the workflow now reads it back from there.

### Changes

- **Trigger moved from `push: tags` to `release: published`.** This is the part that makes it work at all — on a tag push the release does not reliably exist yet, so its body cannot be read.
- The previous tag is parsed from the compare link and passed as `fromTag`, with `toTag` set to the released tag.
- Last occurrence wins, so a body that quotes other compare links above the generated footer is handled.
- When there is no compare link — handwritten notes, or a first release whose footer is a `/commits/` link rather than `/compare/` — `fromTag` stays empty and the action falls back to its own tag detection, i.e. exactly today's behaviour.
- Checkout, version extraction and the release step address the tag explicitly through the event payload instead of the ref.
- The body is read through an `env:` variable rather than inlined into the script, so quotes or backticks in release notes cannot break out of the shell.

Extraction was tested against six shapes: standard generated notes, a deliberately older previous tag, the markdown-link form, multiple compare links, handwritten notes, and a first release. The first four resolve correctly; the last two yield an empty value and fall back.

### One consequence worth confirming

**Pushing a bare tag no longer creates a release by itself** — releases must be created through the GitHub UI or API. That matches how you already work, since you are selecting a previous release when creating them, but it is a real change to the process and the reason this is a separate PR rather than a silent tweak.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (n/a — workflow change; extraction verified against six note formats)
- [x] Documentation updated if needed (rationale documented in the workflow itself)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a