### PR TITLE
fix: damp the realtime idle to zero_grid upgrade with the deadband band

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -251,6 +251,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # mode every realtime-update tick.
         self._last_hybrid_idle_decision: str = ACTION_IDLE
 
+        # Hysteresis state for the realtime idle→zero_grid upgrade in
+        # _resolve_controller_mode. The 15-min run damps its own idle/zero_grid
+        # decision (see _last_hybrid_idle_decision), but the realtime loop
+        # re-derives the controller mode from the live grid reading on every
+        # tick, so it needs its own band and memory or a surplus appearing
+        # mid-period flips idle/zero_grid until the next run.
+        self._last_idle_upgrade_decision: str = ACTION_IDLE
+
         # Hysteresis state for the hybrid charging branch: tracks whether we were
         # following the DP schedule ("charging") or capturing PV surplus only
         # ("zero_grid") so surplus hovering near the coverage threshold doesn't
@@ -879,17 +887,43 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         )
         return should_capture
 
+    def _hybrid_deadband_w(self) -> float:
+        """Return the hysteresis band for the hybrid mode transitions, in W.
+
+        Reuses the user-tunable zero-grid deadband: the idle/zero_grid and
+        charging/zero_grid transitions address the same real-time sensor-noise
+        problem the deadband already exists to solve. Read from the live entry
+        options so the number entity takes effect without a reload.
+        """
+        entry_id = self.config.get("entry_id", "")
+        live_entry = self.hass.config_entries.async_get_entry(entry_id)
+        live_options = live_entry.options if live_entry is not None else {}
+        return float(
+            live_options.get(
+                CONF_ZERO_GRID_DEADBAND_W,
+                self.config.get(
+                    CONF_ZERO_GRID_DEADBAND_W, DEFAULT_ZERO_GRID_DEADBAND_W
+                ),
+            )
+        )
+
     def _resolve_controller_mode(
         self, effective_mode: str, current_grid_w: float
     ) -> str:
         """Map effective mode to zero_grid_controller mode.
 
-        For idle mode with PV surplus (grid < 0), upgrades to zero_grid
-        when real-time power sensors are available. Uses a 50 W hysteresis:
-        enter zero_grid when grid < 0, stay in zero_grid until grid >= 50 W.
-        This prevents oscillation when the battery successfully absorbs PV and
-        grid reads near 0 W (which would otherwise flip back to idle mode,
-        stopping the charge, causing the grid to go negative again).
+        For idle mode with PV surplus, upgrades to zero_grid when real-time
+        power sensors are available. The decision is damped with a band of
+        ±zero_grid_deadband_w (the user-tunable number entity, default 50 W)
+        around the 0 W crossing, remembered across calls: enter zero_grid only
+        once the grid exports more than the band, then stay there until it
+        climbs solidly positive.
+
+        Without that band the battery absorbing PV drives the grid to ~0 W,
+        which reads as "no surplus", which stops the charge, which sends the
+        grid negative again — an oscillation at tick rate. The setpoint
+        deadband does not damp it, because the swing between the zero_grid
+        setpoint and idle's 0 W is far larger than the deadband.
 
         In hybrid+ mode the upgrade is suppressed while surplus capture is
         blocked (exporting is worth more than storing per the shadow price),
@@ -909,23 +943,36 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if effective_mode == "zero_grid":
             return "zero_grid"
         # Upgrade idle → zero_grid only in zero_grid/hybrid/hybrid+ modes (not
-        # follow_schedule or manual, where idle must mean truly stop). Only when
-        # grid is actually exporting (negative), i.e. real PV surplus — not just
-        # near-zero import noise. Hybrid+ additionally requires that surplus
-        # capture is economical per the last optimizer run.
-        if (
-            effective_mode == ACTION_IDLE
-            and self._control_mode not in (MODE_FOLLOW_SCHEDULE, MODE_MANUAL)
-            and not (
-                self._control_mode == MODE_HYBRID_PLUS
-                and self._hybrid_plus_capture_blocked
-            )
-            and current_grid_w < 0
-            and has_power_sensors
-        ):
-            return "zero_grid"
+        # follow_schedule or manual, where idle must mean truly stop). Hybrid+
+        # additionally requires that surplus capture is economical per the last
+        # optimizer run.
         if effective_mode == ACTION_IDLE:
-            return ACTION_IDLE
+            upgrade_allowed = (
+                self._control_mode not in (MODE_FOLLOW_SCHEDULE, MODE_MANUAL)
+                and not (
+                    self._control_mode == MODE_HYBRID_PLUS
+                    and self._hybrid_plus_capture_blocked
+                )
+                and has_power_sensors
+            )
+            if not upgrade_allowed:
+                # Reset the memory so a later upgrade starts from the strict
+                # entry threshold rather than the sticky one.
+                self._last_idle_upgrade_decision = ACTION_IDLE
+                return ACTION_IDLE
+            band = self._hybrid_deadband_w()
+            if self._last_idle_upgrade_decision == "zero_grid":
+                # Was capturing surplus; keep doing so until the grid climbs
+                # solidly positive (the surplus has genuinely disappeared).
+                has_pv_surplus = current_grid_w < band
+            else:
+                # Was idle; only start capturing once the surplus is solid, so
+                # near-zero import noise does not trigger it.
+                has_pv_surplus = current_grid_w < -band
+            self._last_idle_upgrade_decision = (
+                "zero_grid" if has_pv_surplus else ACTION_IDLE
+            )
+            return "zero_grid" if has_pv_surplus else ACTION_IDLE
         if effective_mode == "manual":
             return "manual"
         if effective_mode in (ACTION_CHARGING, ACTION_DISCHARGING):
@@ -1975,18 +2022,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 self.config.get(CONF_MIN_PRICE_SPREAD, DEFAULT_MIN_PRICE_SPREAD),
             )
         )
-        # Reuse the user-tunable zero-grid deadband as the hysteresis band for
-        # the hybrid-mode idle/zero_grid and charging/zero_grid transitions
-        # below: both address the same real-time sensor-noise problem the
-        # deadband already exists to solve.
-        hybrid_deadband_w = float(
-            live_options.get(
-                CONF_ZERO_GRID_DEADBAND_W,
-                self.config.get(
-                    CONF_ZERO_GRID_DEADBAND_W, DEFAULT_ZERO_GRID_DEADBAND_W
-                ),
-            )
-        )
+        hybrid_deadband_w = self._hybrid_deadband_w()
 
         # Synthesise start_times for fallback paths that have no real timestamps
         now_utc = dt_util.utcnow()

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -1003,15 +1003,16 @@ def test_resolve_controller_mode(hass):
     # zero_grid effective mode → "zero_grid"
     assert coord._resolve_controller_mode("zero_grid", 100.0) == "zero_grid"
 
-    # idle in non-follow/non-manual mode with negative grid → upgrade to zero_grid
+    # idle in non-follow/non-manual mode with a solid export surplus (beyond the
+    # deadband band) → upgrade to zero_grid
     coord._control_mode = MODE_ZERO_GRID
-    assert coord._resolve_controller_mode("idle", -50.0) == "zero_grid"
+    assert coord._resolve_controller_mode("idle", -200.0) == "zero_grid"
 
     # idle in follow_schedule mode → stays idle
     from custom_components.battery_controller.const import MODE_FOLLOW_SCHEDULE
 
     coord._control_mode = MODE_FOLLOW_SCHEDULE
-    assert coord._resolve_controller_mode("idle", -50.0) == "idle"
+    assert coord._resolve_controller_mode("idle", -200.0) == "idle"
 
     # manual mode
     assert coord._resolve_controller_mode("manual", 0.0) == "manual"
@@ -1021,6 +1022,64 @@ def test_resolve_controller_mode(hass):
 
     # discharging
     assert coord._resolve_controller_mode("discharging", 0.0) == "follow_schedule"
+
+
+def test_resolve_controller_mode_idle_upgrade_hysteresis(hass):
+    """The realtime idle→zero_grid upgrade is damped by the deadband band.
+
+    Regression: the 15-min run damps its own idle/zero_grid decision, but the
+    realtime loop re-derives the controller mode from the live grid reading on
+    every tick. With a bare `current_grid_w < 0` test, a surplus appearing
+    mid-period made the battery absorb it, which drove the grid to ~0 W, which
+    read as "no surplus", which stopped the charge — flipping every tick until
+    the next optimizer run.
+    """
+    from custom_components.battery_controller.const import MODE_HYBRID
+
+    coord = _make_coordinator(hass)
+    coord._control_mode = MODE_HYBRID
+    coord._power_consumption_sensors = ["sensor.c"]
+    band = coord._hybrid_deadband_w()
+
+    # Near-zero import noise must not trigger the upgrade.
+    assert coord._resolve_controller_mode("idle", -band / 2) == "idle"
+
+    # A solid surplus does.
+    assert coord._resolve_controller_mode("idle", -band * 4) == "zero_grid"
+
+    # Now the battery absorbs it and the grid settles near zero. The mode must
+    # hold rather than flipping back — this is the oscillation being damped.
+    for grid_w in (-band / 2, 0.0, band / 2):
+        assert coord._resolve_controller_mode("idle", grid_w) == "zero_grid"
+
+    # Only once the grid climbs solidly positive has the surplus really gone.
+    assert coord._resolve_controller_mode("idle", band * 4) == "idle"
+
+    # And re-entry needs a solid surplus again, not just a dip below zero.
+    assert coord._resolve_controller_mode("idle", -band / 2) == "idle"
+
+
+def test_resolve_controller_mode_idle_upgrade_resets_when_blocked(hass):
+    """A blocked upgrade resets the memory to the strict entry threshold."""
+    from custom_components.battery_controller.const import (
+        MODE_FOLLOW_SCHEDULE,
+        MODE_HYBRID,
+    )
+
+    coord = _make_coordinator(hass)
+    coord._control_mode = MODE_HYBRID
+    coord._power_consumption_sensors = ["sensor.c"]
+    band = coord._hybrid_deadband_w()
+
+    assert coord._resolve_controller_mode("idle", -band * 4) == "zero_grid"
+
+    # Switching to follow_schedule blocks the upgrade and clears the memory.
+    coord._control_mode = MODE_FOLLOW_SCHEDULE
+    assert coord._resolve_controller_mode("idle", -band * 4) == "idle"
+
+    # Back in hybrid, a grid inside the band must not resume zero_grid.
+    coord._control_mode = MODE_HYBRID
+    assert coord._resolve_controller_mode("idle", -band / 2) == "idle"
 
 
 def test_split_setpoint_no_batteries(hass):


### PR DESCRIPTION
## Description

`_resolve_controller_mode` decides the realtime `idle → zero_grid` upgrade on a bare `current_grid_w < 0`, with no band and no memory. Its docstring described *"a 50 W hysteresis: enter zero_grid when grid < 0, stay in zero_grid until grid >= 50 W"* — but the code never had it. The hysteresis that does exist lives in `_run_optimization` (`_last_hybrid_idle_decision`, using the tunable deadband as the band), on the 15-minute path only.

That gap is reachable, and it oscillates:

1. The 15-min run settles on `idle` (no surplus at decision time).
2. A cloud clears and a surplus appears mid-period. The tick upgrades to `zero_grid` and starts a charge.
3. The battery absorbs the surplus, so the grid settles at ~0 W.
4. The next tick reads that as "no surplus", returns `idle`, and `_calculate_idle` commands 0 W.
5. The grid goes negative again → back to 2, every tick, until the next optimizer run.

The setpoint deadband does not damp this: the swing between the `zero_grid` setpoint and idle's 0 W is far larger than the band it compares against. This is the residual form of #81 — that fix landed on the 15-minute path, while the realtime loop re-derives the mode and bypasses it. It affects `hybrid` and `hybrid+`; `follow_schedule` and `manual` are excluded from the upgrade anyway, and with `zero_grid` as the control mode the early return applies.

## Fix

Apply the same band and memory as the 15-minute branch — enter `zero_grid` only once the export exceeds the band, then hold until the grid climbs solidly positive.

The band reuses the **Zero Grid Deadband** number entity rather than introducing a constant, and that coupling is load-bearing: the exit threshold must be at least the setpoint deadband, or successful regulation (which holds the grid at 0 ± deadband) reads as its own exit condition. Sharing one number keeps that relationship true at any value the user picks. Both call sites now read it through `_hybrid_deadband_w()`.

## Behaviour change

Entry is stricter than before: a surplus smaller than the band no longer triggers the upgrade, where previously any negative reading did. This is deliberate — a battery inverter's own standby draw is comparable to the default band, so chasing smaller surpluses stores nothing. One existing assertion used exactly `-50.0`, sitting on the new boundary, and was moved to a clearly-solid surplus.

Note that setting the deadband to `0` collapses the hysteresis and restores the old behaviour. The existing 15-minute branch has the same property, so this is left consistent rather than floored.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed — the stale docstring is corrected to describe the behaviour that now exists
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Two regression tests added: one walks the full oscillation scenario (noise → solid surplus → grid settling near zero must hold → solid import releases → re-entry needs a solid surplus again), one covers the memory reset when the upgrade is blocked.

Full suite green, coverage 95.82 % (floor 90 %). `pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjUmZWiLB6xHSeoLWUMjr)_