### PR TITLE
docs(analyzer): say the SoC boundary tips describe the planned horizon

### DIFF
--- a/docs/__tests__/analyzer.test.js
+++ b/docs/__tests__/analyzer.test.js
@@ -596,6 +596,34 @@ describe('generateTips', () => {
     expect(tips.some(t => t.title.toLowerCase().includes('pv forecast'))).toBe(false);
   });
 
+  test('SoC boundary tips name the planned horizon, not history', () => {
+    const d = makeDiag();
+    // Battery pinned at max for the whole planned schedule
+    d.battery_config.max_soc_kwh = 9.0;
+    d.battery_config.min_soc_kwh = 1.0;
+    d.optimization.schedule.soc_schedule_kwh = [9, 9, 9, 9, 9];
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.toLowerCase().includes('max soc'));
+    expect(tip).toBeDefined();
+    // Must not read as a claim about measured history
+    expect(tip.title.toLowerCase()).toContain('planned');
+    expect(tip.title.toLowerCase()).toContain('horizon');
+    expect(tip.title.toLowerCase()).not.toContain('of the time');
+    expect(tip.text.toLowerCase()).toContain('not what the battery did in the past');
+  });
+
+  test('minimum SoC tip is worded the same way', () => {
+    const d = makeDiag();
+    d.battery_config.max_soc_kwh = 9.0;
+    d.battery_config.min_soc_kwh = 1.0;
+    d.optimization.schedule.soc_schedule_kwh = [1, 1, 1, 1, 1];
+    const tips = generateTips(d);
+    const tip = tips.find(t => t.title.toLowerCase().includes('minimum soc'));
+    expect(tip).toBeDefined();
+    expect(tip.title.toLowerCase()).toContain('planned');
+    expect(tip.text.toLowerCase()).toContain('not what the battery did in the past');
+  });
+
   test('ok tip included in clean configuration', () => {
     // Only ok and info tips should result in a "well-tuned" message
     // Remove any triggers for warn/err

--- a/docs/analyzer.js
+++ b/docs/analyzer.js
@@ -822,7 +822,11 @@ function generateTips(d) {
       connecting a sensor improves PV and export timing decisions.`});
   }
 
-  // 6. SoC boundary hits
+  // 6. SoC boundary hits.
+  // soc_schedule_kwh is the schedule the optimizer just produced for the
+  // horizon ahead — not measured history. The wording has to say so, or the
+  // percentage reads as a claim about what the battery actually did, which
+  // sends people looking for a fault in the past.
   const socVals = sched.soc_schedule_kwh || [];
   const maxSoc  = bc.max_soc_kwh || Infinity;
   const minSoc  = bc.min_soc_kwh || 0;
@@ -830,14 +834,19 @@ function generateTips(d) {
     const atMax = socVals.filter(s => s >= maxSoc - 0.15).length / socVals.length;
     const atMin = socVals.filter(s => s <= minSoc + 0.15).length / socVals.length;
     if (atMax > 0.4) {
-      tips.push({ t:'info', title:`Battery at max SoC ${(atMax*100).toFixed(0)}% of the time`,
-        text:`Frequent saturation may indicate: (1) PV production exceeds battery capacity,
+      tips.push({ t:'info', title:`Planned schedule sits at max SoC for ${(atMax*100).toFixed(0)}% of the horizon`,
+        text:`This describes the schedule the optimizer just produced for the hours ahead,
+        not what the battery did in the past.<br>
+        Planned saturation may indicate: (1) PV production exceeds battery capacity,
         (2) max_soc_percent too conservative, or (3) not enough discharge windows to make room.`});
     }
     if (atMin > 0.35) {
-      tips.push({ t:'info', title:`Battery at minimum SoC ${(atMin*100).toFixed(0)}% of the time`,
-        text:`Battery is frequently depleted. Could indicate undersized capacity vs discharge demand,
-        or min_soc_percent too high. Consider whether this is intentional (backup reserve) or not.`});
+      tips.push({ t:'info', title:`Planned schedule sits at minimum SoC for ${(atMin*100).toFixed(0)}% of the horizon`,
+        text:`This describes the schedule the optimizer just produced for the hours ahead,
+        not what the battery did in the past.<br>
+        The plan leaves the battery depleted for much of the horizon. Could indicate undersized
+        capacity vs discharge demand, or min_soc_percent too high. Consider whether this is
+        intentional (backup reserve) or not.`});
     }
   }
 


### PR DESCRIPTION
## Description

Companion to #119, from the same confusion in #106.

The SoC boundary tips read:

> Battery at max SoC 62% **of the time**

That sounds like a statement about measured history. It is not — it is computed from `soc_schedule_kwh`, the schedule the optimizer produced for the hours *ahead*. In #106 a user read a neighbouring tip as a historical claim and went looking for a fault in the past that had never happened, so the ambiguity is not hypothetical.

### Changes

- Titles now read **"Planned schedule sits at max/minimum SoC for N% of the horizon"**.
- Both texts open by stating this describes the plan ahead, not what the battery did.
- The "battery is frequently depleted" phrasing becomes "the plan leaves the battery depleted for much of the horizon", for the same reason.
- A comment at the computation records why the wording matters, so it does not drift back.

Thresholds and logic are unchanged — this is purely how the finding is stated.

### Tests

Two tests assert the wording cannot regress to the historical reading: the titles must contain "planned" and "horizon" and must *not* contain "of the time", and both texts must carry the disclaimer.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable (2 new Jest tests; 57 passing)
- [x] Documentation updated if needed (rationale recorded at the computation)
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a