### PR TITLE
fix: swap charge/discharge shadow price thresholds

### DIFF
--- a/custom_components/battery_controller/diagnostics.py
+++ b/custom_components/battery_controller/diagnostics.py
@@ -178,10 +178,12 @@ async def async_get_config_entry_diagnostics(
             "shadow_price_eur_kwh": data.get("shadow_price_eur_kwh"),
             "raw_total_cost": data.get("raw_total_cost"),
             "raw_savings": data.get("raw_savings"),
-            "discharge_threshold_eur_kwh": round(shadow_price * sqrt_rte, 4),
-            "charge_threshold_eur_kwh": round(
+            # Sell above lambda / sqrt(RTE), buy below lambda * sqrt(RTE): both
+            # conversions lose sqrt(RTE), so the sell threshold is the higher one.
+            "discharge_threshold_eur_kwh": round(
                 shadow_price / sqrt_rte if sqrt_rte > 0 else 0.0, 4
             ),
+            "charge_threshold_eur_kwh": round(shadow_price * sqrt_rte, 4),
             "commitment_state": {
                 "action": getattr(optimization_coord, "_committed_action", None),
                 "power_kw": getattr(optimization_coord, "_committed_power", None),

--- a/custom_components/battery_controller/sensor.py
+++ b/custom_components/battery_controller/sensor.py
@@ -583,8 +583,10 @@ class BatteryShadowPriceSensor(BatteryControllerSensor):
     stored in the battery right now, derived from the DP value function.
 
     Use as a decision threshold:
-    - Charge when buy_price < shadow_price / sqrt(RTE)
-    - Export/discharge when feed_in_price > shadow_price * sqrt(RTE)
+    - Charge when buy_price < shadow_price * sqrt(RTE): buying 1 kWh AC stores
+      only sqrt(RTE) kWh, each worth the shadow price.
+    - Export/discharge when feed_in_price > shadow_price / sqrt(RTE): taking
+      1 kWh out of the battery yields only sqrt(RTE) kWh at the meter.
     """
 
     _attr_translation_key = "shadow_price"
@@ -615,12 +617,15 @@ class BatteryShadowPriceSensor(BatteryControllerSensor):
         sqrt_rte_val = rte**0.5
         return {
             "shadow_price_eur_kwh": shadow_price,
-            # Minimum sell price at which discharging/exporting captures full value
-            "discharge_threshold_eur_kwh": round(shadow_price * sqrt_rte_val, 4),
-            # Maximum buy price at which charging is still economically justified
-            "charge_threshold_eur_kwh": (
+            # Minimum sell price at which discharging/exporting captures full value:
+            # 1 kWh drawn from the battery reaches the meter as sqrt(RTE) kWh, so
+            # the sell price must exceed lambda / sqrt(RTE) to beat holding it.
+            "discharge_threshold_eur_kwh": (
                 round(shadow_price / sqrt_rte_val, 4) if sqrt_rte_val > 0 else None
             ),
+            # Maximum buy price at which charging is still economically justified:
+            # 1 kWh bought stores only sqrt(RTE) kWh, worth lambda * sqrt(RTE).
+            "charge_threshold_eur_kwh": round(shadow_price * sqrt_rte_val, 4),
         }
 
 

--- a/docs/analyzer/index.html
+++ b/docs/analyzer/index.html
@@ -828,8 +828,8 @@ function renderDiagnostics(raw) {
     kv('Time step', (sched.price_interval || opts.time_step_minutes) ? `${sched.price_interval || opts.time_step_minutes} min` : '—') +
     kv('Current price', opt.current_price !== undefined ? `€ ${opt.current_price.toFixed(4)}/kWh` : '—') +
     kv('Current feed-in price', opt.current_feed_in_price !== undefined ? `€ ${opt.current_feed_in_price.toFixed(4)}/kWh` : '—') +
-    kv('Discharge threshold (λ·√RTE)', discThr !== undefined ? `€ ${discThr.toFixed(4)}/kWh` : '—') +
-    kv('Charge threshold (λ/√RTE)', chgThr !== undefined ? `€ ${chgThr.toFixed(4)}/kWh` : '—') +
+    kv('Discharge threshold (λ/√RTE)', discThr !== undefined ? `€ ${discThr.toFixed(4)}/kWh` : '—') +
+    kv('Charge threshold (λ·√RTE)', chgThr !== undefined ? `€ ${chgThr.toFixed(4)}/kWh` : '—') +
     kv('Optimizer action', opt.optimal_mode ? `${opt.optimal_mode} @ ${opt.optimal_power_kw?.toFixed(3)} kW` : '—') +
     kv('Published setpoint', publishedSetpointKw !== null && !Number.isNaN(publishedSetpointKw) ? `${publishedSetpointKw.toFixed(3)} kW` : '—');
 

--- a/tests/test_sensor_coverage.py
+++ b/tests/test_sensor_coverage.py
@@ -469,8 +469,13 @@ class TestBatteryShadowPriceSensor:
         coord.battery_config.round_trip_efficiency = 0.81  # sqrt = 0.9
         sensor = BatteryShadowPriceSensor(coord, _make_device(), _make_entry())
         attrs = sensor.extra_state_attributes
-        assert "discharge_threshold_eur_kwh" in attrs
-        assert "charge_threshold_eur_kwh" in attrs
+        # Both conversions lose sqrt(RTE): buy below lambda * sqrt(RTE), sell
+        # above lambda / sqrt(RTE). The sell threshold is therefore the higher one.
+        assert attrs["charge_threshold_eur_kwh"] == pytest.approx(0.20 * 0.9)
+        assert attrs["discharge_threshold_eur_kwh"] == pytest.approx(
+            0.20 / 0.9, abs=1e-4
+        )
+        assert attrs["charge_threshold_eur_kwh"] < attrs["discharge_threshold_eur_kwh"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The shadow price λ is the marginal value of one kWh **stored in the battery**. Both conversions lose `sqrt(RTE)`, so the two decision thresholds are:

- charge while `buy_price < λ * sqrt(RTE)` — 1 kWh bought from AC stores only `sqrt(RTE)` kWh, each worth λ
- discharge/export while `feed_in > λ / sqrt(RTE)` — 1 kWh drawn from the battery reaches the meter as only `sqrt(RTE)` kWh

The charge threshold is therefore always the **lower** of the two. The `shadow_price` sensor attributes and the diagnostics dump had them reversed, reporting a charge threshold *above* the discharge threshold — a band in which charging and discharging both look justified at once, which cannot happen.

These values are diagnostic only. The actual control decisions are unaffected: `_hybrid_plus_should_capture_surplus` and the hybrid discharge branch in `coordinator_optimization.py` already use the correct form, as do the docstring in `optimizer.py` and `docs/algorithm.md` §9. Only what the sensor and the analyzer *display* changes.

Changes:
- `sensor.py` — swap the two attributes, expand the class docstring with the reasoning
- `diagnostics.py` — same swap in the diagnostics dump
- `docs/analyzer/index.html` — swap the matching `(λ·√RTE)` / `(λ/√RTE)` labels
- `tests/test_sensor_coverage.py` — the test only asserted that the keys existed, so it could not catch this; it now asserts the values and their ordering

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed — `docs/algorithm.md` §9 was already correct and needed no change
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Local verification: 863 pytest tests and 73 Jest tests pass; `pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).

