### PR TITLE
docs: document the sub-step resolution limit and the re-solve cadence

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,6 +64,26 @@ SoC can shift how much capacity gets allocated to the current window versus a la
 This is expected rolling-horizon DP behaviour. See
 [the learning period](how-it-works.md#learning-period-give-the-optimizer-time-to-calibrate).
 
+### Why does it not re-optimize every few seconds?
+
+Two reasons, and the first is the surprising one.
+
+Within a price period the prices and the forecasts do not change. The only thing that could
+flip a decision between two ticks is the shadow price moving as the battery fills or
+empties — and it barely moves. The value function is piecewise linear in SoC, so the
+[shadow price](glossary.md) is piecewise *constant*, flat over most of the range.
+Re-evaluating it every five seconds returns the answer it returned fifteen minutes ago.
+
+The second is cost. A full solve takes roughly twenty seconds on a fast machine and runs
+four times an hour. Running it every five seconds is about a hundred and eighty times the
+processing, and not even possible, since a single solve outlasts the interval. Shortening
+the horizon scales down proportionally, but a one-hour horizon still costs several times
+the entire current optimizer — and it cannot see tomorrow evening, so its shadow price
+would be a worse signal than the one already published.
+
+Real-time correction is handled by the zero-grid controller instead, which runs every few
+seconds and needs no optimization at all.
+
 ### The optimizer stopped charging during what looked like the most profitable window
 
 Usually one of three things:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -175,3 +175,9 @@ the more stable the resulting schedule.
 - **Consumption pattern learning** — the consumption model needs several weeks of kWh
   sensor history for accurate patterns. Forecasts are less accurate during the initial
   period.
+- **Sub-step resolution** — the cost function prices the *net* grid exchange over a whole
+  time step. Variation inside a step averages out, so when the meter flows both ways
+  within one step, the difference between the buying and selling price on the smaller of
+  the two directions is not seen. This needs the planned flow to sit near zero, which
+  makes it mainly a [Follow Schedule](control-modes.md#follow-schedule) concern — Hybrid
+  hands those periods to zero-grid.


### PR DESCRIPTION
## Description

Two documentation additions, both covering ground that was previously only implicit.

**`how-it-works.md` → Known limitations** gains an entry for sub-step resolution. The Follow Schedule warning added in #144/#145 describes the same effect, but that text is mode-specific, while the limitation itself lives in the cost function and applies everywhere: `calculate_step_cost` prices the *net* exchange over a whole step, so a swing that averages out inside a step is invisible to it. The entry notes that this needs the planned flow to sit near zero, which is what makes it mainly a Follow Schedule concern.

**`faq.md` → Modes and scheduling** gains *"Why does it not re-optimize every few seconds?"*. The intuitive assumption is that it should, so it is worth stating why it would not help:

- Within a price period the prices and forecasts do not change. The only thing that could flip a decision between ticks is the shadow price moving as the SoC changes — and the value function is piecewise linear in SoC, so the shadow price is piecewise *constant*, flat over most of the range. A per-tick re-evaluation returns the previous answer.
- The cost side: a full solve is roughly twenty seconds and runs four times an hour. Every five seconds is about 180× the processing, and not even possible since a single solve outlasts the interval. Shortening the horizon scales down proportionally, but a one-hour horizon still costs several times the entire current optimizer and cannot see tomorrow evening.

Deliberately not documented: any euro figure for the sub-step effect. The magnitude depends on the installation and any number in the docs would be held against it.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — docs only, no tests apply
- [x] Documentation updated if needed
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

`pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjUmZWiLB6xHSeoLWUMjr)_