### PR TITLE
fix: describe both consumption sensor routes in the UI

### DIFF
--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -20,7 +20,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -28,9 +28,9 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
-              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
+              "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
+              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {
@@ -126,7 +126,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -134,9 +134,9 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
-              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
+              "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
+              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -20,7 +20,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -28,9 +28,9 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
-              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
+              "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
+              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {
@@ -126,7 +126,7 @@
               "feed_in_price_sensor": "Feed-in price sensor (if different from buy price)",
               "power_consumption_sensors": "Power consumption sensors (W, e.g. DSMR - for real-time grid balance)",
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
-              "electricity_consumption_sensors": "Electricity consumption sensors (kWh, gross household load)",
+              "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
               "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
@@ -134,9 +134,9 @@
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
               "power_consumption_sensors": "Sum of all grid import power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
-              "electricity_consumption_sensors": "Cumulative kWh sensors for gross household load — everything the house draws, from grid, PV or battery alike. Not grid import: the PV forecast is subtracted separately, so a grid meter here subtracts PV twice. Used to learn consumption patterns over time.",
-              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Used for production tracking.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters. Prevents double-counting consumption when grid export sensors already include PV production."
+              "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
+              "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -29,7 +29,7 @@
             "data": {
               "feed_in_price_sensor": "Terugleverprijs sensor (optioneel)",
               "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
-              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh, bruto huisverbruik)",
+              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh)",
               "electricity_production_sensors": "Elektriciteitsproductie sensoren (kWh, bijv. DSMR)"
             }
           },
@@ -99,7 +99,7 @@
             "data": {
               "feed_in_price_sensor": "Terugleverprijs sensor (optioneel)",
               "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
-              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh, bruto huisverbruik)",
+              "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh)",
               "electricity_production_sensors": "Elektriciteitsproductie sensoren (kWh, bijv. DSMR)"
             }
           },


### PR DESCRIPTION
## Description

Follow-up to #149, which overcorrected. It replaced *"grid import"* with *"gross household load"* and added **"Not grid import: a grid meter here subtracts PV twice"**.

That prohibition is wrong. Grid import in this field is correct — *provided* `electricity_production_sensors` and `pv_production_sensors` are filled in as well, because `ConsumptionModel` then reconstructs gross load itself (`forecast_models.py:122-131`, `249-269`):

```
net   = sum(consumption_sensors) - sum(production_sensors)   # grid import - grid export
gross = net + sum(pv_production_sensors)
```

The reconstruction runs through `statistics_during_period` with `{"change"}`, so counter resets are handled by the statistics layer. It is a supported, already implemented route, and #149 sent people away from it.

## What changed

The field accepts either input depending on what else is configured, and that condition was missing from the UI entirely. `docs/configuration.md` does cover both, but across two separate admonitions where the first reads as a flat prohibition and the second walks it back — the config flow has room for one string, so it now states both routes and the condition separating them:

> Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.

The neighbouring `electricity_production_sensors` and `pv_production_sensors` descriptions are aligned with the same wording, so the three fields read as one mechanism rather than three unrelated ones. Labels drop the parenthetical qualifier, since the description now carries it.

Docs are unchanged — they were already complete.

## Known gap, not addressed here

The reconstruction omits the battery terms: the full identity is `import − export + pv + discharge − charge`, and grid charging is therefore still learned as household load. Tracked in #151.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — string-only change, no behaviour to test
- [x] Documentation updated if needed — docs already documented both routes
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

`strings.json` verified byte-identical to `translations/en.json`; both files plus `nl.json` validated as JSON. Full suite green, `pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjUmZWiLB6xHSeoLWUMjr)_