### PR TITLE
test: close the coroutine that was left un-awaited, and fail on the next one

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,14 @@ addopts =
         -p syrupy
         --strict
 
+# A coroutine that is never awaited is a bug, not a note: the call silently
+# does nothing. --disable-warnings above only hides the summary section, so
+# this class of warning could sit in the suite unnoticed — which is exactly
+# what happened. Promoting it to an error still works with that flag, because
+# an error filter raises rather than reports.
+filterwarnings =
+        error:coroutine .* was never awaited:RuntimeWarning
+
 [flake8]
 max-line-length = 88
 ignore =

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -1360,11 +1360,25 @@ async def test_async_update_data_pending_schedules_rerun(hass, monkeypatch):
     monkeypatch.setattr(coord, "_run_optimization", fake_run)
 
     tasks = []
-    monkeypatch.setattr(
-        coord.hass,
-        "async_create_task",
-        lambda coro: tasks.append(coro),
-    )
+
+    def capture_task(coro):
+        """Record the scheduled coroutine, then dispose of it.
+
+        The real async_request_refresh is not patched here, so this receives a
+        genuine coroutine object. Stashing it without ever scheduling it leaves
+        it to be garbage collected un-awaited, which raises
+
+            RuntimeWarning: coroutine 'DataUpdateCoordinator.async_request_refresh'
+            was never awaited
+
+        Closing it keeps the assertion below meaningful — the call still
+        happened and is still recorded — without leaving a dangling coroutine
+        that masks the same warning coming from real code.
+        """
+        tasks.append(coro)
+        coro.close()
+
+    monkeypatch.setattr(coord.hass, "async_create_task", capture_task)
 
     result = await coord._async_update_data()
     assert result == {"control_mode": "result"}


### PR DESCRIPTION
## Description

```
RuntimeWarning: coroutine 'DataUpdateCoordinator.async_request_refresh' was never awaited
```

**This is a test artefact, not a production bug.** Every real call site is correct: `switch.py` and `select.py` `await` it, and the coordinators wrap it in `hass.async_create_task(...)`. I checked all seventeen.

The source is `test_async_update_data_pending_schedules_rerun`:

```python
monkeypatch.setattr(
    coord.hass,
    "async_create_task",
    lambda coro: tasks.append(coro),
)
```

`async_request_refresh` is *not* patched in this test, so the coordinator builds a genuine coroutine object, hands it to the fake scheduler, and nothing ever awaits or closes it. When it is collected, the warning fires.

The capture now closes the coroutine after recording it. The assertion keeps its meaning — the call still happened and is still recorded.

### The more useful half

A coroutine that is never awaited is a bug: the call silently does nothing. This one sat in the suite unnoticed because `addopts` carries `--disable-warnings`, which hides the warnings summary.

So the same message is now promoted to an error:

```ini
filterwarnings =
        error:coroutine .* was never awaited:RuntimeWarning
```

That still works alongside `--disable-warnings`, because an error filter *raises* rather than reports. The next one of these fails the suite instead of scrolling past.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [ ] CI is green — see the caveat below
- [x] PR targets the `dev` branch

## What I verified, and what I could not

**I could not run pytest.** `pytest-homeassistant-custom-component` does not build in the environment this was authored in (`PyRIC`, `paho-mqtt` and `mock-open` fail to produce wheels), so the suite itself is unverified here. CI is the check.

What I did verify directly:

```
filter regex vs the real message      -> matches
coro.close() then collect             -> no RuntimeWarning
no close() then collect               -> RuntimeWarning fires
py_compile on the modified test        -> OK
pre-commit on both changed files       -> passes
```

**A risk worth naming.** If any *other* never-awaited coroutine exists in the suite, this filter will now fail it. That is the intended behaviour and the finding would be real, but it means this PR can go red for a reason beyond the one line it fixes. If that happens and the second instance is not worth chasing now, dropping the `filterwarnings` block is a clean one-line revert that keeps the actual fix.