### PR TITLE
docs: correct the netting explanation in the Follow Schedule warning

### DIFF
--- a/docs/control-modes.md
+++ b/docs/control-modes.md
@@ -60,12 +60,20 @@ imported from the grid.
     prices the **grid exchange** that this power was expected to produce — so when the
     forecast is wrong, the realised cost is not the planned one.
 
-    This is harmless while import and export net out. Once they are priced separately, it
-    costs money whenever the net flow *changes sign within a settlement interval*: a
-    passing cloud makes you export a few minutes of surplus at the feed-in price and
-    import it back minutes later at the full retail price. Both registers count it; the
-    spread on that energy is lost. Steady periods, and periods with a firmly
-    one-directional plan, are unaffected.
+    The meter has separate registers for import and export, and they simply accumulate:
+    nothing is ever netted between them. While a netting arrangement applies at billing
+    time this does not matter, but once each direction is billed at its own price, every
+    exported Wh that you later import back costs you the spread.
+
+    The optimizer handles that trade-off *between* time steps — storing surplus versus
+    exporting it is its core decision. What it cannot see is variation *within* one step:
+    `calculate_step_cost` prices the net exchange over the whole step, so a sub-step swing
+    that changes direction is invisible to it. A passing cloud exports a few minutes of
+    surplus at the feed-in price and imports it back minutes later at the full retail
+    price; the step's net looks unchanged. The window here is the optimizer's own time
+    step — the resolution of your price sensor, 15 or 60 minutes — not any billing
+    interval. Steady periods, and periods with a firmly one-directional plan, are
+    unaffected.
 
     Exposure is largest when the planned grid flow is near zero — a planned `idle` with
     PV roughly matching consumption, or a discharge sized to cover the house.


### PR DESCRIPTION
## Description

Follow-up to #144, which described the exposure as the net flow *"changing sign within a settlement interval"*. That framing is wrong and worth correcting.

Import and export registers never net against each other at the meter — there is one connection point, so at any instant only one of them advances. A netting arrangement is a billing rule layered on top of the register totals, and its window is the billing period, not any short interval. Once each direction is billed at its own price there is no netting window at all, at any timescale.

So the exposure is not a billing boundary but a **model-resolution limit**. The optimizer already prices the store-versus-export trade-off *between* time steps — that is its core decision. What it cannot see is variation *within* one step, because `calculate_step_cost` prices the net exchange over the whole step. The relevant window is therefore the optimizer's own time step (the price sensor's resolution, 15 or 60 min), which is what the text now says.

Docs only; the surrounding guidance and the mode behaviour are unchanged.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — docs only, no tests apply
- [x] Documentation updated if needed
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

`pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).