### PR TITLE
fix: correct the electricity consumption sensor description in the UI

### DIFF
--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -20,7 +20,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, e.g. DSMR tariff 1+2)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -28,7 +28,7 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for grid import. Used to learn household consumption patterns over time.",
+              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
               "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
             }
@@ -126,7 +126,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, e.g. DSMR tariff 1+2)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -134,7 +134,7 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for grid import. Used to learn household consumption patterns over time.",
+              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
               "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
             }

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -20,7 +20,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, e.g. DSMR tariff 1+2)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -28,7 +28,7 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for grid import. Used to learn household consumption patterns over time.",
+              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
               "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
             }
@@ -126,7 +126,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, e.g. DSMR tariff 1+2)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -134,7 +134,7 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for grid import. Used to learn household consumption patterns over time.",
+              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
               "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
             }

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -29,7 +29,7 @@
             "data": {
               "feed_in_price_sensor": "Terugleverprijs sensor (optioneel)",
               "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
-              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh, bijv. DSMR tarief 1+2)",
+              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh, bruto huisverbruik)",
               "electricity_production_sensors": "Elektriciteitsproductie sensoren (kWh, bijv. DSMR)"
             }
           },
@@ -99,7 +99,7 @@
             "data": {
               "feed_in_price_sensor": "Terugleverprijs sensor (optioneel)",
               "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
-              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh, bijv. DSMR tarief 1+2)",
+              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh, bruto huisverbruik)",
               "electricity_production_sensors": "Elektriciteitsproductie sensoren (kWh, bijv. DSMR)"
             }
           },


### PR DESCRIPTION
## Description

Reported in #106: the config flow contradicts the documentation on what **Electricity consumption sensors (kWh)** should contain.

The UI said:

> Electricity consumption sensors (kWh, e.g. DSMR tariff 1+2)
> Cumulative kWh sensors for **grid import**. Used to learn household consumption patterns over time.

That is precisely the sensor the docs say not to use — and the DSMR tariff registers named in the label *are* the grid import registers.

**The docs are the correct side.** `coordinator_forecast.py` computes `net_load = consumption − total_pv`, and `calculate_step_cost` then prices `net_grid_w = consumption_w − total_ac_pv_w + grid_to_battery_w`. The learned series must therefore be gross household load; feeding grid import subtracts PV twice — once physically, since it never passed the meter, and once in the model.

Every documentation page already says gross household load (`configuration.md`, `faq.md`, `glossary.md`, `installation.md`, `troubleshooting.md`). The UI strings were the sole outlier, and they misdirected people at the exact moment they were picking the sensor.

## Changes

- `translations/en.json` and `strings.json` — label no longer names the DSMR registers; description states gross household load, says explicitly that grid import is wrong, and gives the reason.
- `translations/nl.json` — label only, since it carries no `data_description` and falls back to English.
- `power_consumption_sensors` is deliberately left alone: that field *does* take grid import, and the contrast between the two is now explicit rather than accidental.

Not addressed here: the reporter's second point, that most HA users have no gross-load sensor at all and compute it on the fly in the Energy Dashboard. That deserves its own issue.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — string-only change, no behaviour to test
- [x] Documentation updated if needed — docs were already correct; this brings the UI in line
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

`strings.json` verified to remain an exact copy of `translations/en.json`. Full suite green, `pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjUmZWiLB6xHSeoLWUMjr)_