### PR TITLE
ci: set up the Python environment on session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# SessionStart hook: make the Python suite runnable in Claude Code on the web.
+#
+# Without this, `pip install -r requirements.txt` runs under the container's
+# default python3 (3.11). pytest-homeassistant-custom-component follows Home
+# Assistant's supported Python floor, so on 3.11 pip resolves back to 0.13.109
+# (2023), whose dependency tree — PyRIC, mock-open, an old paho-mqtt — no
+# longer builds against modern setuptools. The install fails, and it looks
+# like the environment cannot run the tests at all.
+#
+# On 3.13 pip resolves 0.13.316 and installs cleanly. So the fix is not to
+# work around the build errors but to stop using an interpreter that Home
+# Assistant left behind.
+set -euo pipefail
+
+# Local checkouts have their own environments; only set one up in the remote
+# container.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}"
+
+VENV=".venv"
+
+# Newest first: Home Assistant's floor keeps rising, and a newer interpreter
+# resolves a newer Home Assistant. 3.13 is the oldest that still works.
+PYTHON=""
+for candidate in python3.16 python3.15 python3.14 python3.13; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    PYTHON="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PYTHON" ]; then
+  echo "No Python >= 3.13 found; skipping the virtualenv." >&2
+  echo "The test suite will not be runnable in this session." >&2
+  exit 0
+fi
+
+# Idempotent: reuse the venv if it already targets the interpreter we want,
+# rebuild it if the container has since gained a newer one.
+if [ -x "$VENV/bin/python" ]; then
+  have=$("$VENV/bin/python" -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+  want=$("$PYTHON" -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+  if [ "$have" != "$want" ]; then
+    echo "Rebuilding .venv: was Python $have, now using $want"
+    rm -rf "$VENV"
+  fi
+fi
+
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "Creating .venv with $PYTHON"
+  "$PYTHON" -m venv "$VENV"
+fi
+
+"$VENV/bin/python" -m pip install --quiet --upgrade pip
+
+# pre-commit and mypy are not in requirements.txt but the CI lint job installs
+# them, so a session that can run the tests should be able to run the linters
+# too.
+echo "Installing test and lint dependencies"
+"$VENV/bin/python" -m pip install --quiet -r requirements.txt pre-commit mypy
+
+# The analyzer's Jest suite and its DP runtime guard.
+if command -v npm >/dev/null 2>&1 && [ -f package.json ]; then
+  echo "Installing npm dependencies"
+  npm install --no-audit --no-fund --silent
+fi
+
+# Put the venv first on PATH for the rest of the session, so `pytest`,
+# `mypy` and `pre-commit` resolve to it without an explicit path.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export VIRTUAL_ENV=\"$PWD/$VENV\""
+    echo "export PATH=\"$PWD/$VENV/bin:\$PATH\""
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+HA_VERSION=$("$VENV/bin/python" -m pip show homeassistant 2>/dev/null \
+  | awk '/^Version:/ {print $2}')
+echo "Ready: $("$VENV/bin/python" -V), Home Assistant ${HA_VERSION:-unknown}"
+
+# Known gap: the pre-commit mypy hook pins language_version to python3.14
+# (see .pre-commit-config.yaml). If this container has no 3.14, that one hook
+# cannot build its environment. Every other hook works; use
+# `SKIP=mypy pre-commit run --all-files`, and run mypy directly instead.
+if ! command -v python3.14 >/dev/null 2>&1; then
+  echo "Note: no python3.14 here, so the pre-commit mypy hook cannot run."
+  echo "      Use: SKIP=mypy pre-commit run --all-files"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,5 +26,17 @@
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description

Running `pip install -r requirements.txt` in the web container fails, and **the failure is misleading**. It reports that `PyRIC`, `mock-open` and `paho-mqtt` cannot be built, which reads as a broken environment. It is not:

```
python3 (3.11)  → pytest-homeassistant-custom-component 0.13.109   (2023)
python3.13      → pytest-homeassistant-custom-component 0.13.316   (current)
```

`pytest-homeassistant-custom-component` follows Home Assistant's supported Python floor. On 3.11 pip resolves back to a 2023 release whose dependency tree no longer builds against modern setuptools. On 3.13 it installs cleanly and the suite runs — **855 tests in 47 seconds**.

So the fix is not to work around the build errors but to stop using an interpreter Home Assistant left behind. This is the same failure mode as the mypy stubs in #123 and the Home Assistant version in #126: an unpinned dependency resolving quietly downwards because the interpreter is too old. I spent most of a session believing the container could not run these tests before checking which interpreter pip was actually using.

### What the hook does

- Builds a virtualenv on the **newest available** interpreter, trying 3.16 down to 3.13 — Home Assistant's floor keeps rising, and a newer interpreter resolves a newer Home Assistant.
- Installs `requirements.txt` plus `pre-commit` and `mypy`, which the CI lint job needs but `requirements.txt` does not carry.
- Runs `npm install` for the analyzer's Jest suite and DP runtime guard.
- Exports the venv onto `PATH` via `CLAUDE_ENV_FILE`, so `pytest`, `mypy` and `pre-commit` resolve without an explicit path.
- Rebuilds the venv if the container later gains a newer interpreter; otherwise reuses it (second run: **2.1 s**).
- Does nothing outside the remote container.

It also reports the one thing it cannot fix: after #126 the pre-commit `mypy` hook pins `language_version: python3.14`, and this container has only up to 3.13. That hook cannot build its environment here. The hook prints the workaround (`SKIP=mypy pre-commit run --all-files`, and run `mypy` directly) rather than leaving the next session to rediscover it.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added or updated where applicable — n/a, environment setup only
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch

## Validation

All run against a deleted `.venv`, so this is the cold path a fresh session takes.

| Check | Result |
|---|---|
| ✅ Hook execution | exits 0; `Ready: Python 3.13.12, Home Assistant 2026.2.3` |
| ✅ Linter | `SKIP=mypy pre-commit run --files …` all hooks pass; `mypy` directly: `Success: no issues found` |
| ✅ Test | `pytest tests/test_battery_model.py` → 26 passed |
| ✅ Idempotent | second run completes in 2.1 s and reuses the venv |
| ✅ Remote-only guard | with `CLAUDE_CODE_REMOTE` unset: no output, exit 0 |
| ✅ `CLAUDE_ENV_FILE` | `which pytest` → `.venv/bin/pytest` |
| ✅ Not committed | `.venv` is already covered by `.gitignore` |

One note on the guard test: `CLAUDE_CODE_REMOTE=true` is already set in this container, so the first attempt to test the local no-op path was invalid — it inherited the variable and ran anyway. Re-tested with `env -u CLAUDE_CODE_REMOTE`, which is the result above.

## Hook execution mode: synchronous

The hook runs synchronously, not in async mode.

- **Pro:** dependencies are guaranteed installed before the session starts, so there is no race where Claude tries to run tests or linters before they exist.
- **Con:** the remote session only starts once the hook finishes — roughly the length of one `pip install` on a cold container, and about 2 s on a warm one.

Say the word if you would rather have async mode for faster startup.

Once this is merged into the default branch, every future session picks it up.