### PR TITLE
ci: put coverage and DP runtime in the job summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,54 @@ jobs:
         run: |
           HA_VERSION=$(pip show homeassistant | awk '/^Version:/ {print $2}')
           echo "Python ${{ matrix.python-version }} resolved Home Assistant $HA_VERSION"
-          echo "- Python \`${{ matrix.python-version }}\` → Home Assistant \`$HA_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Environment"
+            echo ""
+            echo "Python \`${{ matrix.python-version }}\` → Home Assistant \`$HA_VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run pytest
         run: pytest --cov=custom_components --cov-report=xml -q
+
+      # setup.cfg gates the build at 90%, but the number itself appeared
+      # nowhere on the pull request — so a run could sit just above the floor,
+      # or drift down towards it, with nothing to notice. always() matters
+      # here: the figure is most interesting on the run that just failed the
+      # gate.
+      - name: Summarise coverage
+        if: always()
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          print("### Coverage\n")
+
+          report = Path("coverage.xml")
+          if not report.is_file():
+              print("No `coverage.xml` was produced — pytest did not get that far.")
+              raise SystemExit
+
+          root = ET.parse(report).getroot()
+          total = float(root.get("line-rate", 0)) * 100
+          floor = 90.0
+          mark = "✅" if total >= floor else "❌"
+          print(f"{mark} **{total:.1f}%** overall (floor {floor:.0f}%)\n")
+
+          files = sorted(
+              (
+                  (float(c.get("line-rate", 0)) * 100, c.get("filename", "?"))
+                  for c in root.iter("class")
+              ),
+          )
+          weakest = [f for f in files if f[0] < 95.0][:5]
+          if weakest:
+              print("Least covered files:\n")
+              print("| File | Coverage |")
+              print("| --- | ---: |")
+              for rate, name in weakest:
+                  print(f"| `{name}` | {rate:.1f}% |")
+          PY
 
       - name: Upload coverage
         uses: codecov/codecov-action@v7
@@ -127,7 +171,27 @@ jobs:
       # this hot numeric loop, so a benchmark inside it would measure jest
       # rather than the DP.
       - name: Check DP runtime
-        run: npm run test:perf
+        run: |
+          # pipefail so the guard's exit code survives the tee; bash -e alone
+          # would report the exit status of tee instead.
+          set -o pipefail
+          npm run test:perf | tee perf-output.txt
+
+      # The benchmark prints its median on every run, but inside a job log that
+      # only gets read when something already failed. Surfacing it here makes a
+      # drift towards the ceiling visible while the check is still passing.
+      - name: Summarise DP runtime
+        if: always()
+        run: |
+          {
+            echo "### Analyzer DP runtime"
+            echo ""
+            if grep -q '^DP runtime:' perf-output.txt 2>/dev/null; then
+              sed -n 's/^DP runtime: //p' perf-output.txt
+            else
+              echo "The benchmark produced no timing — it failed before measuring."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   hassfest:
     name: Home Assistant hassfest


### PR DESCRIPTION
## Description

Both numbers were already being produced, then buried.

`setup.cfg` gates the build at 90% coverage (#127), but the figure itself appeared **nowhere** on a pull request — so a run could sit just above the floor, or drift towards it, with nothing to notice. The DP benchmark (#132) prints its median on every run, inside a job log that only gets read once something has already failed.

Neither is a pass/fail signal. GitHub's own check list covers that, and a PR comment restating it would just duplicate the merge box. What was missing is the **trend**, so both now go to `$GITHUB_STEP_SUMMARY`, next to the resolved Home Assistant version already reported there.

### What a run looks like now

```markdown
### Environment

Python `3.14` → Home Assistant `2026.8.1`

### Coverage

✅ **95.1%** overall (floor 90%)

Least covered files:

| File | Coverage |
| --- | ---: |
| `custom_components/battery_controller/coordinator_optimization.py` | 79.1% |
| `custom_components/battery_controller/helpers.py` | 93.4% |

### Analyzer DP runtime

144 steps, median 558 ms (runs: 595, 586, 551, 558, 542 ms, ceiling 5000 ms)
```

The per-file list is the actionable half: it names `coordinator_optimization.py` at 79% rather than leaving 95% overall to look uniformly healthy.

### Details worth reviewing

- **Both summary steps run under `always()`.** The figure is most interesting on exactly the run that just failed the gate.
- **Each handles its input being absent.** A run that died before producing `coverage.xml` or a timing says so, instead of the summary step erroring on top of the real failure.
- **`set -o pipefail` on the benchmark call.** Piping through `tee` would otherwise report `tee`'s exit status and silently swallow a failing runtime guard.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated where applicable — n/a, workflow configuration only
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch

## Verification

The coverage script was run against a synthetic `coverage.xml` in coverage.py's Cobertura layout — the output above is its real result, not a mock-up. Both failure branches were exercised too:

| Case | Result |
|---|---|
| Normal report | 95.1% total, two files listed |
| `coverage.xml` missing | "No `coverage.xml` was produced — pytest did not get that far." |
| DP runtime line present | extracted correctly from real `npm run test:perf` output |
| Benchmark output with no timing | "The benchmark produced no timing — it failed before measuring." |
| Workflow YAML | parses, step order and `always()` guards as intended |
| `pre-commit` on the changed file | passes |

The pytest suite still cannot be run in this environment (`pytest-homeassistant-custom-component` fails to build `PyRIC`, `paho-mqtt` and `mock-open`), so the coverage step is verified against a representative report rather than a live one. CI is the real check.