### PR TITLE
fix: report total PV production in the PV Forecast sensor

### DIFF
--- a/custom_components/battery_controller/sensor.py
+++ b/custom_components/battery_controller/sensor.py
@@ -373,7 +373,18 @@ class BatteryPowerSensor(BatteryControllerSensor):
 
 
 class PVForecastSensor(BatteryForecastSensor):
-    """Sensor for PV production forecast."""
+    """Sensor for PV production forecast.
+
+    Reports total panel production: AC-coupled plus DC-coupled arrays. The
+    state used to be the AC series alone, which reads a permanent 0 kW on a
+    fully DC-coupled system even while the panels are at full output — there
+    the AC series is legitimately empty and everything sits in the DC series.
+    The AC/DC split stays available in the attributes.
+
+    No inverter derating is applied here: this is what the panels produce,
+    not what reaches the AC bus. Grid exchange is the net load sensor's job,
+    and that one does apply DC_TO_AC_INVERTER_EFFICIENCY.
+    """
 
     _attr_translation_key = "pv_forecast"
     _attr_name = "PV Forecast"
@@ -390,16 +401,22 @@ class PVForecastSensor(BatteryForecastSensor):
     def native_value(self) -> float | None:
         if self.coordinator.data is None:
             return None
-        return cast(float | None, self.coordinator.data.get("current_pv_kw", 0.0))
+        ac_kw = self.coordinator.data.get("current_pv_kw", 0.0) or 0.0
+        dc_kw = self.coordinator.data.get("current_dc_pv_kw", 0.0) or 0.0
+        return round(float(ac_kw) + float(dc_kw), 3)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         if self.coordinator.data is None:
             return {}
+        ac_forecast = self.coordinator.data.get("pv_forecast_kw", [])
         attrs: dict[str, Any] = {
-            "forecast_kw": self.coordinator.data.get("pv_forecast_kw", []),
+            "forecast_kw": ac_forecast,
             "forecast_interval_minutes": self.coordinator.data.get(
                 "forecast_interval_minutes", 60
+            ),
+            "current_ac_pv_kw": round(
+                float(self.coordinator.data.get("current_pv_kw", 0.0) or 0.0), 3
             ),
         }
         dc_forecast = self.coordinator.data.get("pv_dc_forecast_kw", [])
@@ -408,6 +425,11 @@ class PVForecastSensor(BatteryForecastSensor):
             attrs["current_dc_pv_kw"] = self.coordinator.data.get(
                 "current_dc_pv_kw", 0.0
             )
+            # Total series, so a DC-coupled system can chart production
+            # without having to add the two series itself.
+            attrs["total_forecast_kw"] = [
+                round(a + d, 3) for a, d in zip(ac_forecast, dc_forecast)
+            ]
         return attrs
 
 

--- a/tests/test_sensor_coverage.py
+++ b/tests/test_sensor_coverage.py
@@ -286,6 +286,19 @@ class TestPVForecastSensor:
     def test_returns_current_pv_kw(self):
         assert self._sensor({"current_pv_kw": 3.5}).native_value == 3.5
 
+    def test_state_sums_ac_and_dc(self):
+        data = {"current_pv_kw": 1.5, "current_dc_pv_kw": 2.0}
+        assert self._sensor(data).native_value == pytest.approx(3.5)
+
+    def test_state_reports_dc_only_system(self):
+        """A fully DC-coupled system must not read a permanent 0 kW."""
+        data = {"current_pv_kw": 0.0, "current_dc_pv_kw": 7.318}
+        assert self._sensor(data).native_value == pytest.approx(7.318)
+
+    def test_state_handles_none_values(self):
+        data = {"current_pv_kw": None, "current_dc_pv_kw": None}
+        assert self._sensor(data).native_value == 0.0
+
     def test_extra_attrs_empty_when_no_data(self):
         assert self._sensor(None).extra_state_attributes == {}
 
@@ -304,6 +317,20 @@ class TestPVForecastSensor:
         attrs = self._sensor(data).extra_state_attributes
         assert "dc_forecast_kw" in attrs
         assert attrs["current_dc_pv_kw"] == 0.5
+        # zip stops at the shorter series
+        assert attrs["total_forecast_kw"] == [1.5]
+
+    def test_ac_split_exposed_in_attributes(self):
+        data = {
+            "pv_forecast_kw": [0.0],
+            "pv_dc_forecast_kw": [7.0],
+            "current_pv_kw": 0.0,
+            "current_dc_pv_kw": 7.0,
+        }
+        attrs = self._sensor(data).extra_state_attributes
+        # The AC part stays visible even though the state is now the total
+        assert attrs["current_ac_pv_kw"] == 0.0
+        assert attrs["current_dc_pv_kw"] == 7.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

From #106: the PV Forecast sensor shows a flat 0 kW on a DC-coupled system.

The state was `current_pv_kw`, i.e. the **AC series alone**. On a fully DC-coupled system that series is legitimately empty — all production sits in `pv_dc_forecast_kw` — so the sensor read a permanent 0 kW while the panels were at full output. The reporter's diagnostics show `current_pv_kw: 0.0` against `current_dc_pv_kw: 7.318`.

### Fix

The state is now **AC + DC**: what the panels produce.

No inverter derating is applied here, on purpose. `DC_TO_AC_INVERTER_EFFICIENCY` describes what reaches the AC bus, which is a *grid exchange* question — that belongs to the Net Grid Forecast sensor, which already applies it since #115. A production sensor should read like the inverter's own production figure.

- `current_ac_pv_kw` added to the attributes, so the split stays visible
- `total_forecast_kw` series added alongside `forecast_kw` / `dc_forecast_kw` when DC production is present, so a DC-coupled system can chart production without summing two series itself
- `forecast_kw` keeps its current meaning (AC series), so existing consumers are unaffected

### Side effect worth flagging

The consumption model's layer-2 PV correction reads *this sensor's own recorder history* to reconstruct gross consumption (`{entry_id}_pv_forecast`). For DC-coupled systems it was adding back zero; it now adds back the real production. That is a correctness improvement, but it does mean the correction changes behaviour for those users, and history recorded before this release still holds the old AC-only values.

### Tests

DC-only system (must not read 0), mixed AC+DC, `None` values, the attribute split, and the total series.

This is the third instance of the same defect class, after #113 (analyzer chart) and #115 (net load forecast).

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (758 passing; 5 new)
- [x] Documentation updated if needed (n/a)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a