### PR TITLE
fix: restore the manifest stamp in release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,9 @@ name: CI
 
 on:
   push:
-    # main is included because bump-version.yml pushes the version commit and
-    # its tag straight to main, and release.yml builds the shipped ZIP from
-    # that tag. Without main here, the one commit that reaches users is the
-    # one commit no job ever tests.
+    # main is included because releases are tagged from it, and release.yml
+    # builds the shipped ZIP from that tag. Without main here, the commit that
+    # reaches users would be one no job ever ran against.
     branches: ["main", "dev", "feature/**", "fix/**", "hotfix/**"]
     tags-ignore: ["**"]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,21 +50,17 @@ jobs:
           fi
           echo "from_tag=$FROM_TAG" >> $GITHUB_OUTPUT
 
-      # manifest.json is not rewritten here. bump-my-version already updates it
-      # (see .bumpversion.toml) in the very commit this tag points at, so a sed
-      # would only rewrite the value to itself — while reading as though the
-      # release process depends on it.
-      - name: Verify the tag matches the manifest version
+      # Load-bearing, despite .bumpversion.toml also listing manifest.json.
+      # Releases are cut by creating the tag in the GitHub UI, not through the
+      # Bump Version workflow, so the committed manifest.json still carries the
+      # previous version. Stamping it here is what makes the published ZIP —
+      # and therefore what HACS installs — report the version being released.
+      # The repository copy is intentionally left alone; only the artifact is
+      # stamped.
+      - name: Stamp the released version into manifest.json
         run: |
-          MANIFEST_VERSION=$(python3 -c \
-            "import json; print(json.load(open('custom_components/battery_controller/manifest.json'))['version'])")
-          if [ "$MANIFEST_VERSION" != "${{ steps.version.outputs.version }}" ]; then
-            echo "::error::Tag ${{ github.event.release.tag_name }} does not match" \
-                 "manifest.json version $MANIFEST_VERSION. The tag was probably" \
-                 "created by hand instead of through the Bump Version workflow."
-            exit 1
-          fi
-          echo "manifest.json version $MANIFEST_VERSION matches the tag."
+          sed -i 's/"version": "[^"]*"/"version": "${{ steps.version.outputs.version }}"/' \
+            custom_components/battery_controller/manifest.json
 
       - name: Create release ZIP
         run: |


### PR DESCRIPTION
## Description

Reverts the `release.yml` half of #129 (commit 0dee8b9). **That change would have failed every release.**

I removed the `sed` that stamps `manifest.json` before zipping, on the reasoning that `.bumpversion.toml` already updates it so the step was rewriting the value to itself. That reasoning assumed releases go through the Bump Version workflow. They do not — tags are created by hand in the GitHub UI.

Which inverts the conclusion completely:

- No bump-my-version commit precedes the tag, so the committed `manifest.json` still carries the **previous** version.
- The `sed` is therefore exactly what makes the published ZIP — and so what HACS installs — report the version being released.
- The "verify the tag matches the manifest" step I put in its place would have failed on precisely the case the `sed` exists to handle: every hand-tagged release.

The stamping step is restored, with a comment stating why it is load-bearing instead of asserting the opposite. Only the artifact is stamped; the repository copy is deliberately left alone.

Also corrects the CI trigger comment from the same change, which justified covering `main` by "bump-version.yml pushes the version commit there". Covering `main` is still right — releases are tagged from it — but the stated reason referred to a workflow that is not used.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated where applicable — n/a, workflow configuration only
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch

## Verification

The stamping behaviour was simulated against the real manifest:

```
repo manifest stays:  2.0.0
stamped artifact:     2.9.0
quality_scale intact: platinum
```

So the substitution hits only the `version` key, leaves the rest of the manifest — including the `quality_scale` added in #125 — untouched, and does not modify the checked-in file.

`release.yml` parses with the expected step order, and pre-commit passes on both changed files. The release path itself cannot be exercised without publishing a release.

## Note on bump-version.yml

`bump-version.yml` is still in the repository but is not part of how releases are actually cut. This PR leaves it alone — removing a workflow is your call, not a side effect of a revert. Happy to open a separate PR deleting it, along with `.bumpversion.toml` if you want that gone too.