### PR TITLE
build: pin the mypy hook to Python 3.13 so stubs resolve correctly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,15 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
+        # Pin the interpreter: without this, pre-commit builds the hook env
+        # with whatever Python it happens to run under. On 3.11 or 3.12 pip
+        # silently resolves homeassistant-stubs down to 2024.3.3 (the last
+        # release allowing <3.13), which predates ConfigEntry.runtime_data and
+        # subentries and reports ~70 false positives. CI already uses 3.13.
+        language_version: python3.13
         args: [--ignore-missing-imports]
         additional_dependencies:
-          - homeassistant-stubs
+          # Floor, so an environment that cannot satisfy it fails loudly
+          # instead of quietly type-checking against two-year-old stubs.
+          - homeassistant-stubs>=2025.1.0
         files: ^custom_components/battery_controller/


### PR DESCRIPTION
## Description

The `mypy` pre-commit hook declared no `language_version`, so pre-commit built its environment with whatever Python it happened to run under. Every `homeassistant-stubs` release from 2024.4 onwards requires `>=3.12`, so on a 3.11 interpreter pip silently resolved down to **2024.3.3** — the last release that still allowed `<3.13`.

Those stubs predate `ConfigEntry.runtime_data` (HA 2024.6) and config entry subentries, so `pre-commit run --all-files` reported **~70 false positives** across eleven files:

```
custom_components/battery_controller/__init__.py:272: error: "ConfigEntry" has no attribute "runtime_data"  [attr-defined]
custom_components/battery_controller/sensor.py:82: error: "ConfigEntry" has no attribute "subentries"  [attr-defined]
custom_components/battery_controller/coordinator_optimization.py:1834: error: Unexpected keyword argument "translation_key" for "UpdateFailed"  [call-arg]
Found 71 errors in 11 files (checked 19 source files)
```

None of them are real. The CI lint job pins `python-version: "3.13"`, gets modern stubs, and is green — so this only bites contributors whose default Python is older, and it bites them with a wall of errors that look like genuine defects.

This pins the hook to `python3.13`, matching the CI job and the version Home Assistant itself requires. It also gives `homeassistant-stubs` a floor, so an environment that cannot satisfy it fails loudly rather than quietly type-checking against two-year-old stubs.

No source files are touched — this is toolchain configuration only.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated where applicable — n/a, no source changes
- [x] Documentation updated if needed — the rationale is a comment on the hook itself
- [x] CI is green
- [x] PR targets the `dev` branch

## Logs

Before, on Python 3.11:

```
$ ls .../py_env-python3.11/lib/python3.11/site-packages/ | grep stubs
homeassistant_stubs-2024.3.3.dist-info      # Requires-Python: >=3.11,<3.13

$ pre-commit run mypy --all-files
mypy.....................................................................Failed
Found 71 errors in 11 files (checked 19 source files)
```

After:

```
$ ls .../py_env-python3.13/lib/python3.13/site-packages/ | grep stubs
homeassistant_stubs-2026.2.3.dist-info

$ pre-commit run mypy --all-files
mypy.....................................................................Passed
```

Full `pre-commit run --all-files` passes on every hook.