### PR TITLE
chore: declare the platinum quality scale in the manifest

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -13,7 +13,7 @@ battery_controller/
 │   ├── const.py              # SOC_RESOLUTION_WH=10Wh, POWER_STEP_W=100W, config keys
 │   ├── sensor.py / number.py / select.py / switch.py / binary_sensor.py
 │   ├── helpers.py            # Price extraction (Nordpool/ENTSO-E/generic formats)
-│   ├── manifest.json         # domain, version, requirements: [aiohttp]
+│   ├── manifest.json         # domain, version, quality_scale; requirements: [] (aiohttp is a Core requirement)
 │   └── translations/         # en.json + nl.json (strings.json = copy of en.json)
 ├── tests/                    # pytest tests (one file per source module)
 └── setup.cfg                 # pytest, flake8, isort, mypy, bumpversion config

--- a/custom_components/battery_controller/manifest.json
+++ b/custom_components/battery_controller/manifest.json
@@ -10,6 +10,7 @@
   "documentation": "https://www.github.com/bvweerd/battery_controller",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/bvweerd/battery_controller/issues",
+  "quality_scale": "platinum",
   "requirements": [],
   "version": "2.0.0"
 }

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -32,6 +32,12 @@ rules:
   docs-actions:
     status: exempt
     comment: No service actions.
+  docs-conditions:
+    status: exempt
+    comment: No condition platform; the integration provides no conditions.
+  docs-triggers:
+    status: exempt
+    comment: No trigger platform; the integration provides no triggers.
   docs-high-level-description:
     status: done
     comment: README "What is Battery Controller?" section.


### PR DESCRIPTION
## Description

`quality_scale.yaml` has assessed this integration at platinum for a long time, but `manifest.json` never declared it. That assessment was therefore never checked by anything.

hassfest's `quality_scale` plugin **does** run for custom integrations — it sits in `INTEGRATION_PLUGINS`, not the core-only `HASS_PLUGINS` list — but it opens with:

```python
if declared_quality_scale is None:
    return
```

So with no manifest key, validation bails out immediately. Green CI has been saying nothing about the quality scale either way.

This PR declares `"quality_scale": "platinum"`, which turns that validation on. The key is schema-valid for custom integrations: `CUSTOM_INTEGRATION_MANIFEST_SCHEMA` extends `INTEGRATION_MANIFEST_SCHEMA`, which carries `vol.Optional("quality_scale")`.

**Two missing rules.** Home Assistant has added `docs-conditions` and `docs-triggers` to the bronze tier since `quality_scale.yaml` was written, and platinum requires every prerequisite tier. This integration ships neither a `trigger.py` nor a `condition.py` and registers no triggers or conditions, so both are marked `exempt`. That takes the file from 52 to 54 rules, matching the current tier totals (21 bronze + 10 silver + 20 gold + 3 platinum).

**One documentation correction.** `.claude/rules/architecture.md` described the manifest as `requirements: [aiohttp]`. The manifest is right and the note was not — `aiohttp` is a Core requirement, and the developer documentation has a section titled *Custom integration requirements* stating that "custom integrations should only include requirements that are not required by the Core [requirements.txt]". The integration uses aiohttp through `async_get_clientsession`, which is exactly the intended route.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated where applicable — n/a, no source changes
- [x] Documentation updated if needed
- [ ] CI is green — **this PR exists to find out; see below**
- [x] PR targets the `dev` branch

## What I could and could not verify

Verified locally:

| Check | Result |
|---|---|
| Platinum rules against the code | `mypy --strict` passes (0 errors, 19 files); `async_get_clientsession` used in `coordinator_weather.py` and `config_flow.py` |
| `quality_scale.yaml` parses, all 54 rules `done` or `exempt` | yes |
| `manifest.json` valid JSON, `requirements: []` | yes |
| `pre-commit` on the changed files | passes |
| No `trigger.py` / `condition.py`, no trigger or condition registration | confirmed |

**Not verified: hassfest itself.** Running it needs the Home Assistant core repository, which is not available here, so I read the validator source rather than executing it. This is the one PR in the set whose CI outcome I cannot predict with confidence — if hassfest's rule expectations differ from what I derived from `script/hassfest/quality_scale.py`, this is where it will surface. That is the point of turning the validation on, but it does mean CI is the real check rather than a formality.

If it fails, the fix is either another missing rule entry or dropping the manifest key again; I would rather learn that from CI than keep an unvalidated platinum claim in the repository.