### PR TITLE
chore: add issue management labels to GitHub config

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -50,3 +50,23 @@
 - name: "breaking change"
   color: "e11d48"
   description: "Contains a breaking change"
+
+- name: "never-stale"
+  color: "1d76db"
+  description: "Never mark as stale or auto-close"
+
+- name: pinned
+  color: "1d76db"
+  description: "Kept open regardless of inactivity"
+
+- name: security
+  color: "b60205"
+  description: "Security related, exempt from auto-close"
+
+- name: backlog
+  color: "c5def5"
+  description: "Planned for later, exempt from auto-close"
+
+- name: "work-in-progress"
+  color: "fbca04"
+  description: "Still being worked on, exempt from auto-close"


### PR DESCRIPTION
## Description

Adds five new GitHub issue labels to `.github/labels.yml` to improve issue lifecycle and triage management:

- **never-stale**: Prevents issues from being auto-closed by stale bots
- **pinned**: Keeps issues open regardless of inactivity
- **security**: Marks security-related issues, exempt from auto-close
- **backlog**: Indicates planned work for later, exempt from auto-close
- **work-in-progress**: Marks issues still being worked on, exempt from auto-close

These labels enable better control over which issues should remain open and help organize the issue backlog.

## Type of change

- [x] `chore:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable (N/A — configuration change)
- [x] Documentation updated if needed (N/A)
- [x] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Notes

This is a configuration-only change with no impact on the integration code, tests, or documentation.