### PR TITLE
ci: validate the docs build and the analyzer on what actually ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          # Node 20 left maintenance in April 2026, so the analyzer tests were
+          # running on an unsupported runtime. 22 is the current LTS.
+          node-version: "22"
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,24 +8,35 @@ on:
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - ".github/workflows/pages.yml"
+  # The strict build is only a guard if it runs before the merge. Without this
+  # trigger a pull request that breaks an internal link merges green and takes
+  # the deploy down afterwards.
+  #
+  # The path list is repeated rather than shared through a YAML anchor:
+  # GitHub Actions does not support anchors, even though local YAML parsers
+  # resolve them happily.
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/pages.yml"
   workflow_dispatch:
 
 concurrency:
-  group: pages
+  # Pull requests get their own group so a docs PR cannot cancel a deploy, and
+  # two pushes to the same pull request still supersede one another.
+  group: pages-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
+    name: Build site
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
 
@@ -40,6 +51,37 @@ jobs:
       # --strict turns a broken internal link into a build failure, so a renamed
       # page cannot silently ship a dead link. The analyzer under docs/analyzer/
       # is copied verbatim; docs/__tests__/ is dropped via exclude_docs.
+      - name: Build site
+        run: mkdocs build --strict --site-dir _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Pull requests validate only. Deploying from a pull request would publish
+    # unreviewed content to the live site.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install documentation dependencies
+        run: pip install -r requirements-docs.txt
+
+      # Rebuilt rather than carried across from the build job: the build is
+      # sub-second and deterministic, so passing a directory between jobs costs
+      # more machinery than it saves.
       - name: Build site
         run: mkdocs build --strict --site-dir _site
 


### PR DESCRIPTION
## Description

Two places where CI was checking something other than what reaches users.

### The strict docs build ran after the merge, not before

`pages.yml` only triggered on push to `dev`, so `mkdocs build --strict` was a *post-merge* gate. A pull request that broke an internal link merged green and took the deploy down afterwards.

#124 merged without CI building the site even once, which makes the "strict build prevents dead links" claim in that PR half true at best. This closes that.

The workflow is now split:

- **`build`** — runs on pull requests as well as pushes. Just `mkdocs build --strict`.
- **`deploy`** — gated on `github.event_name != 'pull_request'`. Deploying from a pull request would publish unreviewed content to the live site.

Workflow-level permissions drop to `contents: read`, with `pages: write` and `id-token: write` granted to the deploy job alone, so the pull request path holds no publish rights at all.

Two deliberate choices worth flagging for review:

- The deploy job **rebuilds** rather than carrying the directory over from `build`. The build is sub-second and deterministic, so passing a directory between jobs costs more machinery than it saves.
- The path filter is **repeated rather than shared through a YAML anchor**. GitHub Actions does not support anchors, even though local YAML parsers resolve them happily — so an anchor here would validate locally and fail on GitHub.

### The analyzer tests ran on an end-of-life Node

`js-test` pinned `node-version: "20"`. Node 20 left maintenance in April 2026, so the analyzer suite was running on an unsupported runtime. Moved to 22, the current LTS.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated where applicable — n/a, workflow configuration only
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch

## Verification

| Check | Result |
|---|---|
| `npm test` on Node 22 | 70/70 pass — the local runtime here is v22.22.2, so this is measured, not assumed |
| `mkdocs build --strict` | passes |
| `pages.yml` structure | parses; `build` holds no pages permissions, `deploy` is gated on non-pull-request and depends on `build` |
| No YAML anchors remain | confirmed |
| `pre-commit run --all-files` | all hooks pass |

This pull request touches `docs/`-adjacent workflow paths, so it should exercise the new `build` job on itself.