### PR TITLE
ci: run CI on main and stop pretending the release patches the manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
-    branches: ["dev", "feature/**", "fix/**", "hotfix/**"]
+    # main is included because bump-version.yml pushes the version commit and
+    # its tag straight to main, and release.yml builds the shipped ZIP from
+    # that tag. Without main here, the one commit that reaches users is the
+    # one commit no job ever tests.
+    branches: ["main", "dev", "feature/**", "fix/**", "hotfix/**"]
     tags-ignore: ["**"]
   pull_request:
     branches: [dev, main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,21 @@ jobs:
           fi
           echo "from_tag=$FROM_TAG" >> $GITHUB_OUTPUT
 
-      - name: Update version in manifest.json
+      # manifest.json is not rewritten here. bump-my-version already updates it
+      # (see .bumpversion.toml) in the very commit this tag points at, so a sed
+      # would only rewrite the value to itself — while reading as though the
+      # release process depends on it.
+      - name: Verify the tag matches the manifest version
         run: |
-          sed -i 's/"version": "[^"]*"/"version": "${{ steps.version.outputs.version }}"/' \
-            custom_components/battery_controller/manifest.json
+          MANIFEST_VERSION=$(python3 -c \
+            "import json; print(json.load(open('custom_components/battery_controller/manifest.json'))['version'])")
+          if [ "$MANIFEST_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag ${{ github.event.release.tag_name }} does not match" \
+                 "manifest.json version $MANIFEST_VERSION. The tag was probably" \
+                 "created by hand instead of through the Bump Version workflow."
+            exit 1
+          fi
+          echo "manifest.json version $MANIFEST_VERSION matches the tag."
 
       - name: Create release ZIP
         run: |


### PR DESCRIPTION
## Description

Two gaps around the code that actually ships.

### CI never ran on `main`

The push trigger covered `dev` and the feature branch patterns, but not `main`:

```yaml
branches: ["dev", "feature/**", "fix/**", "hotfix/**"]
```

`bump-version.yml` pushes the version commit **and its tag** straight to `main`, and `release.yml` builds the release ZIP from that tag. So the one commit that reaches users was the one commit no job ever ran against. `main` is now in the trigger list.

### `release.yml` rewrote `manifest.json` for no reason

```yaml
- name: Update version in manifest.json
  run: sed -i 's/"version": "[^"]*"/"version": "…"/' …
```

That has been dead code since bump-my-version took over. `.bumpversion.toml` already lists `manifest.json` as a target, so the version is updated in the very commit the tag points at — the `sed` rewrote the value to itself, while reading as though the release process depended on it.

**Removing it outright would have lost something real**, though: a hand-created tag that skipped the Bump Version workflow used to be silently patched into agreement. So rather than deleting the step, it is replaced with an explicit check that fails the release when the tag and `manifest.json` disagree, naming the likely cause.

⚠️ **This is a behaviour change, not pure cleanup.** A release whose tag does not match the manifest now *stops* instead of shipping a ZIP whose manifest was corrected on the fly while the tagged commit says otherwise. That is the safer default in my view, but it is a judgement call — if you would rather such releases keep going through, say so and I will restore the silent patch with the dead-code comment removed instead.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated where applicable — n/a, workflow configuration only
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch

## Verification

Both workflows parse, and the release check's logic was exercised against the real manifest:

```
manifest = 2.0.0
v2.0.0 -> passes   (correct)
v9.9.9 -> fails    (correct)
```

`pre-commit run --all-files` passes. The release path itself cannot be exercised without publishing a release, so that step is verified by construction and by the logic test above rather than by a run.