### PR TITLE
docs: warn that Follow Schedule has no real-time correction

### DIFF
--- a/docs/control-modes.md
+++ b/docs/control-modes.md
@@ -55,6 +55,26 @@ This is the mode that produces the lowest cost *if your forecasts are correct*. 
 real-time correction, so a consumption spike the forecast did not anticipate is simply
 imported from the grid.
 
+!!! warning "No real-time correction once import and export are priced separately"
+    Follow Schedule executes the planned **battery power**. The optimizer's cost model
+    prices the **grid exchange** that this power was expected to produce — so when the
+    forecast is wrong, the realised cost is not the planned one.
+
+    This is harmless while import and export net out. Once they are priced separately, it
+    costs money whenever the net flow *changes sign within a settlement interval*: a
+    passing cloud makes you export a few minutes of surplus at the feed-in price and
+    import it back minutes later at the full retail price. Both registers count it; the
+    spread on that energy is lost. Steady periods, and periods with a firmly
+    one-directional plan, are unaffected.
+
+    Exposure is largest when the planned grid flow is near zero — a planned `idle` with
+    PV roughly matching consumption, or a discharge sized to cover the house.
+    [Hybrid](#hybrid-recommended) and [Hybrid+](#hybrid) avoid this: they hand those
+    periods to zero-grid, which regulates the meter to ~0 continuously.
+
+    Choose Follow Schedule when you want a predictable setpoint — for instance when your
+    own automations build on it. Choose Hybrid when you want the cheapest realised bill.
+
 ## Hybrid (recommended)
 
 DP schedule for arbitrage, zero-grid for self-consumption.


### PR DESCRIPTION
## Description

Adds a warning admonition to the **Follow Schedule** section of `docs/control-modes.md`.

Follow Schedule executes the planned *battery power*, but the optimizer's cost model prices the *grid exchange* that this power was expected to produce. When the forecast is wrong those two diverge, and the realised cost is not the planned one.

This is harmless while import and export net out. Once they are priced separately it costs money whenever the net flow **changes sign within a settlement interval** — a passing cloud exports a few minutes of surplus at the feed-in price and imports it back minutes later at the full retail price, with both registers counting it. Steady periods, and periods with a firmly one-directional plan, are unaffected; exposure is largest when the planned grid flow is near zero (a planned `idle` with PV roughly matching consumption, or a discharge sized to cover the house).

The admonition documents the exposure, when it bites, and points to Hybrid / Hybrid+ as the modes that avoid it by handing those periods to zero-grid.

**No behaviour change.** The `idle → zero_grid` upgrade in `_resolve_controller_mode` is already deliberately disabled for `follow_schedule` and `manual` ("where idle must mean truly stop"), and that stays as-is: literal execution is exactly what users of that mode rely on, in particular when their own automations build on the published setpoint.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — docs only, no tests apply
- [x] Documentation updated if needed
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

`pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment). Anchor links follow the existing slug convention already used by `docs/how-it-works.md:127` (`control-modes.md#hybrid-recommended`).
