### PR TITLE
docs: state the DC-bus pairing rule for DC-coupled PV

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,27 @@ rather than asked for.
     production that went straight from the panels to the house appears in no term of the
     identity at all, so the derived figure comes out too low.
 
+!!! warning "DC-coupled PV: match the PV sensor to the battery counter"
+    With PV on the battery inverter's DC bus, the derivation is exact only when the PV
+    sensor and the charged counter sit on the **same side of the DC bus**. Either both
+    count DC production, or neither does.
+
+    Take 5 kWh of DC production, 3 kWh of it charging the battery and 2 kWh reaching the
+    house — so the true household load is 2 kWh:
+
+    | PV sensor reports | Charged counter reports | Derived load | |
+    |-------------------|-------------------------|--------------|---|
+    | 5 kWh — total panel output | 3 kWh — includes DC charging | 2 kWh | correct |
+    | AC arrays only | AC-side charging only | 0 kWh | 2 kWh too low |
+    | 5 kWh | AC-side charging only | 5 kWh | 3 kWh too high |
+
+    Row two only looks harmless: it is correct just as long as no DC production reaches
+    the house directly, which on a hybrid inverter it normally does. So in practice, pair
+    a DC-side PV sensor with a charged counter that includes DC charging.
+
+    If your hardware does not report that pair, use **Household load sensors** instead —
+    it measures the answer directly and sidesteps the question.
+
 !!! danger "Do not confuse the kWh fields with the W fields"
     **Power consumption sensors (W)** must be your **grid meter**, positive = import. It
     feeds only the real-time zero-grid controller, which regulates the grid toward zero.


### PR DESCRIPTION
Follow-up to #157, which merged before this landed.

## Description

Raised in #106 as the remaining unsolved case: with PV on the battery inverter's DC bus it is not obvious whether to fill in the PV sensor, because the answer depends on what the battery charged counter already includes.

Working it through, the balance is exact whenever the PV sensor and the charged counter sit on the **same side of the DC bus** — either both count DC production, or neither does. With 5 kWh of DC production, 3 kWh charging the battery and 2 kWh reaching the house, so a true household load of 2 kWh:

| PV sensor reports | Charged counter reports | Derived load | |
|---|---|---|---|
| 5 kWh — total panel output | 3 kWh — includes DC charging | 2 kWh | correct |
| AC arrays only | AC-side charging only | 0 kWh | 2 kWh too low |
| 5 kWh | AC-side charging only | 5 kWh | 3 kWh too high |

The all-AC row is the trap: it is correct only while no DC production reaches the house directly, which on a hybrid inverter it normally does — the surplus case described at the end of that thread.

So the guidance reduces to one check rather than a branching case list: pair a DC-side PV sensor with a charged counter that includes DC charging, and fall back to **Household load sensors** when the hardware does not report that pair.

Docs only.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — docs only, no tests apply
- [x] Documentation updated if needed
- [ ] CI is green — pending
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

`pre-commit run --all-files` clean (mypy skipped — no Python 3.14 in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjUmZWiLB6xHSeoLWUMjr)_