### PR TITLE
fix: include the battery in the gross consumption reconstruction

### DIFF
--- a/custom_components/battery_controller/config_flow.py
+++ b/custom_components/battery_controller/config_flow.py
@@ -16,8 +16,8 @@ import voluptuous as vol
 
 from .const import (
     BATTERY_SUBENTRY_TYPE,
-    CONF_BATTERY_ENERGY_CHARGED_SENSORS,
-    CONF_BATTERY_ENERGY_DISCHARGED_SENSORS,
+    CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
     CONF_BATTERY_POWER_SENSOR,
     CONF_NAME,
     CONF_BATTERY_SOC_SENSOR,
@@ -144,6 +144,18 @@ def _build_battery_subentry_schema(
                 description={"suggested_value": d.get(CONF_BATTERY_POWER_SENSOR)},
             ): selector({"entity": {"domain": "sensor", "device_class": "power"}}),
             vol.Optional(
+                CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+                description={
+                    "suggested_value": d.get(CONF_BATTERY_ENERGY_CHARGED_SENSOR)
+                },
+            ): selector({"entity": {"domain": "sensor", "device_class": "energy"}}),
+            vol.Optional(
+                CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
+                description={
+                    "suggested_value": d.get(CONF_BATTERY_ENERGY_DISCHARGED_SENSOR)
+                },
+            ): selector({"entity": {"domain": "sensor", "device_class": "energy"}}),
+            vol.Optional(
                 CONF_PV_DC_EFFICIENCY,
                 default=d.get(CONF_PV_DC_EFFICIENCY, DEFAULT_PV_DC_EFFICIENCY),
                 description={"suggested_value": d.get(CONF_PV_DC_EFFICIENCY)},
@@ -227,8 +239,13 @@ def _validate_battery_subentry(user_input: dict[str, Any]) -> dict[str, Any]:
             ),
         }
     )
-    if validated.get(CONF_BATTERY_POWER_SENSOR):
-        result[CONF_BATTERY_POWER_SENSOR] = validated[CONF_BATTERY_POWER_SENSOR]
+    for optional_sensor in (
+        CONF_BATTERY_POWER_SENSOR,
+        CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+        CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
+    ):
+        if validated.get(optional_sensor):
+            result[optional_sensor] = validated[optional_sensor]
     # SoC-dependent derating: only store when explicitly provided
     for key, default in (
         (CONF_HIGH_SOC_CHARGE_THRESHOLD_PCT, DEFAULT_HIGH_SOC_CHARGE_THRESHOLD_PCT),
@@ -347,18 +364,6 @@ def _build_main_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 CONF_PV_PRODUCTION_SENSORS,
                 description={"suggested_value": d.get(CONF_PV_PRODUCTION_SENSORS)},
             ): energy_selector,
-            vol.Optional(
-                CONF_BATTERY_ENERGY_CHARGED_SENSORS,
-                description={
-                    "suggested_value": d.get(CONF_BATTERY_ENERGY_CHARGED_SENSORS)
-                },
-            ): energy_selector,
-            vol.Optional(
-                CONF_BATTERY_ENERGY_DISCHARGED_SENSORS,
-                description={
-                    "suggested_value": d.get(CONF_BATTERY_ENERGY_DISCHARGED_SENSORS)
-                },
-            ): energy_selector,
         }
     )
 
@@ -428,12 +433,6 @@ def _extract_main_data(user_input: dict[str, Any]) -> dict[str, Any]:
             opt, CONF_ELECTRICITY_PRODUCTION_SENSORS, []
         ),
         CONF_PV_PRODUCTION_SENSORS: _g(opt, CONF_PV_PRODUCTION_SENSORS, []),
-        CONF_BATTERY_ENERGY_CHARGED_SENSORS: _g(
-            opt, CONF_BATTERY_ENERGY_CHARGED_SENSORS, []
-        ),
-        CONF_BATTERY_ENERGY_DISCHARGED_SENSORS: _g(
-            opt, CONF_BATTERY_ENERGY_DISCHARGED_SENSORS, []
-        ),
         # Advanced
         CONF_FIXED_FEED_IN_PRICE: float(
             _g(adv, CONF_FIXED_FEED_IN_PRICE, DEFAULT_FIXED_FEED_IN_PRICE)

--- a/custom_components/battery_controller/config_flow.py
+++ b/custom_components/battery_controller/config_flow.py
@@ -16,6 +16,8 @@ import voluptuous as vol
 
 from .const import (
     BATTERY_SUBENTRY_TYPE,
+    CONF_BATTERY_ENERGY_CHARGED_SENSORS,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSORS,
     CONF_BATTERY_POWER_SENSOR,
     CONF_NAME,
     CONF_BATTERY_SOC_SENSOR,
@@ -345,6 +347,18 @@ def _build_main_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 CONF_PV_PRODUCTION_SENSORS,
                 description={"suggested_value": d.get(CONF_PV_PRODUCTION_SENSORS)},
             ): energy_selector,
+            vol.Optional(
+                CONF_BATTERY_ENERGY_CHARGED_SENSORS,
+                description={
+                    "suggested_value": d.get(CONF_BATTERY_ENERGY_CHARGED_SENSORS)
+                },
+            ): energy_selector,
+            vol.Optional(
+                CONF_BATTERY_ENERGY_DISCHARGED_SENSORS,
+                description={
+                    "suggested_value": d.get(CONF_BATTERY_ENERGY_DISCHARGED_SENSORS)
+                },
+            ): energy_selector,
         }
     )
 
@@ -414,6 +428,12 @@ def _extract_main_data(user_input: dict[str, Any]) -> dict[str, Any]:
             opt, CONF_ELECTRICITY_PRODUCTION_SENSORS, []
         ),
         CONF_PV_PRODUCTION_SENSORS: _g(opt, CONF_PV_PRODUCTION_SENSORS, []),
+        CONF_BATTERY_ENERGY_CHARGED_SENSORS: _g(
+            opt, CONF_BATTERY_ENERGY_CHARGED_SENSORS, []
+        ),
+        CONF_BATTERY_ENERGY_DISCHARGED_SENSORS: _g(
+            opt, CONF_BATTERY_ENERGY_DISCHARGED_SENSORS, []
+        ),
         # Advanced
         CONF_FIXED_FEED_IN_PRICE: float(
             _g(adv, CONF_FIXED_FEED_IN_PRICE, DEFAULT_FIXED_FEED_IN_PRICE)

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -88,14 +88,17 @@ CONF_PRICE_SENSOR = "price_sensor"
 CONF_FEED_IN_PRICE_SENSOR = "feed_in_price_sensor"
 CONF_BATTERY_SOC_SENSOR = "battery_soc_sensor"
 CONF_BATTERY_POWER_SENSOR = "battery_power_sensor"
+# kWh total-energy counters per battery subentry. Grid charging passes the grid
+# meter, so without these it is reconstructed as household load. Where one
+# inverter reports a single counter for several packs, set it on one of them:
+# the totals stay correct, only per-pack use of the figure is unavailable.
+CONF_BATTERY_ENERGY_CHARGED_SENSOR = "battery_energy_charged_sensor"
+CONF_BATTERY_ENERGY_DISCHARGED_SENSOR = "battery_energy_discharged_sensor"
 CONF_ELECTRICITY_CONSUMPTION_SENSORS = "electricity_consumption_sensors"
 CONF_ELECTRICITY_PRODUCTION_SENSORS = "electricity_production_sensors"
 # kWh total-energy sensors from PV inverters (used to reconstruct gross consumption)
 CONF_PV_PRODUCTION_SENSORS = "pv_production_sensors"
-# kWh total-energy sensors for battery charge/discharge. Grid charging passes the
-# grid meter, so without these it is reconstructed as household load.
-CONF_BATTERY_ENERGY_CHARGED_SENSORS = "battery_energy_charged_sensors"
-CONF_BATTERY_ENERGY_DISCHARGED_SENSORS = "battery_energy_discharged_sensors"
+# Configuration keys - Battery subentry
 CONF_POWER_CONSUMPTION_SENSORS = "power_consumption_sensors"
 CONF_POWER_PRODUCTION_SENSORS = "power_production_sensors"
 

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -92,6 +92,10 @@ CONF_ELECTRICITY_CONSUMPTION_SENSORS = "electricity_consumption_sensors"
 CONF_ELECTRICITY_PRODUCTION_SENSORS = "electricity_production_sensors"
 # kWh total-energy sensors from PV inverters (used to reconstruct gross consumption)
 CONF_PV_PRODUCTION_SENSORS = "pv_production_sensors"
+# kWh total-energy sensors for battery charge/discharge. Grid charging passes the
+# grid meter, so without these it is reconstructed as household load.
+CONF_BATTERY_ENERGY_CHARGED_SENSORS = "battery_energy_charged_sensors"
+CONF_BATTERY_ENERGY_DISCHARGED_SENSORS = "battery_energy_discharged_sensors"
 CONF_POWER_CONSUMPTION_SENSORS = "power_consumption_sensors"
 CONF_POWER_PRODUCTION_SENSORS = "power_production_sensors"
 

--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -14,8 +14,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    CONF_BATTERY_ENERGY_CHARGED_SENSORS,
-    CONF_BATTERY_ENERGY_DISCHARGED_SENSORS,
+    CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
     CONF_ELECTRICITY_CONSUMPTION_SENSORS,
     CONF_ELECTRICITY_PRODUCTION_SENSORS,
     CONF_PV_FORECAST_SENSORS,
@@ -34,6 +34,21 @@ from .forecast_models import (
 from .helpers import extract_pv_forecast_series
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _battery_energy_sensors(config: dict[str, Any], key: str) -> list[str]:
+    """Collect one battery energy counter per subentry that has it configured.
+
+    Deduplicated: where a single inverter reports one counter for several packs,
+    the same entity may legitimately be selected on more than one subentry, and
+    counting it twice would distort the reconstruction.
+    """
+    seen: list[str] = []
+    for _subentry_id, data in config.get("battery_subentries", []):
+        entity_id = data.get(key)
+        if entity_id and entity_id not in seen:
+            seen.append(entity_id)
+    return seen
 
 
 class ForecastCoordinator(DataUpdateCoordinator):
@@ -114,9 +129,11 @@ class ForecastCoordinator(DataUpdateCoordinator):
             base_consumption_kw=0.5,
             pv_production_sensors=config.get(CONF_PV_PRODUCTION_SENSORS, []),
             entry_id=config.get("entry_id"),
-            battery_charge_sensors=config.get(CONF_BATTERY_ENERGY_CHARGED_SENSORS, []),
-            battery_discharge_sensors=config.get(
-                CONF_BATTERY_ENERGY_DISCHARGED_SENSORS, []
+            battery_charge_sensors=_battery_energy_sensors(
+                config, CONF_BATTERY_ENERGY_CHARGED_SENSOR
+            ),
+            battery_discharge_sensors=_battery_energy_sensors(
+                config, CONF_BATTERY_ENERGY_DISCHARGED_SENSOR
             ),
         )
 

--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -14,6 +14,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    CONF_BATTERY_ENERGY_CHARGED_SENSORS,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSORS,
     CONF_ELECTRICITY_CONSUMPTION_SENSORS,
     CONF_ELECTRICITY_PRODUCTION_SENSORS,
     CONF_PV_FORECAST_SENSORS,
@@ -112,6 +114,10 @@ class ForecastCoordinator(DataUpdateCoordinator):
             base_consumption_kw=0.5,
             pv_production_sensors=config.get(CONF_PV_PRODUCTION_SENSORS, []),
             entry_id=config.get("entry_id"),
+            battery_charge_sensors=config.get(CONF_BATTERY_ENERGY_CHARGED_SENSORS, []),
+            battery_discharge_sensors=config.get(
+                CONF_BATTERY_ENERGY_DISCHARGED_SENSORS, []
+            ),
         )
 
         self.net_load_model = NetLoadForecast(

--- a/custom_components/battery_controller/forecast_models.py
+++ b/custom_components/battery_controller/forecast_models.py
@@ -129,6 +129,13 @@ class ConsumptionForecastModel:
     1. pv_production_sensors: real kWh sensors from inverter(s) → add back to net
     2. own pv_forecast sensor history (via entry_id lookup) → self-consistent correction
     3. Warning log when production_sensors configured without a correction method
+
+    Battery correction: battery_discharge_sensors are added back and
+    battery_charge_sensors subtracted, completing the identity
+    gross = import - export + pv + discharge - charge. Without it, charging from
+    the grid is learned as household load. Like the PV correction it only applies
+    when production_sensors is set, since that is what marks the consumption
+    input as net grid exchange rather than gross load.
     """
 
     def __init__(
@@ -140,6 +147,8 @@ class ConsumptionForecastModel:
         base_consumption_kw: float = 0.5,
         pv_production_sensors: list[str] | None = None,
         entry_id: str | None = None,
+        battery_charge_sensors: list[str] | None = None,
+        battery_discharge_sensors: list[str] | None = None,
     ):
         """Initialize consumption forecast model."""
         self.hass = hass
@@ -148,6 +157,8 @@ class ConsumptionForecastModel:
         self.history_days = history_days
         self.base_consumption_kw = base_consumption_kw
         self.pv_production_sensors = pv_production_sensors or []
+        self.battery_charge_sensors = battery_charge_sensors or []
+        self.battery_discharge_sensors = battery_discharge_sensors or []
         self._entry_id = entry_id
         # Non-seasonal pattern (hour, day_of_week) → average kW
         self._hourly_pattern: dict[tuple[int, int], float] = {}
@@ -318,6 +329,59 @@ class ConsumptionForecastModel:
                     "but no PV correction could be applied. This may cause double-counting "
                     "of PV in the consumption forecast. Configure 'pv_production_sensors' "
                     "with your inverter's total energy sensor(s) to fix this."
+                )
+
+            # Battery correction: complete the identity
+            #   gross = import - export + pv + discharge - charge
+            # Charging from the grid passes the grid meter, so without this it is
+            # reconstructed as household load; discharging displaces import, so
+            # without this the load it served goes missing. Both errors are
+            # concentrated in specific hours, which is exactly the axis the
+            # pattern is learned on.
+            battery_ids = set(self.battery_charge_sensors) | set(
+                self.battery_discharge_sensors
+            )
+            if self.production_sensors and battery_ids:
+                battery_stats = await get_instance(self.hass).async_add_executor_job(
+                    statistics_during_period,
+                    self.hass,
+                    start_time,
+                    end_time,
+                    battery_ids,
+                    "hour",
+                    None,
+                    {"change"},
+                )
+                # Both are non-negative cumulative counters; clamp so a bogus
+                # negative change cannot flip the correction's direction.
+                for sensor_id in self.battery_discharge_sensors:
+                    for stat in battery_stats.get(sensor_id, []):
+                        result = _ts_and_value(stat, "change")
+                        if result:
+                            stat_dt, val = result
+                            hourly_net[stat_dt] = hourly_net.get(stat_dt, 0.0) + max(
+                                0.0, val
+                            )
+                for sensor_id in self.battery_charge_sensors:
+                    for stat in battery_stats.get(sensor_id, []):
+                        result = _ts_and_value(stat, "change")
+                        if result:
+                            stat_dt, val = result
+                            hourly_net[stat_dt] = hourly_net.get(stat_dt, 0.0) - max(
+                                0.0, val
+                            )
+                _LOGGER.debug(
+                    "Battery correction applied from %d charge and %d discharge sensor(s)",
+                    len(self.battery_charge_sensors),
+                    len(self.battery_discharge_sensors),
+                )
+            elif self.production_sensors:
+                _LOGGER.warning(
+                    "electricity_production_sensors are configured, so consumption is "
+                    "reconstructed from net grid exchange, but no battery energy sensors "
+                    "are set. Grid charging will be learned as household consumption. "
+                    "Configure 'battery_energy_charged_sensors' and "
+                    "'battery_energy_discharged_sensors' to fix this."
                 )
 
             # Group by (hour, day_of_week) and also (hour, day_of_week, season).

--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -22,7 +22,9 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
+              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
+              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -30,7 +32,9 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
+              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
+              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
             }
           },
           "advanced": {
@@ -128,7 +132,9 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
+              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
+              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -136,7 +142,9 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
+              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
+              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
             }
           },
           "advanced": {

--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -22,9 +22,7 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
-              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
-              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -32,9 +30,7 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
-              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
-              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {
@@ -132,9 +128,7 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
-              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
-              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -142,9 +136,7 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
-              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
-              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {
@@ -191,6 +183,8 @@
             "max_soc_percent": "Maximum SoC (%)",
             "battery_soc_sensor": "Battery SoC sensor",
             "battery_power_sensor": "Battery power sensor (optional)",
+            "battery_energy_charged_sensor": "Battery charged sensor (kWh, optional)",
+            "battery_energy_discharged_sensor": "Battery discharged sensor (kWh, optional)",
             "pv_dc_efficiency": "DC coupling efficiency (0–1, for DC-coupled PV on this inverter)",
             "high_soc_charge_threshold_pct": "High-SoC charge derating threshold (%, optional)",
             "high_soc_max_charge_kw": "Derated charge power above threshold (kW, optional)",
@@ -205,6 +199,8 @@
             "max_soc_percent": "Optimizer will not charge above this level. Keeping below 100% extends battery life.",
             "battery_soc_sensor": "Sensor reporting state of charge (0–100 %) or energy in kWh. Required.",
             "battery_power_sensor": "Sensor reporting instantaneous battery power (W or kW). Positive = charging, negative = discharging (this is the opposite sign convention from the power sensors the integration creates, e.g. Battery Setpoint). Optional; improves real-time charge/discharge mode detection.",
+            "battery_energy_charged_sensor": "Cumulative kWh charged into this battery. Used to reconstruct gross household load when the consumption sensor measures grid import, because charging from the grid passes the meter and would otherwise be learned as household consumption. If one inverter reports a single counter for several packs, set it on one of them.",
+            "battery_energy_discharged_sensor": "Cumulative kWh discharged from this battery. Added back for the same reconstruction, because discharging displaces grid import and would otherwise hide the load it served.",
             "pv_dc_efficiency": "Efficiency from PV panels to the inverter's DC bus (typically 0.97 for MPPT conversion losses only). Only relevant when DC-coupled PV arrays are configured.",
             "high_soc_charge_threshold_pct": "Above this SoC the battery's accepted charge power is reduced. Leave empty if not applicable.",
             "high_soc_max_charge_kw": "Maximum charge power allowed above the high-SoC threshold. Leave empty if not applicable.",
@@ -226,6 +222,8 @@
             "max_soc_percent": "Maximum SoC (%)",
             "battery_soc_sensor": "Battery SoC sensor",
             "battery_power_sensor": "Battery power sensor (optional)",
+            "battery_energy_charged_sensor": "Battery charged sensor (kWh, optional)",
+            "battery_energy_discharged_sensor": "Battery discharged sensor (kWh, optional)",
             "pv_dc_efficiency": "DC coupling efficiency (0–1)",
             "high_soc_charge_threshold_pct": "High-SoC charge derating threshold (%, optional)",
             "high_soc_max_charge_kw": "Derated charge power above threshold (kW, optional)",
@@ -240,6 +238,8 @@
             "max_soc_percent": "Optimizer will not charge above this level. Keeping below 100% extends battery life.",
             "battery_soc_sensor": "Sensor reporting state of charge (0–100 %) or energy in kWh. Required.",
             "battery_power_sensor": "Sensor reporting instantaneous battery power (W or kW). Positive = charging, negative = discharging (this is the opposite sign convention from the power sensors the integration creates, e.g. Battery Setpoint). Optional; improves real-time charge/discharge mode detection.",
+            "battery_energy_charged_sensor": "Cumulative kWh charged into this battery. Used to reconstruct gross household load when the consumption sensor measures grid import, because charging from the grid passes the meter and would otherwise be learned as household consumption. If one inverter reports a single counter for several packs, set it on one of them.",
+            "battery_energy_discharged_sensor": "Cumulative kWh discharged from this battery. Added back for the same reconstruction, because discharging displaces grid import and would otherwise hide the load it served.",
             "pv_dc_efficiency": "Efficiency from PV panels to the inverter's DC bus (typically 0.97 for MPPT conversion losses only). Only relevant when DC-coupled PV arrays are configured.",
             "high_soc_charge_threshold_pct": "Above this SoC the battery's accepted charge power is reduced. Leave empty if not applicable.",
             "high_soc_max_charge_kw": "Maximum charge power allowed above the high-SoC threshold. Leave empty if not applicable.",

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -22,7 +22,9 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
+              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
+              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -30,7 +32,9 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
+              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
+              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
             }
           },
           "advanced": {
@@ -128,7 +132,9 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
+              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
+              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -136,7 +142,9 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
+              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
+              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
             }
           },
           "advanced": {

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -22,9 +22,7 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
-              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
-              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -32,9 +30,7 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
-              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
-              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {
@@ -132,9 +128,7 @@
               "power_production_sensors": "Power production sensors (W, e.g. DSMR - for real-time grid balance)",
               "electricity_consumption_sensors": "Electricity consumption sensors (kWh)",
               "electricity_production_sensors": "Electricity production sensors (kWh, e.g. DSMR)",
-              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above",
-              "battery_energy_charged_sensors": "Battery charged sensors (kWh)",
-              "battery_energy_discharged_sensors": "Battery discharged sensors (kWh)"
+              "pv_production_sensors": "PV inverter production sensors (kWh) – corrects double-counting when combined with grid export sensors above"
             },
             "data_description": {
               "feed_in_price_sensor": "Optional separate sensor for the export/feed-in price. If absent, the fixed feed-in price below is used.",
@@ -142,9 +136,7 @@
               "power_production_sensors": "Sum of all grid export power sensors. Used by the zero-grid controller for real-time balance (~5 s updates).",
               "electricity_consumption_sensors": "Cumulative kWh sensors the consumption pattern is learned from. What the model needs is gross household load — everything the house draws, from grid, PV or battery alike. Two ways to give it: point this at a sensor that measures it directly (between inverter and house) and leave the two fields below empty, or point it at grid import and fill in both fields below, and gross load is reconstructed as import − export + PV. Grid import on its own, without those two, subtracts PV twice.",
               "electricity_production_sensors": "Cumulative kWh sensors for grid export. Needed to reconstruct gross household load when the consumption field above measures grid import; leave empty when it already measures gross load.",
-              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate.",
-              "battery_energy_charged_sensors": "Cumulative kWh charged into the battery. Subtracted when gross household load is reconstructed from grid import and export, because charging from the grid passes the meter and would otherwise be learned as household consumption.",
-              "battery_energy_discharged_sensors": "Cumulative kWh discharged from the battery. Added back when gross household load is reconstructed from grid import and export, because discharging displaces grid import and would otherwise hide the load it served."
+              "pv_production_sensors": "Cumulative kWh from PV inverters, added back when gross household load is reconstructed from grid import and export. Without it the integration falls back to its own PV forecast history, which is less accurate."
             }
           },
           "advanced": {
@@ -191,6 +183,8 @@
             "max_soc_percent": "Maximum SoC (%)",
             "battery_soc_sensor": "Battery SoC sensor",
             "battery_power_sensor": "Battery power sensor (optional)",
+            "battery_energy_charged_sensor": "Battery charged sensor (kWh, optional)",
+            "battery_energy_discharged_sensor": "Battery discharged sensor (kWh, optional)",
             "pv_dc_efficiency": "DC coupling efficiency (0–1, for DC-coupled PV on this inverter)",
             "high_soc_charge_threshold_pct": "High-SoC charge derating threshold (%, optional)",
             "high_soc_max_charge_kw": "Derated charge power above threshold (kW, optional)",
@@ -205,6 +199,8 @@
             "max_soc_percent": "Optimizer will not charge above this level. Keeping below 100% extends battery life.",
             "battery_soc_sensor": "Sensor reporting state of charge (0–100 %) or energy in kWh. Required.",
             "battery_power_sensor": "Sensor reporting instantaneous battery power (W or kW). Positive = charging, negative = discharging (this is the opposite sign convention from the power sensors the integration creates, e.g. Battery Setpoint). Optional; improves real-time charge/discharge mode detection.",
+            "battery_energy_charged_sensor": "Cumulative kWh charged into this battery. Used to reconstruct gross household load when the consumption sensor measures grid import, because charging from the grid passes the meter and would otherwise be learned as household consumption. If one inverter reports a single counter for several packs, set it on one of them.",
+            "battery_energy_discharged_sensor": "Cumulative kWh discharged from this battery. Added back for the same reconstruction, because discharging displaces grid import and would otherwise hide the load it served.",
             "pv_dc_efficiency": "Efficiency from PV panels to the inverter's DC bus (typically 0.97 for MPPT conversion losses only). Only relevant when DC-coupled PV arrays are configured.",
             "high_soc_charge_threshold_pct": "Above this SoC the battery's accepted charge power is reduced. Leave empty if not applicable.",
             "high_soc_max_charge_kw": "Maximum charge power allowed above the high-SoC threshold. Leave empty if not applicable.",
@@ -226,6 +222,8 @@
             "max_soc_percent": "Maximum SoC (%)",
             "battery_soc_sensor": "Battery SoC sensor",
             "battery_power_sensor": "Battery power sensor (optional)",
+            "battery_energy_charged_sensor": "Battery charged sensor (kWh, optional)",
+            "battery_energy_discharged_sensor": "Battery discharged sensor (kWh, optional)",
             "pv_dc_efficiency": "DC coupling efficiency (0–1)",
             "high_soc_charge_threshold_pct": "High-SoC charge derating threshold (%, optional)",
             "high_soc_max_charge_kw": "Derated charge power above threshold (kW, optional)",
@@ -240,6 +238,8 @@
             "max_soc_percent": "Optimizer will not charge above this level. Keeping below 100% extends battery life.",
             "battery_soc_sensor": "Sensor reporting state of charge (0–100 %) or energy in kWh. Required.",
             "battery_power_sensor": "Sensor reporting instantaneous battery power (W or kW). Positive = charging, negative = discharging (this is the opposite sign convention from the power sensors the integration creates, e.g. Battery Setpoint). Optional; improves real-time charge/discharge mode detection.",
+            "battery_energy_charged_sensor": "Cumulative kWh charged into this battery. Used to reconstruct gross household load when the consumption sensor measures grid import, because charging from the grid passes the meter and would otherwise be learned as household consumption. If one inverter reports a single counter for several packs, set it on one of them.",
+            "battery_energy_discharged_sensor": "Cumulative kWh discharged from this battery. Added back for the same reconstruction, because discharging displaces grid import and would otherwise hide the load it served.",
             "pv_dc_efficiency": "Efficiency from PV panels to the inverter's DC bus (typically 0.97 for MPPT conversion losses only). Only relevant when DC-coupled PV arrays are configured.",
             "high_soc_charge_threshold_pct": "Above this SoC the battery's accepted charge power is reduced. Leave empty if not applicable.",
             "high_soc_max_charge_kw": "Maximum charge power allowed above the high-SoC threshold. Leave empty if not applicable.",

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -29,6 +29,8 @@
             "data": {
               "feed_in_price_sensor": "Terugleverprijs sensor (optioneel)",
               "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
+              "battery_energy_charged_sensor": "Accu geladen sensor (kWh, optioneel)",
+              "battery_energy_discharged_sensor": "Accu ontladen sensor (kWh, optioneel)",
               "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh)",
               "electricity_production_sensors": "Elektriciteitsproductie sensoren (kWh, bijv. DSMR)"
             }
@@ -99,6 +101,8 @@
             "data": {
               "feed_in_price_sensor": "Terugleverprijs sensor (optioneel)",
               "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
+              "battery_energy_charged_sensor": "Accu geladen sensor (kWh, optioneel)",
+              "battery_energy_discharged_sensor": "Accu ontladen sensor (kWh, optioneel)",
               "electricity_consumption_sensors": "Elektriciteitsverbruik sensoren (kWh)",
               "electricity_production_sensors": "Elektriciteitsproductie sensoren (kWh, bijv. DSMR)"
             }
@@ -157,6 +161,8 @@
             "max_soc_percent": "Maximum SoC (%)",
             "battery_soc_sensor": "Batterij SoC sensor",
             "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
+            "battery_energy_charged_sensor": "Accu geladen sensor (kWh, optioneel)",
+            "battery_energy_discharged_sensor": "Accu ontladen sensor (kWh, optioneel)",
             "pv_dc_efficiency": "DC-koppelingsrendement (0–1, voor DC-gekoppelde PV op deze omvormer)"
           },
           "data_description": {
@@ -178,6 +184,8 @@
             "max_soc_percent": "Maximum SoC (%)",
             "battery_soc_sensor": "Batterij SoC sensor",
             "battery_power_sensor": "Batterij vermogen sensor (optioneel)",
+            "battery_energy_charged_sensor": "Accu geladen sensor (kWh, optioneel)",
+            "battery_energy_discharged_sensor": "Accu ontladen sensor (kWh, optioneel)",
             "pv_dc_efficiency": "DC-koppelingsrendement (0–1)"
           },
           "data_description": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,11 +77,15 @@ If the house draws 3 kW while the battery charges at 4 kW, then **A** reads 3 kW
     your consumption sensor measures net grid import. See
     [PV double counting](installation.md#verifying-your-consumption-sensors).
 
-    On that route, also fill in *Battery charged* and *Battery discharged*. The full
-    identity is `gross = import − export + PV + discharge − charge`, and without the
-    battery terms every kWh charged from the grid is learned as household load. Because
-    the optimizer chooses when to charge, the model would partly be learning its own past
-    decisions. A warning is logged when production sensors are configured without them.
+    On that route, also set *Battery charged sensor* and *Battery discharged sensor* on
+    each battery subentry. The full identity is
+    `gross = import − export + PV + discharge − charge`, and without the battery terms
+    every kWh charged from the grid is learned as household load. Because the optimizer
+    chooses when to charge, the model would partly be learning its own past decisions. A
+    warning is logged when production sensors are configured without them.
+
+    Where one inverter reports a single counter covering several packs, set it on one of
+    them — the totals stay correct, and the same entity selected twice is counted once.
 
     None of these corrections apply when your consumption sensor already measures gross
     load — such a sensor sits between the inverter and the house, so battery charging

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,16 @@ If the house draws 3 kW while the battery charges at 4 kW, then **A** reads 3 kW
     your consumption sensor measures net grid import. See
     [PV double counting](installation.md#verifying-your-consumption-sensors).
 
+    On that route, also fill in *Battery charged* and *Battery discharged*. The full
+    identity is `gross = import − export + PV + discharge − charge`, and without the
+    battery terms every kWh charged from the grid is learned as household load. Because
+    the optimizer chooses when to charge, the model would partly be learning its own past
+    decisions. A warning is logged when production sensors are configured without them.
+
+    None of these corrections apply when your consumption sensor already measures gross
+    load — such a sensor sits between the inverter and the house, so battery charging
+    never passes it.
+
 ### Advanced
 
 | Parameter | Default | Range | Description |

--- a/tests/test_coordinator_forecast.py
+++ b/tests/test_coordinator_forecast.py
@@ -8,8 +8,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+from custom_components.battery_controller.const import (
+    CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+)
 from custom_components.battery_controller.coordinator_forecast import (
     ForecastCoordinator,
+    _battery_energy_sensors,
 )
 
 
@@ -1197,3 +1201,50 @@ async def test_net_load_unchanged_for_ac_only_system(hass):
         result = await coord._async_update_data()
 
     assert result["net_load_forecast_kw"][0] == pytest.approx(2.0 - 3.0)
+
+
+class TestBatteryEnergySensors:
+    """Collecting the per-subentry battery energy counters."""
+
+    def test_empty_without_subentries(self):
+        assert (
+            _battery_energy_sensors(
+                _minimal_config(), CONF_BATTERY_ENERGY_CHARGED_SENSOR
+            )
+            == []
+        )
+
+    def test_collects_one_per_subentry(self):
+        config = _minimal_config(
+            battery_subentries=[
+                ("a", {CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.pack_a_in"}),
+                ("b", {CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.pack_b_in"}),
+            ]
+        )
+        assert _battery_energy_sensors(config, CONF_BATTERY_ENERGY_CHARGED_SENSOR) == [
+            "sensor.pack_a_in",
+            "sensor.pack_b_in",
+        ]
+
+    def test_skips_subentries_without_the_sensor(self):
+        config = _minimal_config(
+            battery_subentries=[
+                ("a", {CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.pack_a_in"}),
+                ("b", {}),
+            ]
+        )
+        assert _battery_energy_sensors(config, CONF_BATTERY_ENERGY_CHARGED_SENSOR) == [
+            "sensor.pack_a_in"
+        ]
+
+    def test_deduplicates_a_shared_inverter_counter(self):
+        """One inverter counter selected on several packs must count once."""
+        config = _minimal_config(
+            battery_subentries=[
+                ("a", {CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.inverter_in"}),
+                ("b", {CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.inverter_in"}),
+            ]
+        )
+        assert _battery_energy_sensors(config, CONF_BATTERY_ENERGY_CHARGED_SENSOR) == [
+            "sensor.inverter_in"
+        ]

--- a/tests/test_forecast_models.py
+++ b/tests/test_forecast_models.py
@@ -174,6 +174,71 @@ class TestAsyncUpdatePattern:
         assert (10, 0) in model._hourly_pattern
         assert model._hourly_pattern[(10, 0)] == pytest.approx(2.0)
 
+    async def test_battery_correction_completes_the_identity(self):
+        """Battery charge is subtracted and discharge added back.
+
+        gross = import - export + pv + discharge - charge. Without this,
+        charging from the grid is learned as household consumption.
+        """
+        hass = MagicMock()
+        model = ConsumptionForecastModel(
+            hass=hass,
+            consumption_sensors=["sensor.consumption"],
+            production_sensors=["sensor.production"],
+            pv_production_sensors=["sensor.pv_total"],
+            battery_charge_sensors=["sensor.batt_in"],
+            battery_discharge_sensors=["sensor.batt_out"],
+        )
+        # import 4.0, export 1.5, pv 1.5, charged 2.0, discharged 0.5
+        # gross = 4.0 - 1.5 + 1.5 + 0.5 - 2.0 = 2.5
+        base_stats = self._base_stats(4.0, 1.5)
+        pv_stats = {"sensor.pv_total": [{"start": self._TS, "change": 1.5}]}
+        battery_stats = {
+            "sensor.batt_in": [{"start": self._TS, "change": 2.0}],
+            "sensor.batt_out": [{"start": self._TS, "change": 0.5}],
+        }
+
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(
+            side_effect=[base_stats, pv_stats, battery_stats]
+        )
+
+        with patch(
+            "homeassistant.components.recorder.util.get_instance",
+            return_value=mock_instance,
+        ):
+            await model.async_update_pattern()
+
+        assert model._hourly_pattern[(10, 0)] == pytest.approx(2.5)
+
+    async def test_battery_correction_skipped_for_gross_load_input(self):
+        """Without production_sensors the input is gross load already.
+
+        A gross-load sensor sits between inverter and house, so grid-to-battery
+        charging never passes it and must not be corrected for.
+        """
+        hass = MagicMock()
+        model = ConsumptionForecastModel(
+            hass=hass,
+            consumption_sensors=["sensor.consumption"],
+            battery_charge_sensors=["sensor.batt_in"],
+            battery_discharge_sensors=["sensor.batt_out"],
+        )
+        base_stats = {"sensor.consumption": [{"start": self._TS, "change": 2.0}]}
+
+        mock_instance = MagicMock()
+        mock_instance.async_add_executor_job = AsyncMock(side_effect=[base_stats])
+
+        with patch(
+            "homeassistant.components.recorder.util.get_instance",
+            return_value=mock_instance,
+        ):
+            await model.async_update_pattern()
+
+        # Untouched: exactly one statistics query, no battery correction.
+        assert mock_instance.async_add_executor_job.await_count == 1
+        assert model._hourly_pattern[(10, 0)] == pytest.approx(2.0)
+
     async def test_layer2_uses_entity_registry_fallback(self):
         """Layer 2: own pv_forecast entity used when pv_production_sensors absent."""
         hass = MagicMock()


### PR DESCRIPTION
Closes #151.

> **Stacked on #152** — this branches off `claude/fix-consumption-sensor-strings-both-routes`, not `dev`, because both touch the same translation keys. Merge #152 first and this retargets cleanly to `dev`.

## Description

When the consumption field holds grid import, `ConsumptionModel` reconstructs gross household load as `import − export + pv`. The full identity is:

```
gross = import - export + pv + discharge - charge
```

Both battery terms were missing. Charging from the grid passes the grid meter with nothing subtracting it again, so it was learned as household consumption; discharging displaces import, so the load it served went missing.

Both errors sit in specific hours rather than spreading evenly, which is exactly the axis the pattern is learned on — a nightly grid charge teaches a phantom night-time load, an evening discharge teaches an artificially small evening. It also closed a loop: the optimizer picks those hours itself, so the model was partly learning back its own past decisions.

## Changes

- `const.py` — `battery_energy_charged_sensor` / `battery_energy_discharged_sensor`, **per battery subentry**
- `config_flow.py` — two optional energy selectors on the battery subentry schema, alongside the SoC and power sensors that already live there
- `coordinator_forecast.py` — `_battery_energy_sensors()` collects one counter per subentry, deduplicated
- `forecast_models.py` — discharge added back, charge subtracted, under the same condition as the PV correction: only when `production_sensors` is set, since that is what marks the consumption input as net grid rather than gross load. Both clamped with `max(0.0, val)` so a bogus negative change cannot flip the correction's direction.
- translations / `strings.json` / `nl.json` — labels and descriptions on the battery subentry step
- `docs/configuration.md` — the existing correction admonition now covers the battery terms

A warning is logged when the reconstruction route is used without battery sensors, mirroring the existing layer-3 PV warning, since that is the silent-wrong-answer case.

## Per subentry, not main-options lists

The first version of this PR used main-options lists. Per subentry is the better home, and this was the only free moment to change it — the keys have not shipped, so moving them after a release would be a breaking change for anyone who had configured them.

The argument for lists does not survive scrutiny. It was that one inverter reporting a single counter for several packs cannot be expressed per pack — but it can: set it on one of them, and the totals stay correct. The collector deduplicates, so selecting the same entity on several packs counts it once. Per-pack *use* of the figure is then unavailable, which is honest, because with a single counter that data does not exist.

Keeping the lists as well would have meant two places to configure the same measurement plus a precedence rule between them, permanently. #106 is a long thread about two similar sensor fields being confused; a third dimension is not worth the convenience.

`pv_production_sensors` deliberately stays a list. It has shipped, and given a list and N arrays there is no way to know which sensor belongs to which array, so migrating it needs either a wrong guess or a deprecated fallback. Tracked separately in #154.

## Not affected

Installations that point the consumption field at a true gross-load sensor. Such a sensor sits between the inverter and the house, so grid-to-battery charging never passes it, and no correction of any kind should apply. A regression test pins that: no correction, and no extra statistics query.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [ ] CI is green — pending
- [ ] PR targets the `dev` branch — targets #152's branch while stacked; retarget on merge

## Screenshots / Logs (optional)

Six tests added: the full identity (import 4.0, export 1.5, PV 1.5, charged 2.0, discharged 0.5 → 2.5 kWh gross), the gross-load path left untouched, and four on the subentry collector including the shared-inverter-counter dedup. Full suite green, coverage 95.85 % (floor 90 %). `pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).