### PR TITLE
[split into #163 and #164] PV and battery calibration

### DIFF
--- a/custom_components/battery_controller/__init__.py
+++ b/custom_components/battery_controller/__init__.py
@@ -57,6 +57,7 @@ SERVICE_RESET_CHARGE_EFFICIENCY_CALIBRATION = "reset_charge_efficiency_calibrati
 SERVICE_RESET_DISCHARGE_EFFICIENCY_CALIBRATION = (
     "reset_discharge_efficiency_calibration"
 )
+SERVICE_RESET_PV_CALIBRATION = "reset_pv_calibration"
 SERVICE_ENTRY_ID = "entry_id"
 SERVICE_RESET_SCHEMA = vol.Schema({vol.Optional(SERVICE_ENTRY_ID): cv.string})
 
@@ -124,6 +125,20 @@ async def _async_handle_reset_efficiency_calibration(
             await coordinator.async_reset_discharge_eff_calibration()
 
 
+async def _async_handle_reset_pv_calibration(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    """Reset every per-array PV forecast correction for one or more entries."""
+    requested_entry_id = call.data.get(SERVICE_ENTRY_ID)
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if requested_entry_id is not None and entry.entry_id != requested_entry_id:
+            continue
+        runtime_data = getattr(entry, "runtime_data", None)
+        if runtime_data is None:
+            continue
+        await runtime_data.forecast_coordinator.async_reset_pv_calibration()
+
+
 async def _async_handle_reset_charge_efficiency_calibration(
     hass: HomeAssistant, call: ServiceCall
 ) -> None:
@@ -162,6 +177,16 @@ def _async_register_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_RESET_DISCHARGE_EFFICIENCY_CALIBRATION,
         _handle_discharge_service,
+        schema=SERVICE_RESET_SCHEMA,
+    )
+
+    async def _handle_pv_service(call: ServiceCall) -> None:
+        await _async_handle_reset_pv_calibration(hass, call)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RESET_PV_CALIBRATION,
+        _handle_pv_service,
         schema=SERVICE_RESET_SCHEMA,
     )
 
@@ -367,6 +392,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for service in (
                 SERVICE_RESET_CHARGE_EFFICIENCY_CALIBRATION,
                 SERVICE_RESET_DISCHARGE_EFFICIENCY_CALIBRATION,
+                SERVICE_RESET_PV_CALIBRATION,
             ):
                 if hass.services.has_service(DOMAIN, service):
                     hass.services.async_remove(DOMAIN, service)

--- a/custom_components/battery_controller/config_flow.py
+++ b/custom_components/battery_controller/config_flow.py
@@ -47,6 +47,7 @@ from .const import (
     CONF_PRICE_SENSOR,
     CONF_PV_DC_EFFICIENCY,
     CONF_PV_FORECAST_SENSORS,
+    CONF_PV_MEASURED_PRODUCTION_SENSOR,
     CONF_ROUND_TRIP_EFFICIENCY,
     CONF_MAX_GRID_POWER_KW,
     CONF_ZERO_GRID_DEADBAND_W,
@@ -307,6 +308,12 @@ def _build_pv_subentry_schema(defaults: dict[str, Any] | None = None) -> vol.Sch
                 CONF_PV_FORECAST_SENSORS,
                 description={"suggested_value": d.get(CONF_PV_FORECAST_SENSORS)},
             ): selector({"entity": {"domain": "sensor", "multiple": True}}),
+            vol.Optional(
+                CONF_PV_MEASURED_PRODUCTION_SENSOR,
+                description={
+                    "suggested_value": d.get(CONF_PV_MEASURED_PRODUCTION_SENSOR)
+                },
+            ): selector({"entity": {"domain": "sensor", "device_class": "energy"}}),
         }
     )
 
@@ -571,6 +578,10 @@ def _validate_pv_subentry(user_input: dict[str, Any]) -> dict[str, Any]:
     )
     if validated.get(CONF_PV_FORECAST_SENSORS):
         result[CONF_PV_FORECAST_SENSORS] = list(validated[CONF_PV_FORECAST_SENSORS])
+    if validated.get(CONF_PV_MEASURED_PRODUCTION_SENSOR):
+        result[CONF_PV_MEASURED_PRODUCTION_SENSOR] = validated[
+            CONF_PV_MEASURED_PRODUCTION_SENSOR
+        ]
     return result
 
 

--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -75,6 +75,18 @@ BATTERY_SUBENTRY_TYPE = "battery"
 # internal model remains the fallback for steps not covered by sensor data.
 CONF_PV_FORECAST_SENSORS = "pv_forecast_sensors"
 
+# Configuration keys - PV array (subentry): measured production.
+# A cumulative kWh counter for THIS array. Two consumers:
+#  - the gross-load reconstruction, which only ever needs the sum and is
+#    equally happy with the legacy CONF_PV_PRODUCTION_SENSORS list;
+#  - per-array forecast calibration, which needs the attribution the flat list
+#    cannot express.
+# Same convention as the battery energy counters: where one inverter reports a
+# single counter covering several arrays, set it on one of them and the
+# collector deduplicates, so totals stay correct while per-array use of the
+# figure is unavailable.
+CONF_PV_MEASURED_PRODUCTION_SENSOR = "pv_measured_production_sensor"
+
 # Configuration keys - DC-coupled PV (PV direct on battery inverter)
 # When PV is DC-coupled to the battery, PV power goes directly to the
 # battery without AC conversion. This is common with hybrid inverters
@@ -271,6 +283,28 @@ WEATHER_STALE_AFTER_MINUTES = 120.0  # minutes — weather data older than this 
 # Such a sample is unbounded in magnitude — observed values reach 10^8 kW — and
 # a single one poisons its (hour, weekday) bucket and wrecks the DP cost.
 MAX_PLAUSIBLE_CONSUMPTION_KW = 50.0
+
+# Per-array PV forecast calibration.
+# The correction is a gain factor: it captures a systematically wrong tilt or
+# orientation entry, soiling, or a string that is down. It cannot capture
+# shading, which is a function of sun position rather than a constant factor —
+# see docs/algorithm.md.
+# Samples are only taken in a middle band of the array's rating: below the
+# floor the signal is smaller than the noise, above the ceiling inverter
+# clipping and thermal derating dominate and are not forecast errors.
+PV_CALIBRATION_MIN_LOAD_FRACTION = 0.10
+PV_CALIBRATION_MAX_LOAD_FRACTION = 0.80
+# Energy-weighted over this many samples (a few days of daylight at 15 min),
+# so cloudy low-signal steps cannot dominate the estimate.
+PV_CALIBRATION_WINDOW = 200
+# A single step this far off the forecast is weather, a sensor glitch or a
+# window that did not line up — not a gain error.
+PV_CALIBRATION_MAX_SAMPLE_RATIO = 5.0
+# Bounds on the factor actually applied to a forecast.
+PV_CALIBRATION_APPLY_MIN = 0.5
+PV_CALIBRATION_APPLY_MAX = 1.5
+# Minimum samples before the correction is used at all.
+PV_CALIBRATION_MIN_SAMPLES = 20
 
 # Real-time control thresholds
 BATTERY_MODE_THRESHOLD_W = 50.0  # W — battery power above/below this sets mode

--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -7,8 +7,10 @@ from bisect import bisect_left, bisect_right
 from datetime import datetime, timedelta
 from typing import Any
 
+from collections import deque
+
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import issue_registry as ir, storage
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
@@ -20,10 +22,18 @@ from .const import (
     CONF_GRID_IMPORT_SENSORS,
     CONF_GROSS_LOAD_SENSORS,
     CONF_PV_FORECAST_SENSORS,
+    CONF_PV_MEASURED_PRODUCTION_SENSOR,
     CONF_PV_PRODUCTION_SENSORS,
     DC_TO_AC_INVERTER_EFFICIENCY,
     DOMAIN,
     FORECAST_INTERVAL_MINUTES,
+    PV_CALIBRATION_APPLY_MAX,
+    PV_CALIBRATION_APPLY_MIN,
+    PV_CALIBRATION_MAX_LOAD_FRACTION,
+    PV_CALIBRATION_MAX_SAMPLE_RATIO,
+    PV_CALIBRATION_MIN_LOAD_FRACTION,
+    PV_CALIBRATION_MIN_SAMPLES,
+    PV_CALIBRATION_WINDOW,
     WEATHER_STALE_AFTER_MINUTES,
 )
 from .coordinator_weather import WeatherDataCoordinator
@@ -122,6 +132,33 @@ class ForecastCoordinator(DataUpdateCoordinator):
             peak_power_kwp=0.0, orientation_deg=180, tilt_deg=35, efficiency_factor=1.0
         )
 
+        # Measured production per array, and the union used by the gross-load
+        # reconstruction. The reconstruction only ever needs the sum, so the
+        # legacy flat list keeps working untouched and the per-array sensors are
+        # purely additive — no migration, and nothing to configure twice.
+        self._pv_measured_sensors: dict[str, str] = {}
+        for arr in config.get("pv_arrays", []):
+            sid = arr.get("subentry_id", "")
+            entity_id = arr.get(CONF_PV_MEASURED_PRODUCTION_SENSOR)
+            if sid and entity_id:
+                self._pv_measured_sensors[sid] = entity_id
+        reconstruction_pv_sensors = list(config.get(CONF_PV_PRODUCTION_SENSORS, []))
+        for entity_id in self._pv_measured_sensors.values():
+            if entity_id not in reconstruction_pv_sensors:
+                reconstruction_pv_sensors.append(entity_id)
+
+        # Per-array forecast calibration state.
+        self._pv_cal_samples: dict[str, deque[tuple[float, float]]] = {}
+        self._pv_cal_correction: dict[str, float] = {}
+        self._pv_cal_snapshot: dict[str, Any] = {}
+        self._pv_cal_store: storage.Store[dict[str, Any]] = storage.Store(
+            hass, 1, f"battery_controller_{config.get('entry_id', 'unknown')}_pv_cal"
+        )
+        # Set by the PV-curtailment switch (via the optimization coordinator):
+        # while production is deliberately suppressed the shortfall against the
+        # forecast is not a forecast error and must not be calibrated away.
+        self.pv_curtailed: bool = False
+
         self.consumption_model = ConsumptionForecastModel(
             hass=hass,
             grid_import_sensors=config.get(CONF_GRID_IMPORT_SENSORS, []),
@@ -129,7 +166,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
             gross_load_sensors=config.get(CONF_GROSS_LOAD_SENSORS, []),
             history_days=14,
             base_consumption_kw=0.5,
-            pv_production_sensors=config.get(CONF_PV_PRODUCTION_SENSORS, []),
+            pv_production_sensors=reconstruction_pv_sensors,
             entry_id=config.get("entry_id"),
             battery_charge_sensors=_battery_energy_sensors(
                 config, CONF_BATTERY_ENERGY_CHARGED_SENSOR
@@ -153,6 +190,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
         """Set up the forecast coordinator."""
         # Update consumption pattern from history on startup
         await self.consumption_model.async_update_pattern()
+        await self._async_load_pv_calibration()
 
         # Subscribe to the weather coordinator. A DataUpdateCoordinator only
         # keeps polling while it has listeners, and no entity subscribes to the
@@ -191,6 +229,202 @@ class ForecastCoordinator(DataUpdateCoordinator):
             self._unsub_weather()
             self._unsub_weather = None
         await super().async_shutdown()
+
+    async def _async_load_pv_calibration(self) -> None:
+        """Restore per-array PV corrections from storage."""
+        stored = await self._pv_cal_store.async_load()
+        if not stored:
+            return
+        for sid, entry in (stored.get("arrays") or {}).items():
+            samples = entry.get("samples") or []
+            self._pv_cal_samples[sid] = deque(
+                ((float(m), float(f)) for m, f in samples),
+                maxlen=PV_CALIBRATION_WINDOW,
+            )
+            self._pv_cal_correction[sid] = float(entry.get("correction", 1.0))
+        active = {
+            sid: round(c, 3)
+            for sid, c in self._pv_cal_correction.items()
+            if abs(c - 1.0) > 0.01
+        }
+        if active:
+            _LOGGER.info("Restored PV forecast calibration: %s", active)
+
+    async def _async_save_pv_calibration(self) -> None:
+        """Persist per-array PV corrections."""
+        await self._pv_cal_store.async_save(
+            {
+                "arrays": {
+                    sid: {
+                        "samples": [[m, f] for m, f in samples],
+                        "correction": self._pv_cal_correction.get(sid, 1.0),
+                    }
+                    for sid, samples in self._pv_cal_samples.items()
+                }
+            }
+        )
+
+    async def async_reset_pv_calibration(self) -> None:
+        """Reset every per-array PV correction to the nominal 1.0."""
+        if self._pv_cal_samples or any(
+            abs(c - 1.0) > 1e-9 for c in self._pv_cal_correction.values()
+        ):
+            _LOGGER.info(
+                "Resetting PV forecast calibration for %d array(s)",
+                len(self._pv_cal_correction),
+            )
+        self._pv_cal_samples.clear()
+        self._pv_cal_correction.clear()
+        await self._async_save_pv_calibration()
+
+    def _read_pv_meter_kwh(self, entity_id: str) -> float | None:
+        """Read one cumulative production counter, in kWh."""
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return None
+        try:
+            value = float(state.state)
+        except (ValueError, TypeError):
+            return None
+        unit = str(state.attributes.get("unit_of_measurement") or "kWh")
+        if unit == "Wh":
+            return value / 1000.0
+        if unit == "MWh":
+            return value * 1000.0
+        return value
+
+    def _update_pv_calibration(self, now_utc: datetime) -> None:
+        """Compare the previous step's forecast against what each array produced.
+
+        The correction is an energy-weighted ratio, not a mean of per-step
+        ratios: a quarter hour under cloud has a large relative error on a tiny
+        amount of energy, and weighting by energy stops those steps dominating
+        an estimate that is meant to describe a gain error.
+
+        What it can and cannot fix is stated in const.py: a wrong tilt or
+        orientation entry, soiling and a dead string are gain errors and are
+        captured; shading is a function of sun position, not a constant factor,
+        and is not.
+        """
+        snapshot = self._pv_cal_snapshot
+        self._pv_cal_snapshot = {}
+        if not snapshot:
+            return
+
+        elapsed_min = (now_utc - snapshot["taken_at"]).total_seconds() / 60.0
+        step_min = FORECAST_INTERVAL_MINUTES
+        if not (0.5 * step_min <= elapsed_min <= 1.5 * step_min):
+            # The window the forecast described is not the window that elapsed.
+            return
+
+        if self.pv_curtailed:
+            # Production was deliberately suppressed; the shortfall is not a
+            # forecast error.
+            return
+
+        changed = False
+        for sid, planned_kwh in (snapshot["forecast_kwh"] or {}).items():
+            entity_id = self._pv_measured_sensors.get(sid)
+            before = (snapshot["meter_kwh"] or {}).get(sid)
+            if not entity_id or before is None or planned_kwh <= 0:
+                continue
+            after = self._read_pv_meter_kwh(entity_id)
+            if after is None:
+                continue
+            measured_kwh = after - before
+            if measured_kwh < 0:
+                _LOGGER.debug(
+                    "PV calibration: counter %s went backwards (%.3f -> %.3f kWh); "
+                    "treating as a meter reset",
+                    entity_id,
+                    before,
+                    after,
+                )
+                continue
+            if measured_kwh > PV_CALIBRATION_MAX_SAMPLE_RATIO * planned_kwh:
+                _LOGGER.debug(
+                    "PV calibration: dropping implausible sample for %s "
+                    "(measured %.3f kWh vs forecast %.3f kWh)",
+                    sid,
+                    measured_kwh,
+                    planned_kwh,
+                )
+                continue
+
+            samples = self._pv_cal_samples.setdefault(
+                sid, deque(maxlen=PV_CALIBRATION_WINDOW)
+            )
+            samples.append((measured_kwh, planned_kwh))
+            total_measured = sum(m for m, _ in samples)
+            total_planned = sum(f for _, f in samples)
+            if len(samples) < PV_CALIBRATION_MIN_SAMPLES or total_planned <= 0:
+                continue
+            correction = max(
+                PV_CALIBRATION_APPLY_MIN,
+                min(PV_CALIBRATION_APPLY_MAX, total_measured / total_planned),
+            )
+            previous = self._pv_cal_correction.get(sid, 1.0)
+            self._pv_cal_correction[sid] = correction
+            if abs(correction - previous) > 0.005:
+                changed = True
+                _LOGGER.info(
+                    "PV forecast correction for array %s: %.3f → %.3f "
+                    "(n=%d steps, measured %.2f kWh vs forecast %.2f kWh)",
+                    sid,
+                    previous,
+                    correction,
+                    len(samples),
+                    total_measured,
+                    total_planned,
+                )
+        if changed:
+            self.hass.async_create_task(self._async_save_pv_calibration())
+
+    def _pv_correction_for(self, sid: str, kwp: float, raw_kw: float) -> float:
+        """Return the gain factor to apply to one array's forecast step."""
+        if not sid:
+            return 1.0
+        return self._pv_cal_correction.get(sid, 1.0)
+
+    def _snapshot_pv_calibration(
+        self,
+        now_utc: datetime,
+        raw_first_step_kw: dict[str, float],
+        kwp_by_sid: dict[str, float],
+    ) -> None:
+        """Record what the next step is expected to produce, and the meters now.
+
+        Only arrays whose forecast falls in the middle of their rating are
+        recorded: below the floor the signal is smaller than the noise, above
+        the ceiling inverter clipping and thermal derating dominate and are not
+        forecast errors.
+        """
+        step_hours = FORECAST_INTERVAL_MINUTES / 60.0
+        forecast_kwh: dict[str, float] = {}
+        meter_kwh: dict[str, float] = {}
+        for sid, entity_id in self._pv_measured_sensors.items():
+            kwp = kwp_by_sid.get(sid, 0.0)
+            raw_kw = raw_first_step_kw.get(sid, 0.0)
+            if kwp <= 0:
+                continue
+            load_fraction = raw_kw / kwp
+            if not (
+                PV_CALIBRATION_MIN_LOAD_FRACTION
+                <= load_fraction
+                <= PV_CALIBRATION_MAX_LOAD_FRACTION
+            ):
+                continue
+            meter = self._read_pv_meter_kwh(entity_id)
+            if meter is None:
+                continue
+            forecast_kwh[sid] = raw_kw * step_hours
+            meter_kwh[sid] = meter
+        if forecast_kwh:
+            self._pv_cal_snapshot = {
+                "taken_at": now_utc,
+                "forecast_kwh": forecast_kwh,
+                "meter_kwh": meter_kwh,
+            }
 
     def _apply_sensor_forecast(
         self,
@@ -405,6 +639,12 @@ class ForecastCoordinator(DataUpdateCoordinator):
         poa_dni: list[float] | None = dni_steps or None
         poa_diffuse: list[float] | None = diffuse_steps or None
 
+        # Fold in what the previous step's forecast turned out to be worth,
+        # before this run's forecast is corrected with the result.
+        self._update_pv_calibration(now_utc)
+        raw_first_step_kw: dict[str, float] = {}
+        kwp_by_sid: dict[str, float] = {}
+
         # Sum AC PV forecast across all AC subentry models, applying temperature derating
         pv_forecast = [0.0] * n
         per_pv_array_forecasts: dict[str, list[float]] = {}
@@ -421,6 +661,15 @@ class ForecastCoordinator(DataUpdateCoordinator):
                 longitude=lon,
             )
             extra = self._apply_sensor_forecast(extra, sensors, timestamps_utc)
+            if sid:
+                # Snapshot the UNcorrected value: the factor is always
+                # measured/raw, so it stays a direct estimate instead of
+                # compounding on itself run after run.
+                raw_first_step_kw[sid] = extra[0] if extra else 0.0
+                kwp_by_sid[sid] = model.peak_power_kwp
+            gain = self._pv_correction_for(sid, model.peak_power_kwp, 0.0)
+            if gain != 1.0:
+                extra = [v * gain for v in extra]
             arr_forecast = [round(max(0.0, v), 3) for v in extra[:n]]
             if sid:
                 per_pv_array_forecasts[sid] = arr_forecast
@@ -446,6 +695,12 @@ class ForecastCoordinator(DataUpdateCoordinator):
                 longitude=lon,
             )
             extra_dc = self._apply_sensor_forecast(extra_dc, dc_sensors, timestamps_utc)
+            if sid:
+                raw_first_step_kw[sid] = extra_dc[0] if extra_dc else 0.0
+                kwp_by_sid[sid] = dc_model.peak_power_kwp
+            gain = self._pv_correction_for(sid, dc_model.peak_power_kwp, 0.0)
+            if gain != 1.0:
+                extra_dc = [v * gain for v in extra_dc]
             arr_forecast = [round(max(0.0, v), 3) for v in extra_dc[:n]]
             if sid:
                 per_pv_array_forecasts[sid] = arr_forecast
@@ -475,6 +730,10 @@ class ForecastCoordinator(DataUpdateCoordinator):
         current_total_pv = current_pv + current_dc_pv * DC_TO_AC_INVERTER_EFFICIENCY
         current_consumption = self.consumption_model.get_current_consumption()
 
+        # Record what the step about to elapse should produce, so the next run
+        # can score it.
+        self._snapshot_pv_calibration(now_utc, raw_first_step_kw, kwp_by_sid)
+
         result = {
             "pv_forecast_kw": [round(v, 3) for v in pv_forecast],
             "pv_dc_forecast_kw": [round(v, 3) for v in pv_dc_forecast],
@@ -490,6 +749,13 @@ class ForecastCoordinator(DataUpdateCoordinator):
             if wind_speed_steps
             else 0.0,
             "pv_dc_coupled": has_dc,
+            "pv_calibration": {
+                sid: {
+                    "correction": round(self._pv_cal_correction.get(sid, 1.0), 4),
+                    "samples": len(self._pv_cal_samples.get(sid, ())),
+                }
+                for sid in self._pv_measured_sensors
+            },
             "forecast_interval_minutes": step_min,
             "forecast_start_utc": current_step,
             "timestamp": dt_util.utcnow(),

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -26,6 +26,8 @@ from .const import (
     ACTION_DISCHARGING,
     ACTION_IDLE,
     DC_TO_AC_INVERTER_EFFICIENCY,
+    CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
     CONF_BATTERY_SOC_SENSOR,
     CONF_BATTERY_POWER_SENSOR,
     CONF_CONTROL_MODE,
@@ -93,6 +95,30 @@ _SOC_HYSTERESIS = 0.05
 # this fraction of the planned charge power. Below it, the DP evidently wants
 # grid charging beyond the surplus and the schedule is followed instead.
 _SURPLUS_COVERS_PLAN_FRACTION = 0.8
+
+# Efficiency calibration tuning.
+#
+# A sample is only worth taking when the planned SoC change is comfortably
+# larger than the resolution of whatever measured it. The energy counters are
+# fine-grained, so the floor there is just "big enough to be a real action". A
+# SoC sensor reporting whole percent, by contrast, quantises at capacity/100 —
+# 0.1 kWh on a 10 kWh pack, which is exactly the old fixed floor, so a single
+# sample carried up to +/-50 % quantisation error. On that path the floor
+# scales with the observed quantum instead.
+_CALIBRATION_MIN_DELTA_KWH = 0.1
+_CALIBRATION_SOC_QUANTUM_FACTOR = 4.0
+
+# Samples outside this window are dropped rather than clipped into it. The
+# window is wide enough to contain genuine derating and far enough above 1.0
+# that ordinary measurement noise is not truncated on one side — the previous
+# code capped the ratio at 1.05 while allowing it down to 0.5, so symmetric
+# noise biased the mean downward and could apply a correction below 1.0 to a
+# perfectly healthy battery. The applied correction is still clamped (below).
+_CALIBRATION_ACCEPT_MIN = 0.5
+_CALIBRATION_ACCEPT_MAX = 1.5
+# Bounds on the correction actually handed to the optimizer.
+_CALIBRATION_APPLY_MIN = 0.5
+_CALIBRATION_APPLY_MAX = 1.05
 
 
 class OptimizationCoordinator(DataUpdateCoordinator):
@@ -292,6 +318,16 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # to avoid confounding with passive PV.
         self._charge_eff_samples: deque[float] = deque(maxlen=20)
         self._charge_eff_correction: float = 1.0
+
+        # Cumulative throughput counters as they stood when _last_result was
+        # planned. The difference against the next read is the energy the
+        # battery actually moved over that step — a far finer measurement than
+        # the SoC delta, which on a whole-percent sensor quantises at
+        # capacity/100 (0.1 kWh on a 10 kWh pack).
+        self._energy_counter_snapshot: dict[str, float | None] = {
+            "charged": None,
+            "discharged": None,
+        }
 
         # Persistent storage for charge efficiency calibration (survives reboots).
         entry_id = config.get("entry_id", "unknown")
@@ -1570,6 +1606,175 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._charge_eff_correction = 1.0
         await self._async_save_charge_eff_calibration()
 
+    def _battery_energy_sensor_ids(self, conf_key: str) -> list[str]:
+        """Collect one energy counter per battery subentry that has it configured.
+
+        Deduplicated: where one inverter reports a single counter covering
+        several packs it may legitimately be selected on more than one
+        subentry, and counting it twice would double the measured throughput.
+        Same convention as the forecast coordinator's collector.
+        """
+        seen: list[str] = []
+        for _sid, data in self._battery_subentries:
+            entity_id = data.get(conf_key)
+            if entity_id and entity_id not in seen:
+                seen.append(entity_id)
+        return seen
+
+    def _read_energy_total_kwh(self, conf_key: str) -> float | None:
+        """Sum the configured cumulative energy counters, in kWh.
+
+        Returns None when no counter is configured or any of them is
+        unavailable: a partial sum would look like a jump backwards on the next
+        read and poison the delta.
+        """
+        sensor_ids = self._battery_energy_sensor_ids(conf_key)
+        if not sensor_ids:
+            return None
+        total = 0.0
+        for sensor_id in sensor_ids:
+            state = self.hass.states.get(sensor_id)
+            if state is None or state.state in ("unknown", "unavailable"):
+                return None
+            try:
+                value = float(state.state)
+            except (ValueError, TypeError):
+                return None
+            unit = str(state.attributes.get("unit_of_measurement") or "kWh")
+            if unit == "Wh":
+                value /= 1000.0
+            elif unit == "MWh":
+                value *= 1000.0
+            elif unit != "kWh":
+                self._warn_unit_once(sensor_id, unit, "treating value as kWh")
+            total += value
+        return total
+
+    def _read_energy_totals(self) -> dict[str, float | None]:
+        """Read both cumulative throughput counters at one instant."""
+        return {
+            "charged": self._read_energy_total_kwh(CONF_BATTERY_ENERGY_CHARGED_SENSOR),
+            "discharged": self._read_energy_total_kwh(
+                CONF_BATTERY_ENERGY_DISCHARGED_SENSOR
+            ),
+        }
+
+    def _counter_delta_kwh(
+        self, key: str, totals_now: dict[str, float | None]
+    ) -> float | None:
+        """Throughput measured by the counters since the plan was made.
+
+        None when either end of the interval is missing, or when the counter
+        went backwards — a total_increasing sensor that was reset or replaced,
+        where the difference is meaningless rather than negative.
+        """
+        before = self._energy_counter_snapshot.get(key)
+        after = totals_now.get(key)
+        if before is None or after is None:
+            return None
+        delta = after - before
+        if delta < 0:
+            _LOGGER.debug(
+                "Efficiency calibration: %s counter went backwards "
+                "(%.3f -> %.3f kWh); treating as a meter reset",
+                key,
+                before,
+                after,
+            )
+            return None
+        return delta
+
+    def _soc_quantum_kwh(self) -> float:
+        """Estimate the resolution of the aggregated SoC measurement, in kWh.
+
+        Derived from the decimals each SoC sensor actually reports: a state of
+        "47" is whole-percent, "47.3" is ten times finer. Summed across packs
+        because the aggregate SoC is a sum and the individual quantisation
+        errors can align. Returns 0.0 when nothing can be determined, which
+        leaves the caller on its fixed floor.
+        """
+        total = 0.0
+        for (_sid, cfg), (_sid2, data) in zip(
+            self._individual_battery_configs, self._battery_subentries
+        ):
+            sensor_id = data.get(CONF_BATTERY_SOC_SENSOR)
+            if not sensor_id:
+                continue
+            state = self.hass.states.get(sensor_id)
+            if state is None or state.state in ("unknown", "unavailable"):
+                continue
+            raw = state.state.strip()
+            decimals = len(raw.split(".", 1)[1]) if "." in raw else 0
+            step = 10.0**-decimals
+            unit = str(state.attributes.get("unit_of_measurement") or "%")
+            if unit == "kWh":
+                total += step
+            elif unit == "Wh":
+                total += step / 1000.0
+            else:  # percent (or unitless, which is treated as percent elsewhere)
+                total += step / 100.0 * cfg.capacity_kwh
+        return total
+
+    def _min_planned_delta_kwh(self, from_counters: bool) -> float:
+        """Smallest planned SoC change worth sampling, given how it is measured."""
+        if from_counters:
+            return _CALIBRATION_MIN_DELTA_KWH
+        quantum = self._soc_quantum_kwh()
+        return max(
+            _CALIBRATION_MIN_DELTA_KWH,
+            _CALIBRATION_SOC_QUANTUM_FACTOR * quantum,
+        )
+
+    def _record_calibration_sample(
+        self,
+        *,
+        direction: str,
+        samples: deque[float],
+        current_correction: float,
+        planned_delta: float,
+        actual_delta: float,
+        source: str,
+    ) -> float:
+        """Fold one actual/planned observation into a correction factor.
+
+        Samples outside the acceptance window are dropped rather than clipped
+        into it. Clipping was not symmetric around 1.0 — the ratio was capped
+        at 1.05 but allowed down to 0.5 — so ordinary measurement noise pulled
+        the mean below 1.0 and a healthy battery could end up with a correction
+        applied to it. Only the resulting mean is clamped, and only for use.
+        """
+        ratio = actual_delta / planned_delta
+        if not (_CALIBRATION_ACCEPT_MIN <= ratio <= _CALIBRATION_ACCEPT_MAX):
+            _LOGGER.debug(
+                "%s efficiency calibration: dropping implausible sample "
+                "(ratio=%.3f from %s, planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
+                direction.capitalize(),
+                ratio,
+                source,
+                planned_delta,
+                actual_delta,
+            )
+            return current_correction
+
+        samples.append(ratio)
+        mean = sum(samples) / len(samples)
+        new_correction = max(_CALIBRATION_APPLY_MIN, min(_CALIBRATION_APPLY_MAX, mean))
+        if abs(new_correction - current_correction) > 0.005:
+            _LOGGER.info(
+                "%s efficiency correction updated: %.3f → %.3f "
+                "(latest ratio=%.3f from %s, n=%d samples, "
+                "planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
+                direction.capitalize(),
+                current_correction,
+                new_correction,
+                ratio,
+                source,
+                len(samples),
+                planned_delta,
+                actual_delta,
+            )
+        return new_correction
+
     def _previous_charge_step_complete(self) -> bool:
         """Return whether the previously planned first step has elapsed.
 
@@ -1629,7 +1834,11 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         tolerance_kw = max(0.05, 0.1 * abs(planned_kw))
         return abs(executed_kw - planned_kw) <= tolerance_kw
 
-    def _update_charge_eff_calibration(self, battery_state: BatteryState) -> None:
+    def _update_charge_eff_calibration(
+        self,
+        battery_state: BatteryState,
+        energy_totals_now: dict[str, float | None] | None = None,
+    ) -> None:
         """Compare previous planned SoC to actual SoC and update charge efficiency correction.
 
         Samples are only collected when:
@@ -1679,8 +1888,19 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         planned_next_soc = self._last_result.soc_schedule_kwh[1]
         planned_delta = planned_next_soc - prev_soc
 
-        if planned_delta < 0.1:
-            # Too small to measure reliably; skip.
+        # Prefer the cumulative charged-energy counter over the SoC delta. Both
+        # measure the same quantity — energy into the battery, which is what
+        # the planned SoC change represents — but the counter is not limited by
+        # the SoC sensor's step size.
+        counter_delta = (
+            self._counter_delta_kwh("charged", energy_totals_now)
+            if energy_totals_now is not None
+            else None
+        )
+        from_counters = counter_delta is not None
+
+        if planned_delta < self._min_planned_delta_kwh(from_counters):
+            # Too small to measure reliably at this resolution; skip.
             return
 
         # Skip if the step crosses the high-SoC charge derating threshold.
@@ -1700,32 +1920,23 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 )
                 return
 
-        actual_delta = battery_state.soc_kwh - prev_soc
-        # Cap upward to 1.2× planned to filter out unexpected external charge
-        # sources (e.g. brief grid export reversed, SoC sensor noise).
-        actual_delta = max(0.0, min(actual_delta, 1.2 * planned_delta))
-        ratio = actual_delta / planned_delta
-        # Clip to a physically reasonable range; the correction should never
-        # indicate the battery charged *more* than modelled by more than 5%.
-        ratio = max(0.5, min(1.05, ratio))
+        if counter_delta is not None:
+            actual_delta = counter_delta
+            source = "energy counter"
+        else:
+            actual_delta = max(0.0, battery_state.soc_kwh - prev_soc)
+            source = "SoC delta"
 
-        self._charge_eff_samples.append(ratio)
-        new_correction = sum(self._charge_eff_samples) / len(self._charge_eff_samples)
-
-        changed = abs(new_correction - self._charge_eff_correction) > 0.005
-        if changed:
-            _LOGGER.info(
-                "Charge efficiency correction updated: %.3f → %.3f "
-                "(latest ratio=%.3f, n=%d samples, planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
-                self._charge_eff_correction,
-                new_correction,
-                ratio,
-                len(self._charge_eff_samples),
-                planned_delta,
-                actual_delta,
-            )
-        self._charge_eff_correction = new_correction
-        if changed:
+        previous = self._charge_eff_correction
+        self._charge_eff_correction = self._record_calibration_sample(
+            direction="charge",
+            samples=self._charge_eff_samples,
+            current_correction=previous,
+            planned_delta=planned_delta,
+            actual_delta=actual_delta,
+            source=source,
+        )
+        if abs(self._charge_eff_correction - previous) > 0.005:
             self.hass.async_create_task(self._async_save_charge_eff_calibration())
 
     async def _async_load_discharge_eff_calibration(self) -> None:
@@ -1768,7 +1979,11 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._discharge_eff_correction = 1.0
         await self._async_save_discharge_eff_calibration()
 
-    def _update_discharge_eff_calibration(self, battery_state: BatteryState) -> None:
+    def _update_discharge_eff_calibration(
+        self,
+        battery_state: BatteryState,
+        energy_totals_now: dict[str, float | None] | None = None,
+    ) -> None:
         """Compare previous planned SoC to actual SoC and update discharge efficiency correction.
 
         Samples are only collected when:
@@ -1816,8 +2031,17 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         planned_next_soc = self._last_result.soc_schedule_kwh[1]
         planned_delta = prev_soc - planned_next_soc  # positive: SoC goes down
 
-        if planned_delta < 0.1:
-            # Too small to measure reliably; skip.
+        # Prefer the cumulative discharged-energy counter over the SoC delta
+        # (same reasoning as the charge side).
+        counter_delta = (
+            self._counter_delta_kwh("discharged", energy_totals_now)
+            if energy_totals_now is not None
+            else None
+        )
+        from_counters = counter_delta is not None
+
+        if planned_delta < self._min_planned_delta_kwh(from_counters):
+            # Too small to measure reliably at this resolution; skip.
             return
 
         # Skip if the step crosses the low-SoC discharge derating threshold.
@@ -1838,34 +2062,24 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 )
                 return
 
-        actual_delta = prev_soc - battery_state.soc_kwh  # positive: SoC went down
-        # Cap upward to 1.2× planned to filter out unexpected external discharge
-        # (e.g. grid outage, SoC sensor noise causing apparent over-discharge).
-        actual_delta = max(0.0, min(actual_delta, 1.2 * planned_delta))
-        ratio = actual_delta / planned_delta
-        # Clip to a physically reasonable range; the correction should never
-        # indicate the battery discharged *more* than modelled by more than 5%.
-        ratio = max(0.5, min(1.05, ratio))
+        if counter_delta is not None:
+            actual_delta = counter_delta
+            source = "energy counter"
+        else:
+            # positive: SoC went down
+            actual_delta = max(0.0, prev_soc - battery_state.soc_kwh)
+            source = "SoC delta"
 
-        self._discharge_eff_samples.append(ratio)
-        new_correction = sum(self._discharge_eff_samples) / len(
-            self._discharge_eff_samples
+        previous = self._discharge_eff_correction
+        self._discharge_eff_correction = self._record_calibration_sample(
+            direction="discharge",
+            samples=self._discharge_eff_samples,
+            current_correction=previous,
+            planned_delta=planned_delta,
+            actual_delta=actual_delta,
+            source=source,
         )
-
-        changed = abs(new_correction - self._discharge_eff_correction) > 0.005
-        if changed:
-            _LOGGER.info(
-                "Discharge efficiency correction updated: %.3f → %.3f "
-                "(latest ratio=%.3f, n=%d samples, planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
-                self._discharge_eff_correction,
-                new_correction,
-                ratio,
-                len(self._discharge_eff_samples),
-                planned_delta,
-                actual_delta,
-            )
-        self._discharge_eff_correction = new_correction
-        if changed:
+        if abs(self._discharge_eff_correction - previous) > 0.005:
             self.hass.async_create_task(self._async_save_discharge_eff_calibration())
 
     async def _run_optimization(self) -> dict[str, Any]:
@@ -2278,11 +2492,16 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # Get current battery state
         battery_state = self.get_current_battery_state()
 
-        # Charge efficiency calibration: compare previous planned SoC with actual SoC
-        # to detect systematic over-estimation of charge efficiency (e.g. CV-phase).
-        self._update_charge_eff_calibration(battery_state)
+        # Cumulative throughput counters, read once: they close the previous
+        # planned step and open the new one at the same instant.
+        energy_totals_now = self._read_energy_totals()
+
+        # Charge efficiency calibration: compare the previous plan against what
+        # the battery actually moved, to detect systematic over-estimation of
+        # charge efficiency (e.g. CV-phase).
+        self._update_charge_eff_calibration(battery_state, energy_totals_now)
         # Discharge efficiency calibration: same principle for discharging steps.
-        self._update_discharge_eff_calibration(battery_state)
+        self._update_discharge_eff_calibration(battery_state, energy_totals_now)
 
         battery_config = self.battery_config
 
@@ -2361,6 +2580,9 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         )
 
         self._last_result = result
+        # Snapshot the counters alongside the plan they belong to, so the next
+        # run can measure the throughput of exactly this step.
+        self._energy_counter_snapshot = energy_totals_now
 
         # Get current grid power: prefer real sensor, fall back to estimate
         realtime_grid_w = self._get_realtime_grid_w()

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -403,8 +403,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
 
     @pv_curtailed.setter
     def pv_curtailed(self, value: bool) -> None:
-        """Enable or disable PV curtailment mode."""
+        """Enable or disable PV curtailment mode.
+
+        Propagated to the forecast coordinator: while production is
+        deliberately suppressed, the shortfall against the PV forecast is not a
+        forecast error and must not be learned as a per-array correction.
+        """
         self._pv_curtailed = value
+        self.forecast_coordinator.pv_curtailed = value
 
     async def _handle_price_model_refresh(self, now: datetime) -> None:
         """Refresh historical price model from HA recorder (daily timer)."""

--- a/custom_components/battery_controller/services.yaml
+++ b/custom_components/battery_controller/services.yaml
@@ -19,3 +19,14 @@ reset_discharge_efficiency_calibration:
       example: 01KK4RJJQZBD9C3FMEVYAB0VAB
       selector:
         text:
+
+reset_pv_calibration:
+  name: Reset PV forecast calibration
+  description: Reset every per-array PV forecast correction back to 1.0 and clear all calibration samples.
+  fields:
+    entry_id:
+      name: Config entry ID
+      description: Optional. Reset only the specified Battery Controller config entry. Leave empty to reset all Battery Controller entries.
+      example: 01KK4RJJQZBD9C3FMEVYAB0VAB
+      selector:
+        text:

--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -276,12 +276,14 @@
             "tilt": "Tilt angle (degrees, 0=flat, 90=vertical)",
             "efficiency_factor": "System efficiency (0-1, accounts for shading, wiring, soiling)",
             "dc_coupled": "DC-coupled (directly on battery inverter)",
-            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)"
+            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)",
+            "pv_measured_production_sensor": "Measured production sensor (kWh, optional)"
           },
           "data_description": {
             "peak_power_kwp": "Total rated peak power of all panels in this array",
             "efficiency_factor": "Ignored for DC-coupled arrays (uses DC coupling efficiency from main config)",
-            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback."
+            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback.",
+            "pv_measured_production_sensor": "Cumulative kWh produced by THIS array. Used to learn a per-array correction on the forecast — a wrong tilt or orientation entry, soiling or a dead string show up as a systematic gain error. Also feeds the gross-load reconstruction, alongside any sensors already configured there. If one inverter reports a single counter for several arrays, set it on one of them."
           }
         },
         "reconfigure": {
@@ -294,10 +296,12 @@
             "tilt": "Tilt angle (degrees, 0=flat, 90=vertical)",
             "efficiency_factor": "System efficiency (0-1)",
             "dc_coupled": "DC-coupled (directly on battery inverter)",
-            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)"
+            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)",
+            "pv_measured_production_sensor": "Measured production sensor (kWh, optional)"
           },
           "data_description": {
-            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback."
+            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback.",
+            "pv_measured_production_sensor": "Cumulative kWh produced by THIS array. Used to learn a per-array correction on the forecast — a wrong tilt or orientation entry, soiling or a dead string show up as a systematic gain error. Also feeds the gross-load reconstruction, alongside any sensors already configured there. If one inverter reports a single counter for several arrays, set it on one of them."
           }
         }
       },

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -276,12 +276,14 @@
             "tilt": "Tilt angle (degrees, 0=flat, 90=vertical)",
             "efficiency_factor": "System efficiency (0-1, accounts for shading, wiring, soiling)",
             "dc_coupled": "DC-coupled (directly on battery inverter)",
-            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)"
+            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)",
+            "pv_measured_production_sensor": "Measured production sensor (kWh, optional)"
           },
           "data_description": {
             "peak_power_kwp": "Total rated peak power of all panels in this array",
             "efficiency_factor": "Ignored for DC-coupled arrays (uses DC coupling efficiency from main config)",
-            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback."
+            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback.",
+            "pv_measured_production_sensor": "Cumulative kWh produced by THIS array. Used to learn a per-array correction on the forecast — a wrong tilt or orientation entry, soiling or a dead string show up as a systematic gain error. Also feeds the gross-load reconstruction, alongside any sensors already configured there. If one inverter reports a single counter for several arrays, set it on one of them."
           }
         },
         "reconfigure": {
@@ -294,10 +296,12 @@
             "tilt": "Tilt angle (degrees, 0=flat, 90=vertical)",
             "efficiency_factor": "System efficiency (0-1)",
             "dc_coupled": "DC-coupled (directly on battery inverter)",
-            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)"
+            "pv_forecast_sensors": "PV forecast sensors (optional, e.g. Solcast)",
+            "pv_measured_production_sensor": "Measured production sensor (kWh, optional)"
           },
           "data_description": {
-            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback."
+            "pv_forecast_sensors": "Forecast sensors from a PV forecast integration such as Solcast (select both the 'Forecast Today' and 'Forecast Tomorrow' sensors). When set, their data replaces the internal radiation-based model for the periods they cover; the internal model remains the fallback.",
+            "pv_measured_production_sensor": "Cumulative kWh produced by THIS array. Used to learn a per-array correction on the forecast — a wrong tilt or orientation entry, soiling or a dead string show up as a systematic gain error. Also feeds the gross-load reconstruction, alongside any sensors already configured there. If one inverter reports a single counter for several arrays, set it on one of them."
           }
         }
       },

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -215,10 +215,12 @@
             "tilt": "Hellingshoek (graden, 0=vlak, 90=verticaal)",
             "efficiency_factor": "Systeemrendement (0-1, rekening met schaduw, bedrading, vervuiling)",
             "dc_coupled": "DC-gekoppeld (direct op batterij-omvormer)",
-            "pv_forecast_sensors": "PV-voorspellingssensoren (optioneel, bijv. Solcast)"
+            "pv_forecast_sensors": "PV-voorspellingssensoren (optioneel, bijv. Solcast)",
+            "pv_measured_production_sensor": "Gemeten productiesensor (kWh, optioneel)"
           },
           "data_description": {
-            "pv_forecast_sensors": "Voorspellingssensoren van een PV-forecast-integratie zoals Solcast (selecteer zowel de 'Forecast Today' als 'Forecast Tomorrow' sensoren). Indien ingesteld vervangt deze data het interne stralingsmodel voor de periodes die ze dekken; het interne model blijft de terugval."
+            "pv_forecast_sensors": "Voorspellingssensoren van een PV-forecast-integratie zoals Solcast (selecteer zowel de 'Forecast Today' als 'Forecast Tomorrow' sensoren). Indien ingesteld vervangt deze data het interne stralingsmodel voor de periodes die ze dekken; het interne model blijft de terugval.",
+            "pv_measured_production_sensor": "Cumulatieve kWh van DEZE array. Wordt gebruikt om per array een correctie op de voorspelling te leren — een verkeerd ingevoerde hoek of oriëntatie, vervuiling of een uitgevallen string komen naar voren als een systematische afwijking. Telt ook mee in de reconstructie van het huisverbruik, naast de sensoren die daar al zijn ingesteld. Als één omvormer één teller voor meerdere arrays rapporteert, stel hem dan bij één ervan in."
           }
         },
         "reconfigure": {
@@ -231,10 +233,12 @@
             "tilt": "Hellingshoek (graden, 0=vlak, 90=verticaal)",
             "efficiency_factor": "Systeemrendement (0-1)",
             "dc_coupled": "DC-gekoppeld (direct op batterij-omvormer)",
-            "pv_forecast_sensors": "PV-voorspellingssensoren (optioneel, bijv. Solcast)"
+            "pv_forecast_sensors": "PV-voorspellingssensoren (optioneel, bijv. Solcast)",
+            "pv_measured_production_sensor": "Gemeten productiesensor (kWh, optioneel)"
           },
           "data_description": {
-            "pv_forecast_sensors": "Voorspellingssensoren van een PV-forecast-integratie zoals Solcast (selecteer zowel de 'Forecast Today' als 'Forecast Tomorrow' sensoren). Indien ingesteld vervangt deze data het interne stralingsmodel voor de periodes die ze dekken; het interne model blijft de terugval."
+            "pv_forecast_sensors": "Voorspellingssensoren van een PV-forecast-integratie zoals Solcast (selecteer zowel de 'Forecast Today' als 'Forecast Tomorrow' sensoren). Indien ingesteld vervangt deze data het interne stralingsmodel voor de periodes die ze dekken; het interne model blijft de terugval.",
+            "pv_measured_production_sensor": "Cumulatieve kWh van DEZE array. Wordt gebruikt om per array een correctie op de voorspelling te leren — een verkeerd ingevoerde hoek of oriëntatie, vervuiling of een uitgevallen string komen naar voren als een systematische afwijking. Telt ook mee in de reconstructie van het huisverbruik, naast de sensoren die daar al zijn ingesteld. Als één omvormer één teller voor meerdere arrays rapporteert, stel hem dan bij één ervan in."
           }
         }
       },

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -649,6 +649,35 @@ Output: power_schedule_kw, mode_schedule, soc_schedule_kwh,
 
 ---
 
+### Per-array PV forecast calibration
+
+Each PV array can carry a measured production counter. The forecast for that
+array is then scored against what it actually produced and multiplied by a
+learned gain factor.
+
+The factor is an energy-weighted ratio over the last `PV_CALIBRATION_WINDOW`
+sampled steps — `sum(measured) / sum(forecast)`, not a mean of per-step ratios.
+A quarter hour under cloud has a large relative error on a tiny amount of
+energy, and weighting by energy stops those steps dominating an estimate that
+is meant to describe a gain error.
+
+Samples are only taken in the middle of the array's rating (10–80 % of kWp):
+below the floor the signal is smaller than the noise, above the ceiling
+inverter clipping and thermal derating dominate and are not forecast errors.
+Steps are skipped entirely while PV curtailment is active, when the elapsed
+window is not the window the forecast described, and when the counter jumps
+backwards. The applied factor is clamped and only used once enough samples
+exist.
+
+**What it can and cannot fix.** A wrong tilt or orientation entry, soiling and
+a string that is down are gain errors: the array produces a roughly constant
+fraction of what the model expects, and the factor captures that. Shading is
+not — it is a function of sun position, so a single scalar smears a
+morning-only obstruction across the whole day. Modelling that needs a horizon
+profile, which this does not attempt.
+
+---
+
 ## 12. Multi-Battery Dispatch
 
 The DP optimizer treats all configured batteries as a single aggregated virtual battery (`aggregate_battery_configs`). After the optimizer produces a combined setpoint, `_split_setpoint` distributes it across the individual inverters.

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -491,6 +491,8 @@ Let `chg_r = chg_eff_repr` and `dis_r = dis_eff_repr` (representative scalars, �
 
 Charge-speed correction: when runtime calibration detects that the battery gains less SoC per time step than modelled, the optimizer reduces the charge-side efficiency curve for the planned SoC transitions. Economic quantities (step costs, the oscillation-filter threshold) keep using the nominal curves.
 
+The observation is taken from the per-battery cumulative kWh counters when they are configured, and from the SoC delta otherwise. Both measure the same energy, but a SoC sensor reporting whole percent quantises at `capacity / 100` — 0.1 kWh on a 10 kWh pack — so on that path the minimum planned change worth sampling scales with the observed sensor resolution rather than a fixed 0.1 kWh. Samples outside `[0.5, 1.5]` are dropped rather than folded into the mean: an asymmetric clip (capped at 1.05, allowed down to 0.5) let symmetric measurement noise bias the correction below 1.0 for a healthy battery. Only the resulting mean is clamped, to `[0.5, 1.05]`, before it is applied.
+
 The shadow price is always the raw DP value — there is no separate "post-processed" shadow price. Post-processing filters affect `total_cost` and `savings` (where the difference between raw and processed values shows the impact of filtered actions), but the shadow price is a DP concept that is not modified by post-processing.
 
 **Use by hybrid mode**: λ is used by the coordinator as the charge/discharge switching threshold in hybrid mode. It is deliberately not fed back into the next run's terminal condition (see [Section 5](#5-terminal-condition)).

--- a/tests/test_coordinator_forecast.py
+++ b/tests/test_coordinator_forecast.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,6 +11,7 @@ import pytest
 
 from custom_components.battery_controller.const import (
     CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_PV_MEASURED_PRODUCTION_SENSOR,
 )
 from custom_components.battery_controller.coordinator_forecast import (
     ForecastCoordinator,
@@ -1248,3 +1250,249 @@ class TestBatteryEnergySensors:
         assert _battery_energy_sensors(config, CONF_BATTERY_ENERGY_CHARGED_SENSOR) == [
             "sensor.inverter_in"
         ]
+
+
+# ---------------------------------------------------------------------------
+# Per-array PV forecast calibration
+# ---------------------------------------------------------------------------
+
+
+def _pv_array(sid="pv1", kwp=4.0, measured="sensor.pv1_energy", dc=False):
+    return {
+        "subentry_id": sid,
+        "peak_power_kwp": kwp,
+        "orientation": 180.0,
+        "tilt": 35.0,
+        "efficiency_factor": 0.85,
+        "dc_coupled": dc,
+        CONF_PV_MEASURED_PRODUCTION_SENSOR: measured,
+    }
+
+
+def _make_cal_coordinator(hass, pv_arrays=None, legacy_pv_sensors=None):
+    weather_coord = MagicMock()
+    weather_coord.data = None
+    config = _minimal_config(pv_arrays=pv_arrays or [_pv_array()])
+    config["pv_production_sensors"] = legacy_pv_sensors or []
+    with patch(
+        "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+        return_value=_make_mock_consumption(),
+    ):
+        return ForecastCoordinator(hass, weather_coord, config)
+
+
+@pytest.mark.asyncio
+async def test_measured_sensor_joins_the_reconstruction_without_migration(hass):
+    """The per-array sensor is additive: the legacy list keeps working as-is."""
+    weather_coord = MagicMock()
+    weather_coord.data = None
+    config = _minimal_config(pv_arrays=[_pv_array(measured="sensor.pv1_energy")])
+    config["pv_production_sensors"] = ["sensor.legacy_total"]
+
+    captured = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return _make_mock_consumption()
+
+    with patch(
+        "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+        side_effect=_capture,
+    ):
+        ForecastCoordinator(hass, weather_coord, config)
+
+    assert captured["pv_production_sensors"] == [
+        "sensor.legacy_total",
+        "sensor.pv1_energy",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_measured_sensor_is_deduplicated_against_the_legacy_list(hass):
+    """The same entity configured in both places must be counted once."""
+    weather_coord = MagicMock()
+    weather_coord.data = None
+    config = _minimal_config(pv_arrays=[_pv_array(measured="sensor.shared")])
+    config["pv_production_sensors"] = ["sensor.shared"]
+
+    captured = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return _make_mock_consumption()
+
+    with patch(
+        "custom_components.battery_controller.coordinator_forecast.ConsumptionForecastModel",
+        side_effect=_capture,
+    ):
+        ForecastCoordinator(hass, weather_coord, config)
+
+    assert captured["pv_production_sensors"] == ["sensor.shared"]
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_learns_an_energy_weighted_gain(hass):
+    """A systematically over-forecast array converges on the measured ratio."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    step_h = 0.25
+    meter = 100.0
+
+    # 30 quarter-hours where the array delivers 80 % of the forecast.
+    for i in range(30):
+        forecast_kw = 2.0  # 50 % of the 4 kWp rating: inside the sampling band
+        coord._pv_cal_snapshot = {
+            "taken_at": now,
+            "forecast_kwh": {"pv1": forecast_kw * step_h},
+            "meter_kwh": {"pv1": meter},
+        }
+        meter += 0.8 * forecast_kw * step_h
+        hass.states.async_set(
+            "sensor.pv1_energy", f"{meter}", {"unit_of_measurement": "kWh"}
+        )
+        now += timedelta(minutes=15)
+        coord._update_pv_calibration(now)
+
+    assert coord._pv_cal_correction["pv1"] == pytest.approx(0.8, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_waits_for_enough_samples(hass):
+    """Below the sample floor no correction is applied at all."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    meter = 100.0
+    for _ in range(5):
+        coord._pv_cal_snapshot = {
+            "taken_at": now,
+            "forecast_kwh": {"pv1": 0.5},
+            "meter_kwh": {"pv1": meter},
+        }
+        meter += 0.4
+        hass.states.async_set(
+            "sensor.pv1_energy", f"{meter}", {"unit_of_measurement": "kWh"}
+        )
+        now += timedelta(minutes=15)
+        coord._update_pv_calibration(now)
+
+    assert len(coord._pv_cal_samples["pv1"]) == 5
+    assert "pv1" not in coord._pv_cal_correction
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_skipped_while_curtailed(hass):
+    """Deliberately suppressed production is not a forecast error."""
+    coord = _make_cal_coordinator(hass)
+    coord.pv_curtailed = True
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    coord._pv_cal_snapshot = {
+        "taken_at": now,
+        "forecast_kwh": {"pv1": 0.5},
+        "meter_kwh": {"pv1": 100.0},
+    }
+    hass.states.async_set("sensor.pv1_energy", "100.0", {"unit_of_measurement": "kWh"})
+    coord._update_pv_calibration(now + timedelta(minutes=15))
+
+    assert "pv1" not in coord._pv_cal_samples
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_ignores_a_mismatched_window(hass):
+    """If the elapsed time is not the window the forecast described, skip."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    coord._pv_cal_snapshot = {
+        "taken_at": now,
+        "forecast_kwh": {"pv1": 0.5},
+        "meter_kwh": {"pv1": 100.0},
+    }
+    hass.states.async_set("sensor.pv1_energy", "100.4", {"unit_of_measurement": "kWh"})
+    coord._update_pv_calibration(now + timedelta(hours=2))
+
+    assert "pv1" not in coord._pv_cal_samples
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_ignores_a_meter_reset(hass):
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    coord._pv_cal_snapshot = {
+        "taken_at": now,
+        "forecast_kwh": {"pv1": 0.5},
+        "meter_kwh": {"pv1": 100.0},
+    }
+    hass.states.async_set("sensor.pv1_energy", "0.2", {"unit_of_measurement": "kWh"})
+    coord._update_pv_calibration(now + timedelta(minutes=15))
+
+    assert "pv1" not in coord._pv_cal_samples
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_drops_an_absurd_sample(hass):
+    """Five times the forecast in one step is not a gain error."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    coord._pv_cal_snapshot = {
+        "taken_at": now,
+        "forecast_kwh": {"pv1": 0.5},
+        "meter_kwh": {"pv1": 100.0},
+    }
+    hass.states.async_set("sensor.pv1_energy", "110.0", {"unit_of_measurement": "kWh"})
+    coord._update_pv_calibration(now + timedelta(minutes=15))
+
+    assert "pv1" not in coord._pv_cal_samples
+
+
+@pytest.mark.asyncio
+async def test_pv_snapshot_only_inside_the_sampling_band(hass):
+    """Night-time and near-rating steps are not recorded."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    hass.states.async_set("sensor.pv1_energy", "100.0", {"unit_of_measurement": "kWh"})
+
+    # 0.1 kW on a 4 kWp array = 2.5 %: below the floor.
+    coord._snapshot_pv_calibration(now, {"pv1": 0.1}, {"pv1": 4.0})
+    assert coord._pv_cal_snapshot == {}
+
+    # 3.8 kW = 95 %: clipping and thermal derating territory.
+    coord._snapshot_pv_calibration(now, {"pv1": 3.8}, {"pv1": 4.0})
+    assert coord._pv_cal_snapshot == {}
+
+    # 2.0 kW = 50 %: recorded.
+    coord._snapshot_pv_calibration(now, {"pv1": 2.0}, {"pv1": 4.0})
+    assert coord._pv_cal_snapshot["forecast_kwh"]["pv1"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_pv_correction_is_clamped(hass):
+    """However bad the ratio, the applied factor stays inside its bounds."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    meter = 100.0
+    for _ in range(25):
+        coord._pv_cal_snapshot = {
+            "taken_at": now,
+            "forecast_kwh": {"pv1": 1.0},
+            "meter_kwh": {"pv1": meter},
+        }
+        meter += 0.1  # only a tenth of the forecast, every time
+        hass.states.async_set(
+            "sensor.pv1_energy", f"{meter}", {"unit_of_measurement": "kWh"}
+        )
+        now += timedelta(minutes=15)
+        coord._update_pv_calibration(now)
+
+    assert coord._pv_cal_correction["pv1"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_reset(hass):
+    coord = _make_cal_coordinator(hass)
+    coord._pv_cal_correction["pv1"] = 0.8
+    coord._pv_cal_samples["pv1"] = deque([(1.0, 1.25)], maxlen=10)
+    coord._pv_cal_store.async_save = AsyncMock()
+
+    await coord.async_reset_pv_calibration()
+
+    assert coord._pv_cal_correction == {}
+    assert coord._pv_cal_samples == {}

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -8,8 +8,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.battery_controller.battery_model import BatteryState
+from custom_components.battery_controller.battery_model import (
+    BatteryConfig,
+    BatteryState,
+)
 from custom_components.battery_controller.const import (
+    CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
     CONF_BATTERY_SOC_SENSOR,
     CONF_CONTROL_MODE,
     CONF_FEED_IN_PRICE_SENSOR,
@@ -3059,8 +3064,13 @@ def test_calibration_rolling_average_converges(hass):
     assert coord._charge_eff_correction == pytest.approx(0.85, abs=1e-9)
 
 
-def test_calibration_floor_clips_extreme_low_ratio(hass):
-    """Ratio below 0.5 is clipped to the floor."""
+def test_calibration_drops_implausibly_low_ratio(hass):
+    """A ratio below the acceptance window is dropped, not folded into the mean.
+
+    Clipping it to the floor let one disturbed step drag the correction down;
+    a quarter of the planned energy is not an efficiency, it is a step where
+    something else happened.
+    """
     coord = _make_coordinator(hass)
     coord._last_result = _make_fake_result(
         mode_schedule=["charging"],
@@ -3068,17 +3078,18 @@ def test_calibration_floor_clips_extreme_low_ratio(hass):
     )
     _mark_plan_executed(coord)
 
-    # Actual delta = 0.5 kWh → uncipped ratio = 0.25, clipped to 0.5
+    # Actual delta = 0.5 kWh → ratio 0.25, below the 0.5 acceptance floor
     battery_state = BatteryState(
         soc_kwh=5.5, soc_percent=55.0, power_kw=1.0, mode="charging"
     )
     coord._update_charge_eff_calibration(battery_state)
 
-    assert coord._charge_eff_samples[0] == pytest.approx(0.5)
+    assert len(coord._charge_eff_samples) == 0
+    assert coord._charge_eff_correction == pytest.approx(1.0)
 
 
-def test_calibration_ceiling_clips_extra_charge(hass):
-    """Ratio above 1.05 (unexpected extra charge source) is clipped to 1.05."""
+def test_calibration_drops_implausibly_high_ratio(hass):
+    """A ratio above the acceptance window is dropped as well."""
     coord = _make_coordinator(hass)
     coord._last_result = _make_fake_result(
         mode_schedule=["charging"],
@@ -3086,13 +3097,36 @@ def test_calibration_ceiling_clips_extra_charge(hass):
     )
     _mark_plan_executed(coord)
 
-    # Actual delta = 1.5 kWh → unclipped ratio = 1.5, clipped to 1.05
+    # Actual delta = 2.0 kWh → ratio 2.0, above the 1.5 acceptance ceiling
     battery_state = BatteryState(
-        soc_kwh=6.5, soc_percent=65.0, power_kw=1.0, mode="charging"
+        soc_kwh=7.0, soc_percent=70.0, power_kw=1.0, mode="charging"
     )
     coord._update_charge_eff_calibration(battery_state)
 
-    assert coord._charge_eff_samples[0] == pytest.approx(1.05)
+    assert len(coord._charge_eff_samples) == 0
+
+
+def test_calibration_correction_is_clamped_for_use(hass):
+    """A believable over-delivery is sampled, but cannot raise the correction.
+
+    The window is symmetric enough around 1.0 that noise cancels in the mean;
+    the bound on what the optimizer is handed is applied to the mean instead.
+    """
+    coord = _make_coordinator(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
+    )
+    _mark_plan_executed(coord)
+
+    # Actual delta = 1.4 kWh → ratio 1.4, inside the window
+    battery_state = BatteryState(
+        soc_kwh=6.4, soc_percent=64.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state)
+
+    assert coord._charge_eff_samples[0] == pytest.approx(1.4)
+    assert coord._charge_eff_correction == pytest.approx(1.05)
 
 
 def test_calibration_not_applied_for_dc_coupled(hass):
@@ -4526,3 +4560,200 @@ async def test_pv_forecast_aligned_to_price_steps_on_mid_period_run(hass, monkey
     assert captured["durations"][:3] == pytest.approx([0.5, 1.0, 1.0])
     # Each step gets the production of its OWN window, not the next half hour.
     assert captured["pv"][:3] == pytest.approx([1.0, 5.0, 9.0])
+
+
+# ---------------------------------------------------------------------------
+# Efficiency calibration from the cumulative energy counters
+# ---------------------------------------------------------------------------
+
+
+def _coordinator_with_counters(hass, capacity_kwh=10.0, soc_state="50"):
+    """Coordinator whose battery subentry carries kWh throughput counters."""
+    coord = _make_coordinator(hass)
+    coord._battery_subentries = [
+        (
+            "bat1",
+            {
+                CONF_MAX_CHARGE_POWER_KW: 5.0,
+                CONF_MAX_DISCHARGE_POWER_KW: 5.0,
+                CONF_MIN_SOC_PERCENT: 10.0,
+                CONF_MAX_SOC_PERCENT: 90.0,
+                CONF_BATTERY_SOC_SENSOR: "sensor.test_soc",
+                CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.bat_charged",
+                CONF_BATTERY_ENERGY_DISCHARGED_SENSOR: "sensor.bat_discharged",
+            },
+        )
+    ]
+    coord._individual_battery_configs = [
+        ("bat1", BatteryConfig(capacity_kwh=capacity_kwh))
+    ]
+    hass.states.async_set("sensor.test_soc", soc_state, {"unit_of_measurement": "%"})
+    return coord
+
+
+def test_calibration_prefers_the_energy_counter_over_the_soc_delta(hass):
+    """The counter measures the same energy without the SoC sensor's step size."""
+    coord = _coordinator_with_counters(hass)
+    hass.states.async_set("sensor.bat_charged", "100.0", {"unit_of_measurement": "kWh"})
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    hass.states.async_set("sensor.bat_charged", "100.9", {"unit_of_measurement": "kWh"})
+    hass.states.async_set(
+        "sensor.bat_discharged", "50.0", {"unit_of_measurement": "kWh"}
+    )
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
+    )
+    _mark_plan_executed(coord)
+
+    # SoC sensor still reads 50 % (5.0 kWh) — a SoC-based sample would be 0.0.
+    battery_state = BatteryState(
+        soc_kwh=5.0, soc_percent=50.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    # 0.9 kWh counted against 1.0 kWh planned
+    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_uses_the_discharge_counter(hass):
+    coord = _coordinator_with_counters(hass)
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    hass.states.async_set("sensor.bat_charged", "100.0", {"unit_of_measurement": "kWh"})
+    hass.states.async_set(
+        "sensor.bat_discharged", "51.8", {"unit_of_measurement": "kWh"}
+    )
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["discharging"],
+        soc_schedule_kwh=[6.0, 4.0],  # planned drop = 2.0 kWh
+    )
+    _mark_plan_executed(coord)
+
+    battery_state = BatteryState(
+        soc_kwh=6.0, soc_percent=60.0, power_kw=-1.0, mode="discharging"
+    )
+    coord._update_discharge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert coord._discharge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_falls_back_to_soc_when_counters_absent(hass):
+    """No counters configured: the SoC delta still drives the calibration."""
+    coord = _make_coordinator(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],
+    )
+    _mark_plan_executed(coord)
+    battery_state = BatteryState(
+        soc_kwh=5.9, soc_percent=59.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_ignores_a_counter_reset(hass):
+    """A total_increasing counter that jumped backwards must not be used."""
+    coord = _coordinator_with_counters(hass)
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    # Meter replaced: the total restarted from zero.
+    hass.states.async_set("sensor.bat_charged", "0.4", {"unit_of_measurement": "kWh"})
+    hass.states.async_set(
+        "sensor.bat_discharged", "50.0", {"unit_of_measurement": "kWh"}
+    )
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],
+    )
+    _mark_plan_executed(coord)
+    # SoC says the step went fine, so the fallback path produces the sample.
+    battery_state = BatteryState(
+        soc_kwh=5.9, soc_percent=59.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_ignores_an_unavailable_counter(hass):
+    coord = _coordinator_with_counters(hass)
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    hass.states.async_set("sensor.bat_charged", "unavailable")
+    assert coord._read_energy_totals()["charged"] is None
+
+
+def test_soc_quantum_raises_the_sampling_threshold(hass):
+    """A whole-percent SoC sensor cannot resolve a 0.1 kWh step on a 10 kWh pack."""
+    coord = _make_coordinator(hass)
+    coord._individual_battery_configs = [("bat1", BatteryConfig(capacity_kwh=10.0))]
+    coord._battery_subentries = [("bat1", {CONF_BATTERY_SOC_SENSOR: "sensor.test_soc"})]
+
+    hass.states.async_set("sensor.test_soc", "50", {"unit_of_measurement": "%"})
+    assert coord._soc_quantum_kwh() == pytest.approx(0.1)
+    # 4 x the quantum, well above the old fixed 0.1 kWh floor
+    assert coord._min_planned_delta_kwh(from_counters=False) == pytest.approx(0.4)
+
+    # A sensor with one decimal resolves ten times finer.
+    hass.states.async_set("sensor.test_soc", "50.5", {"unit_of_measurement": "%"})
+    assert coord._soc_quantum_kwh() == pytest.approx(0.01)
+    assert coord._min_planned_delta_kwh(from_counters=False) == pytest.approx(0.1)
+
+    # The counters are not limited by the SoC sensor at all.
+    assert coord._min_planned_delta_kwh(from_counters=True) == pytest.approx(0.1)
+
+
+def test_small_step_is_skipped_on_a_coarse_soc_sensor(hass):
+    """Below the resolution-derived floor no sample is taken at all."""
+    coord = _make_coordinator(hass)
+    coord._individual_battery_configs = [("bat1", BatteryConfig(capacity_kwh=10.0))]
+    coord._battery_subentries = [("bat1", {CONF_BATTERY_SOC_SENSOR: "sensor.test_soc"})]
+    hass.states.async_set("sensor.test_soc", "50", {"unit_of_measurement": "%"})
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 5.2],  # planned delta = 0.2 kWh < 0.4 kWh floor
+    )
+    _mark_plan_executed(coord)
+    battery_state = BatteryState(
+        soc_kwh=5.1, soc_percent=51.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert len(coord._charge_eff_samples) == 0
+
+
+def test_symmetric_noise_does_not_bias_the_correction(hass):
+    """Quantisation noise around a perfect battery must average out to 1.0.
+
+    The old code capped the ratio at 1.05 while allowing it down to 0.5, so
+    symmetric noise folded downward and applied a correction to a healthy
+    battery.
+    """
+    coord = _coordinator_with_counters(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
+    )
+    _mark_plan_executed(coord)
+    battery_state = BatteryState(
+        soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging"
+    )
+
+    charged = 100.0
+    for actual in (0.8, 1.2, 0.9, 1.1, 1.3, 0.7):
+        coord._energy_counter_snapshot = {"charged": charged, "discharged": 0.0}
+        charged += actual
+        hass.states.async_set(
+            "sensor.bat_charged", f"{charged}", {"unit_of_measurement": "kWh"}
+        )
+        hass.states.async_set(
+            "sensor.bat_discharged", "0.0", {"unit_of_measurement": "kWh"}
+        )
+        coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert len(coord._charge_eff_samples) == 6
+    assert coord._charge_eff_correction == pytest.approx(1.0, abs=1e-6)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -161,6 +161,7 @@ async def test_async_unload_entry_with_runtime_data():
     assert removed == {
         (DOMAIN, "reset_charge_efficiency_calibration"),
         (DOMAIN, "reset_discharge_efficiency_calibration"),
+        (DOMAIN, "reset_pv_calibration"),
     }
 
 
@@ -239,7 +240,7 @@ async def test_async_setup_entry_no_subentries():
     assert entry.runtime_data.optimization_coordinator is mock_opt_coord
     assert entry.runtime_data.battery_devices == {}
     assert entry.runtime_data.pv_devices == {}
-    assert mock_hass.services.async_register.call_count == 2
+    assert mock_hass.services.async_register.call_count == 3
 
 
 @pytest.mark.asyncio
@@ -372,14 +373,15 @@ def test_register_services_only_once():
     _async_register_services(mock_hass)
     _async_register_services(mock_hass)
 
-    # Both services registered by the first call; the second call is a no-op.
-    assert mock_hass.services.async_register.call_count == 2
+    # All services registered by the first call; the second call is a no-op.
+    assert mock_hass.services.async_register.call_count == 3
     registered = {
         call.args[1] for call in mock_hass.services.async_register.call_args_list
     }
     assert registered == {
         "reset_charge_efficiency_calibration",
         "reset_discharge_efficiency_calibration",
+        "reset_pv_calibration",
     }
     for call in mock_hass.services.async_register.call_args_list:
         assert inspect.iscoroutinefunction(call.args[2])


### PR DESCRIPTION
## Description

Two calibration changes, on top of the optimizer review that landed in #160.

### 1. Battery efficiency calibration: measure it from the energy counters

The charge and discharge corrections read the aggregated SoC delta and compared it against the planned one. Two problems.

A SoC sensor reporting whole percent quantises at `capacity / 100` — 0.1 kWh on a 10 kWh pack, which is exactly the fixed floor the sampler used. A sample at the floor therefore carried up to ±50 % quantisation error on its numerator.

Worse, the ratio was capped at 1.05 but allowed down to 0.5, and out-of-range values were clipped *into* the mean rather than dropped. Symmetric measurement noise around a perfectly healthy battery folds downward under that rule, so the correction drifts below 0.995 and starts being applied — the DP then plans less charge than the battery can actually take, for no physical reason.

#153 put the cumulative kWh counters on each battery subentry, so the energy the battery actually moved over a step is now directly measurable. The calibration takes its observation from those counters when configured, snapshotting the totals alongside the plan they belong to, and falls back to the SoC delta otherwise. Counter resets and unavailable counters fall back rather than producing a bogus delta.

On the SoC path the minimum planned change worth sampling now scales with the resolution the sensor actually reports (read from its decimals) instead of a fixed 0.1 kWh. Samples outside `[0.5, 1.5]` are dropped instead of clipped in, so noise cancels in the mean; only the mean is clamped, to `[0.5, 1.05]`, before use.

### 2. Measured production per PV array, and per-array forecast calibration — closes #154

`pv_production_sensors` is a flat list in the main options. It exists for the gross-load reconstruction, which only ever needs the sum, so the integration never knows which array a measurement belongs to and cannot tell a systematically wrong array from a correct one.

Each PV array subentry now takes an optional measured production counter, using the convention #153 established for the battery counters: where one inverter reports a single counter covering several arrays, set it on one of them and the collector deduplicates.

**On the migration.** The issue weighed a deprecated aggregate fallback against an auto-migration with a repair issue for ambiguous cases. Neither turned out to be needed. The two consumers want different things — the reconstruction wants the sum, calibration wants the attribution — so the reconstruction now reads the **union** of the legacy list and the per-array sensors, deduplicated. Existing configurations keep working untouched, nothing has to be configured twice, and there is no migration to get wrong.

**The calibration** scores each array's forecast against what it produced and applies a learned gain factor:

- Energy-weighted over the sample window (`sum(measured) / sum(forecast)`) rather than a mean of per-step ratios — a quarter hour under cloud has a large relative error on very little energy, and weighting by energy stops those steps dominating an estimate meant to describe a gain error.
- Sampled only in the middle of the array's rating (10–80 % of kWp): below the floor the signal is smaller than the noise, above the ceiling inverter clipping and thermal derating dominate and are not forecast errors.
- Skipped while PV curtailment is active (the flag is now propagated to the forecast coordinator), when the elapsed window is not the window the forecast described, and when the counter jumps backwards.
- Clamped, and withheld until enough samples exist.
- The snapshot records the **uncorrected** forecast, so the factor stays a direct `measured / raw` estimate instead of compounding on itself run after run.

**What it can and cannot fix**, stated in the docs rather than left implied: a wrong tilt or orientation entry, soiling and a string that is down are gain errors and are captured. Shading is not — it is a function of sun position, so a single scalar smears a morning-only obstruction across the whole day. The issue lists shading as a target; that is the one thing a scalar handles worst, and modelling it properly needs a horizon profile.

Adds `reset_pv_calibration` alongside the existing calibration reset services.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [x] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

Locally: 895 Python tests, mypy and pre-commit all green; coverage 95.1 %.

## Screenshots / Logs (optional)

<details>
<summary>Why the old battery sampling was biased</summary>

```
old rule:  actual = clamp(actual, 0, 1.2 * planned)
           ratio  = clamp(actual / planned, 0.5, 1.05)

A healthy battery measured with +/-0.05 kWh quantisation on a 0.1 kWh
planned delta produces ratios spread roughly [0.5, 1.5]. Everything
above 1.05 folds back to 1.05; everything down to 0.5 is kept. The mean
of that lands below 1.0, the correction is applied, and the DP plans
less charge than the battery can take.
```
</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_015pPgrJRHeZMe2iA7mkw5Qe)_