### PR TITLE
fix(analyzer): stop reporting zero-grid runs as SoC/power limited

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -2586,6 +2586,13 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 "dp_mode": result.optimal_mode,
                 "dp_power_kw": round(result.optimal_power_kw, 3),
                 "effective_mode": effective_mode,
+                # The mode the real-time controller actually ran in. This can
+                # differ from effective_mode: idle is upgraded to zero_grid on
+                # PV surplus (see _resolve_controller_mode). In that case
+                # effective_power_kw stays 0 by design while the controller
+                # publishes a real setpoint, so consumers must not read the
+                # difference as the battery having hit a limit.
+                "controller_mode": controller_mode,
                 "effective_power_kw": round(effective_power, 3),
                 "setpoint_kw": round(control_action["target_power_kw"], 3),
                 "raw_target_kw": round(control_action["raw_target_w"] / 1000, 3),

--- a/docs/__tests__/analyzer.test.js
+++ b/docs/__tests__/analyzer.test.js
@@ -596,6 +596,53 @@ describe('generateTips', () => {
     expect(tips.some(t => t.title.toLowerCase().includes('pv forecast'))).toBe(false);
   });
 
+  test('no soc_limited tip when the controller ran zero_grid', () => {
+    const d = makeDiag();
+    // idle upgraded to zero_grid on PV surplus: effective_power is 0 by
+    // design while the real-time controller publishes a real setpoint
+    d.optimization.optimizer_run_log = [
+      { timestamp: '2026-07-28T10:37:00', effective_mode: 'idle',
+        controller_mode: 'zero_grid', effective_power_kw: 0, setpoint_kw: -2.18,
+        soc_kwh: 20.68, grid_kw: -3.8 },
+    ];
+    const tips = generateTips(d);
+    expect(tips.some(t => t.title.toLowerCase().includes('limited'))).toBe(false);
+  });
+
+  test('legacy run log without controller_mode is not flagged either', () => {
+    const d = makeDiag();
+    d.optimization.optimizer_run_log = [
+      { timestamp: '2026-07-28T10:37:00', effective_mode: 'idle',
+        effective_power_kw: 0, setpoint_kw: -2.18, soc_kwh: 20.68, grid_kw: -3.8 },
+    ];
+    const tips = generateTips(d);
+    expect(tips.some(t => t.title.toLowerCase().includes('limited'))).toBe(false);
+  });
+
+  test('a genuine limit is still reported', () => {
+    const d = makeDiag();
+    d.optimization.optimizer_run_log = [
+      { timestamp: '2026-07-28T18:00:00', effective_mode: 'discharging',
+        controller_mode: 'follow_schedule', effective_power_kw: 2.4,
+        setpoint_kw: 0.4, soc_kwh: 1.05, grid_kw: 1.2 },
+    ];
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.toLowerCase().includes('limited'));
+    expect(tip).toBeDefined();
+    expect(tip.t).toBe('warn');
+  });
+
+  test('idle without a grid surplus is still compared', () => {
+    // No surplus means no zero_grid upgrade, so a mismatch is real
+    const d = makeDiag();
+    d.optimization.optimizer_run_log = [
+      { timestamp: '2026-07-28T18:00:00', effective_mode: 'idle',
+        effective_power_kw: 0, setpoint_kw: -2.0, soc_kwh: 20.0, grid_kw: 1.5 },
+    ];
+    const tips = generateTips(d);
+    expect(tips.some(t => t.title.toLowerCase().includes('limited'))).toBe(true);
+  });
+
   test('ok tip included in clean configuration', () => {
     // Only ok and info tips should result in a "well-tuned" message
     // Remove any triggers for warn/err

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -920,9 +920,24 @@ function generateTips(d) {
     // effective_power_kw is always 0 in zero_grid mode by design (the real-time
     // controller determines power dynamically, not the DP schedule), so comparing
     // it to setpoint_kw there would always look "limited" even under normal
-    // zero_grid charging/discharging. Only compare when effective_mode isn't zero_grid.
+    // zero_grid charging/discharging.
+    //
+    // That also covers idle: on PV surplus the coordinator upgrades an idle
+    // effective_mode to a zero_grid controller mode, leaving effective_power_kw
+    // at 0 while the controller publishes a real setpoint. Checking
+    // effective_mode alone flagged every such run as "SoC/power limited" even
+    // with the SoC sitting mid-range. controller_mode records what actually
+    // ran; older diagnostics predate it, so fall back to the shape of that
+    // situation (idle, no effective power, and a grid surplus).
+    const ranZeroGrid = e => {
+      if (e.effective_mode === 'zero_grid' || e.controller_mode === 'zero_grid') return true;
+      if (e.controller_mode !== undefined) return false;
+      return e.effective_mode === 'idle'
+        && (e.effective_power_kw ?? 0) === 0
+        && (e.grid_kw ?? 0) < 0;
+    };
     const socLimitedRuns = runLog2.filter(e =>
-      e.effective_mode !== 'zero_grid'
+      !ranZeroGrid(e)
       && Math.abs((e.setpoint_kw ?? 0) - (e.effective_power_kw ?? 0)) > 0.05
     );
     const commitLocked = runLog2.filter(e => e.commitment_locked);


### PR DESCRIPTION
## Description

From #106. The analyzer reported:

> ⚠ Setpoint was SoC/power limited in 15/86 optimizer runs (17%)
> * 10:37: eff=0.00 kW → setp=-2.18 kW (SoC=20.68 kWh)
> * 10:45: eff=0.00 kW → setp=-2.18 kW (SoC=20.90 kWh)

With limits of 5.5 and 55 kWh, a SoC of 20.7 kWh is nowhere near either. **Nothing was limited** — the tip was wrong, and it told the user their optimizer had planned something impossible.

### Cause

On PV surplus the coordinator upgrades an **idle** `effective_mode` to a **zero_grid** controller mode (`_resolve_controller_mode`: idle + surplus + real-time power sensors → zero_grid). In that state `effective_power_kw` stays 0 *by design* while the real-time controller publishes an actual setpoint — here −2.18 kW, i.e. charging 2.18 kW to absorb the surplus at 40% SoC.

The analyzer already knew to skip this for zero-grid, but only tested the literal value:

```js
e.effective_mode !== 'zero_grid' && Math.abs(setpoint - effective_power) > 0.05
```

Upgraded runs are recorded as `'idle'`, so they slipped past the guard and every one of them was flagged. The run log did not record which mode the controller actually ran in, so the analyzer had no way to distinguish an upgraded idle from a genuine clamp.

Notably this only surfaced for the reporter once he configured a real-time grid power sensor — the upgrade requires one.

### Fix

- **Coordinator**: log `controller_mode` alongside `effective_mode`, with a comment explaining why the two can differ and why the difference must not be read as a limit.
- **Analyzer**: skip runs where the controller ran zero-grid, using `controller_mode` when present. Diagnostics produced before this field existed fall back to the shape of the situation — idle, no effective power, and a grid surplus — so existing files stop producing the false positive too.

### Tests

Upgraded-idle case, the legacy-log fallback, a genuine limit that must still be reported (SoC at the floor, follow_schedule), and idle *without* a surplus where a mismatch is real and should still be flagged.

758 Python tests and 59 Jest tests passing.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (4 new Jest tests; 59 passing)
- [x] Documentation updated if needed (rationale documented at both sites)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a