### PR TITLE
fix: measure battery efficiency calibration from the energy counters, unbiased

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -26,6 +26,8 @@ from .const import (
     ACTION_DISCHARGING,
     ACTION_IDLE,
     DC_TO_AC_INVERTER_EFFICIENCY,
+    CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
     CONF_BATTERY_SOC_SENSOR,
     CONF_BATTERY_POWER_SENSOR,
     CONF_CONTROL_MODE,
@@ -93,6 +95,30 @@ _SOC_HYSTERESIS = 0.05
 # this fraction of the planned charge power. Below it, the DP evidently wants
 # grid charging beyond the surplus and the schedule is followed instead.
 _SURPLUS_COVERS_PLAN_FRACTION = 0.8
+
+# Efficiency calibration tuning.
+#
+# A sample is only worth taking when the planned SoC change is comfortably
+# larger than the resolution of whatever measured it. The energy counters are
+# fine-grained, so the floor there is just "big enough to be a real action". A
+# SoC sensor reporting whole percent, by contrast, quantises at capacity/100 —
+# 0.1 kWh on a 10 kWh pack, which is exactly the old fixed floor, so a single
+# sample carried up to +/-50 % quantisation error. On that path the floor
+# scales with the observed quantum instead.
+_CALIBRATION_MIN_DELTA_KWH = 0.1
+_CALIBRATION_SOC_QUANTUM_FACTOR = 4.0
+
+# Samples outside this window are dropped rather than clipped into it. The
+# window is wide enough to contain genuine derating and far enough above 1.0
+# that ordinary measurement noise is not truncated on one side — the previous
+# code capped the ratio at 1.05 while allowing it down to 0.5, so symmetric
+# noise biased the mean downward and could apply a correction below 1.0 to a
+# perfectly healthy battery. The applied correction is still clamped (below).
+_CALIBRATION_ACCEPT_MIN = 0.5
+_CALIBRATION_ACCEPT_MAX = 1.5
+# Bounds on the correction actually handed to the optimizer.
+_CALIBRATION_APPLY_MIN = 0.5
+_CALIBRATION_APPLY_MAX = 1.05
 
 
 class OptimizationCoordinator(DataUpdateCoordinator):
@@ -292,6 +318,16 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # to avoid confounding with passive PV.
         self._charge_eff_samples: deque[float] = deque(maxlen=20)
         self._charge_eff_correction: float = 1.0
+
+        # Cumulative throughput counters as they stood when _last_result was
+        # planned. The difference against the next read is the energy the
+        # battery actually moved over that step — a far finer measurement than
+        # the SoC delta, which on a whole-percent sensor quantises at
+        # capacity/100 (0.1 kWh on a 10 kWh pack).
+        self._energy_counter_snapshot: dict[str, float | None] = {
+            "charged": None,
+            "discharged": None,
+        }
 
         # Persistent storage for charge efficiency calibration (survives reboots).
         entry_id = config.get("entry_id", "unknown")
@@ -1570,6 +1606,175 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._charge_eff_correction = 1.0
         await self._async_save_charge_eff_calibration()
 
+    def _battery_energy_sensor_ids(self, conf_key: str) -> list[str]:
+        """Collect one energy counter per battery subentry that has it configured.
+
+        Deduplicated: where one inverter reports a single counter covering
+        several packs it may legitimately be selected on more than one
+        subentry, and counting it twice would double the measured throughput.
+        Same convention as the forecast coordinator's collector.
+        """
+        seen: list[str] = []
+        for _sid, data in self._battery_subentries:
+            entity_id = data.get(conf_key)
+            if entity_id and entity_id not in seen:
+                seen.append(entity_id)
+        return seen
+
+    def _read_energy_total_kwh(self, conf_key: str) -> float | None:
+        """Sum the configured cumulative energy counters, in kWh.
+
+        Returns None when no counter is configured or any of them is
+        unavailable: a partial sum would look like a jump backwards on the next
+        read and poison the delta.
+        """
+        sensor_ids = self._battery_energy_sensor_ids(conf_key)
+        if not sensor_ids:
+            return None
+        total = 0.0
+        for sensor_id in sensor_ids:
+            state = self.hass.states.get(sensor_id)
+            if state is None or state.state in ("unknown", "unavailable"):
+                return None
+            try:
+                value = float(state.state)
+            except (ValueError, TypeError):
+                return None
+            unit = str(state.attributes.get("unit_of_measurement") or "kWh")
+            if unit == "Wh":
+                value /= 1000.0
+            elif unit == "MWh":
+                value *= 1000.0
+            elif unit != "kWh":
+                self._warn_unit_once(sensor_id, unit, "treating value as kWh")
+            total += value
+        return total
+
+    def _read_energy_totals(self) -> dict[str, float | None]:
+        """Read both cumulative throughput counters at one instant."""
+        return {
+            "charged": self._read_energy_total_kwh(CONF_BATTERY_ENERGY_CHARGED_SENSOR),
+            "discharged": self._read_energy_total_kwh(
+                CONF_BATTERY_ENERGY_DISCHARGED_SENSOR
+            ),
+        }
+
+    def _counter_delta_kwh(
+        self, key: str, totals_now: dict[str, float | None]
+    ) -> float | None:
+        """Throughput measured by the counters since the plan was made.
+
+        None when either end of the interval is missing, or when the counter
+        went backwards — a total_increasing sensor that was reset or replaced,
+        where the difference is meaningless rather than negative.
+        """
+        before = self._energy_counter_snapshot.get(key)
+        after = totals_now.get(key)
+        if before is None or after is None:
+            return None
+        delta = after - before
+        if delta < 0:
+            _LOGGER.debug(
+                "Efficiency calibration: %s counter went backwards "
+                "(%.3f -> %.3f kWh); treating as a meter reset",
+                key,
+                before,
+                after,
+            )
+            return None
+        return delta
+
+    def _soc_quantum_kwh(self) -> float:
+        """Estimate the resolution of the aggregated SoC measurement, in kWh.
+
+        Derived from the decimals each SoC sensor actually reports: a state of
+        "47" is whole-percent, "47.3" is ten times finer. Summed across packs
+        because the aggregate SoC is a sum and the individual quantisation
+        errors can align. Returns 0.0 when nothing can be determined, which
+        leaves the caller on its fixed floor.
+        """
+        total = 0.0
+        for (_sid, cfg), (_sid2, data) in zip(
+            self._individual_battery_configs, self._battery_subentries
+        ):
+            sensor_id = data.get(CONF_BATTERY_SOC_SENSOR)
+            if not sensor_id:
+                continue
+            state = self.hass.states.get(sensor_id)
+            if state is None or state.state in ("unknown", "unavailable"):
+                continue
+            raw = state.state.strip()
+            decimals = len(raw.split(".", 1)[1]) if "." in raw else 0
+            step = 10.0**-decimals
+            unit = str(state.attributes.get("unit_of_measurement") or "%")
+            if unit == "kWh":
+                total += step
+            elif unit == "Wh":
+                total += step / 1000.0
+            else:  # percent (or unitless, which is treated as percent elsewhere)
+                total += step / 100.0 * cfg.capacity_kwh
+        return total
+
+    def _min_planned_delta_kwh(self, from_counters: bool) -> float:
+        """Smallest planned SoC change worth sampling, given how it is measured."""
+        if from_counters:
+            return _CALIBRATION_MIN_DELTA_KWH
+        quantum = self._soc_quantum_kwh()
+        return max(
+            _CALIBRATION_MIN_DELTA_KWH,
+            _CALIBRATION_SOC_QUANTUM_FACTOR * quantum,
+        )
+
+    def _record_calibration_sample(
+        self,
+        *,
+        direction: str,
+        samples: deque[float],
+        current_correction: float,
+        planned_delta: float,
+        actual_delta: float,
+        source: str,
+    ) -> float:
+        """Fold one actual/planned observation into a correction factor.
+
+        Samples outside the acceptance window are dropped rather than clipped
+        into it. Clipping was not symmetric around 1.0 — the ratio was capped
+        at 1.05 but allowed down to 0.5 — so ordinary measurement noise pulled
+        the mean below 1.0 and a healthy battery could end up with a correction
+        applied to it. Only the resulting mean is clamped, and only for use.
+        """
+        ratio = actual_delta / planned_delta
+        if not (_CALIBRATION_ACCEPT_MIN <= ratio <= _CALIBRATION_ACCEPT_MAX):
+            _LOGGER.debug(
+                "%s efficiency calibration: dropping implausible sample "
+                "(ratio=%.3f from %s, planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
+                direction.capitalize(),
+                ratio,
+                source,
+                planned_delta,
+                actual_delta,
+            )
+            return current_correction
+
+        samples.append(ratio)
+        mean = sum(samples) / len(samples)
+        new_correction = max(_CALIBRATION_APPLY_MIN, min(_CALIBRATION_APPLY_MAX, mean))
+        if abs(new_correction - current_correction) > 0.005:
+            _LOGGER.info(
+                "%s efficiency correction updated: %.3f → %.3f "
+                "(latest ratio=%.3f from %s, n=%d samples, "
+                "planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
+                direction.capitalize(),
+                current_correction,
+                new_correction,
+                ratio,
+                source,
+                len(samples),
+                planned_delta,
+                actual_delta,
+            )
+        return new_correction
+
     def _previous_charge_step_complete(self) -> bool:
         """Return whether the previously planned first step has elapsed.
 
@@ -1629,7 +1834,11 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         tolerance_kw = max(0.05, 0.1 * abs(planned_kw))
         return abs(executed_kw - planned_kw) <= tolerance_kw
 
-    def _update_charge_eff_calibration(self, battery_state: BatteryState) -> None:
+    def _update_charge_eff_calibration(
+        self,
+        battery_state: BatteryState,
+        energy_totals_now: dict[str, float | None] | None = None,
+    ) -> None:
         """Compare previous planned SoC to actual SoC and update charge efficiency correction.
 
         Samples are only collected when:
@@ -1679,8 +1888,19 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         planned_next_soc = self._last_result.soc_schedule_kwh[1]
         planned_delta = planned_next_soc - prev_soc
 
-        if planned_delta < 0.1:
-            # Too small to measure reliably; skip.
+        # Prefer the cumulative charged-energy counter over the SoC delta. Both
+        # measure the same quantity — energy into the battery, which is what
+        # the planned SoC change represents — but the counter is not limited by
+        # the SoC sensor's step size.
+        counter_delta = (
+            self._counter_delta_kwh("charged", energy_totals_now)
+            if energy_totals_now is not None
+            else None
+        )
+        from_counters = counter_delta is not None
+
+        if planned_delta < self._min_planned_delta_kwh(from_counters):
+            # Too small to measure reliably at this resolution; skip.
             return
 
         # Skip if the step crosses the high-SoC charge derating threshold.
@@ -1700,32 +1920,23 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 )
                 return
 
-        actual_delta = battery_state.soc_kwh - prev_soc
-        # Cap upward to 1.2× planned to filter out unexpected external charge
-        # sources (e.g. brief grid export reversed, SoC sensor noise).
-        actual_delta = max(0.0, min(actual_delta, 1.2 * planned_delta))
-        ratio = actual_delta / planned_delta
-        # Clip to a physically reasonable range; the correction should never
-        # indicate the battery charged *more* than modelled by more than 5%.
-        ratio = max(0.5, min(1.05, ratio))
+        if counter_delta is not None:
+            actual_delta = counter_delta
+            source = "energy counter"
+        else:
+            actual_delta = max(0.0, battery_state.soc_kwh - prev_soc)
+            source = "SoC delta"
 
-        self._charge_eff_samples.append(ratio)
-        new_correction = sum(self._charge_eff_samples) / len(self._charge_eff_samples)
-
-        changed = abs(new_correction - self._charge_eff_correction) > 0.005
-        if changed:
-            _LOGGER.info(
-                "Charge efficiency correction updated: %.3f → %.3f "
-                "(latest ratio=%.3f, n=%d samples, planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
-                self._charge_eff_correction,
-                new_correction,
-                ratio,
-                len(self._charge_eff_samples),
-                planned_delta,
-                actual_delta,
-            )
-        self._charge_eff_correction = new_correction
-        if changed:
+        previous = self._charge_eff_correction
+        self._charge_eff_correction = self._record_calibration_sample(
+            direction="charge",
+            samples=self._charge_eff_samples,
+            current_correction=previous,
+            planned_delta=planned_delta,
+            actual_delta=actual_delta,
+            source=source,
+        )
+        if abs(self._charge_eff_correction - previous) > 0.005:
             self.hass.async_create_task(self._async_save_charge_eff_calibration())
 
     async def _async_load_discharge_eff_calibration(self) -> None:
@@ -1768,7 +1979,11 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._discharge_eff_correction = 1.0
         await self._async_save_discharge_eff_calibration()
 
-    def _update_discharge_eff_calibration(self, battery_state: BatteryState) -> None:
+    def _update_discharge_eff_calibration(
+        self,
+        battery_state: BatteryState,
+        energy_totals_now: dict[str, float | None] | None = None,
+    ) -> None:
         """Compare previous planned SoC to actual SoC and update discharge efficiency correction.
 
         Samples are only collected when:
@@ -1816,8 +2031,17 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         planned_next_soc = self._last_result.soc_schedule_kwh[1]
         planned_delta = prev_soc - planned_next_soc  # positive: SoC goes down
 
-        if planned_delta < 0.1:
-            # Too small to measure reliably; skip.
+        # Prefer the cumulative discharged-energy counter over the SoC delta
+        # (same reasoning as the charge side).
+        counter_delta = (
+            self._counter_delta_kwh("discharged", energy_totals_now)
+            if energy_totals_now is not None
+            else None
+        )
+        from_counters = counter_delta is not None
+
+        if planned_delta < self._min_planned_delta_kwh(from_counters):
+            # Too small to measure reliably at this resolution; skip.
             return
 
         # Skip if the step crosses the low-SoC discharge derating threshold.
@@ -1838,34 +2062,24 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 )
                 return
 
-        actual_delta = prev_soc - battery_state.soc_kwh  # positive: SoC went down
-        # Cap upward to 1.2× planned to filter out unexpected external discharge
-        # (e.g. grid outage, SoC sensor noise causing apparent over-discharge).
-        actual_delta = max(0.0, min(actual_delta, 1.2 * planned_delta))
-        ratio = actual_delta / planned_delta
-        # Clip to a physically reasonable range; the correction should never
-        # indicate the battery discharged *more* than modelled by more than 5%.
-        ratio = max(0.5, min(1.05, ratio))
+        if counter_delta is not None:
+            actual_delta = counter_delta
+            source = "energy counter"
+        else:
+            # positive: SoC went down
+            actual_delta = max(0.0, prev_soc - battery_state.soc_kwh)
+            source = "SoC delta"
 
-        self._discharge_eff_samples.append(ratio)
-        new_correction = sum(self._discharge_eff_samples) / len(
-            self._discharge_eff_samples
+        previous = self._discharge_eff_correction
+        self._discharge_eff_correction = self._record_calibration_sample(
+            direction="discharge",
+            samples=self._discharge_eff_samples,
+            current_correction=previous,
+            planned_delta=planned_delta,
+            actual_delta=actual_delta,
+            source=source,
         )
-
-        changed = abs(new_correction - self._discharge_eff_correction) > 0.005
-        if changed:
-            _LOGGER.info(
-                "Discharge efficiency correction updated: %.3f → %.3f "
-                "(latest ratio=%.3f, n=%d samples, planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
-                self._discharge_eff_correction,
-                new_correction,
-                ratio,
-                len(self._discharge_eff_samples),
-                planned_delta,
-                actual_delta,
-            )
-        self._discharge_eff_correction = new_correction
-        if changed:
+        if abs(self._discharge_eff_correction - previous) > 0.005:
             self.hass.async_create_task(self._async_save_discharge_eff_calibration())
 
     async def _run_optimization(self) -> dict[str, Any]:
@@ -2278,11 +2492,16 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # Get current battery state
         battery_state = self.get_current_battery_state()
 
-        # Charge efficiency calibration: compare previous planned SoC with actual SoC
-        # to detect systematic over-estimation of charge efficiency (e.g. CV-phase).
-        self._update_charge_eff_calibration(battery_state)
+        # Cumulative throughput counters, read once: they close the previous
+        # planned step and open the new one at the same instant.
+        energy_totals_now = self._read_energy_totals()
+
+        # Charge efficiency calibration: compare the previous plan against what
+        # the battery actually moved, to detect systematic over-estimation of
+        # charge efficiency (e.g. CV-phase).
+        self._update_charge_eff_calibration(battery_state, energy_totals_now)
         # Discharge efficiency calibration: same principle for discharging steps.
-        self._update_discharge_eff_calibration(battery_state)
+        self._update_discharge_eff_calibration(battery_state, energy_totals_now)
 
         battery_config = self.battery_config
 
@@ -2361,6 +2580,9 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         )
 
         self._last_result = result
+        # Snapshot the counters alongside the plan they belong to, so the next
+        # run can measure the throughput of exactly this step.
+        self._energy_counter_snapshot = energy_totals_now
 
         # Get current grid power: prefer real sensor, fall back to estimate
         realtime_grid_w = self._get_realtime_grid_w()

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -491,6 +491,8 @@ Let `chg_r = chg_eff_repr` and `dis_r = dis_eff_repr` (representative scalars, �
 
 Charge-speed correction: when runtime calibration detects that the battery gains less SoC per time step than modelled, the optimizer reduces the charge-side efficiency curve for the planned SoC transitions. Economic quantities (step costs, the oscillation-filter threshold) keep using the nominal curves.
 
+The observation is taken from the per-battery cumulative kWh counters when they are configured, and from the SoC delta otherwise. Both measure the same energy, but a SoC sensor reporting whole percent quantises at `capacity / 100` — 0.1 kWh on a 10 kWh pack — so on that path the minimum planned change worth sampling scales with the observed sensor resolution rather than a fixed 0.1 kWh. Samples outside `[0.5, 1.5]` are dropped rather than folded into the mean: an asymmetric clip (capped at 1.05, allowed down to 0.5) let symmetric measurement noise bias the correction below 1.0 for a healthy battery. Only the resulting mean is clamped, to `[0.5, 1.05]`, before it is applied.
+
 The shadow price is always the raw DP value — there is no separate "post-processed" shadow price. Post-processing filters affect `total_cost` and `savings` (where the difference between raw and processed values shows the impact of filtered actions), but the shadow price is a DP concept that is not modified by post-processing.
 
 **Use by hybrid mode**: λ is used by the coordinator as the charge/discharge switching threshold in hybrid mode. It is deliberately not fed back into the next run's terminal condition (see [Section 5](#5-terminal-condition)).

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -8,8 +8,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.battery_controller.battery_model import BatteryState
+from custom_components.battery_controller.battery_model import (
+    BatteryConfig,
+    BatteryState,
+)
 from custom_components.battery_controller.const import (
+    CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
     CONF_BATTERY_SOC_SENSOR,
     CONF_CONTROL_MODE,
     CONF_FEED_IN_PRICE_SENSOR,
@@ -3059,8 +3064,13 @@ def test_calibration_rolling_average_converges(hass):
     assert coord._charge_eff_correction == pytest.approx(0.85, abs=1e-9)
 
 
-def test_calibration_floor_clips_extreme_low_ratio(hass):
-    """Ratio below 0.5 is clipped to the floor."""
+def test_calibration_drops_implausibly_low_ratio(hass):
+    """A ratio below the acceptance window is dropped, not folded into the mean.
+
+    Clipping it to the floor let one disturbed step drag the correction down;
+    a quarter of the planned energy is not an efficiency, it is a step where
+    something else happened.
+    """
     coord = _make_coordinator(hass)
     coord._last_result = _make_fake_result(
         mode_schedule=["charging"],
@@ -3068,17 +3078,18 @@ def test_calibration_floor_clips_extreme_low_ratio(hass):
     )
     _mark_plan_executed(coord)
 
-    # Actual delta = 0.5 kWh → uncipped ratio = 0.25, clipped to 0.5
+    # Actual delta = 0.5 kWh → ratio 0.25, below the 0.5 acceptance floor
     battery_state = BatteryState(
         soc_kwh=5.5, soc_percent=55.0, power_kw=1.0, mode="charging"
     )
     coord._update_charge_eff_calibration(battery_state)
 
-    assert coord._charge_eff_samples[0] == pytest.approx(0.5)
+    assert len(coord._charge_eff_samples) == 0
+    assert coord._charge_eff_correction == pytest.approx(1.0)
 
 
-def test_calibration_ceiling_clips_extra_charge(hass):
-    """Ratio above 1.05 (unexpected extra charge source) is clipped to 1.05."""
+def test_calibration_drops_implausibly_high_ratio(hass):
+    """A ratio above the acceptance window is dropped as well."""
     coord = _make_coordinator(hass)
     coord._last_result = _make_fake_result(
         mode_schedule=["charging"],
@@ -3086,13 +3097,36 @@ def test_calibration_ceiling_clips_extra_charge(hass):
     )
     _mark_plan_executed(coord)
 
-    # Actual delta = 1.5 kWh → unclipped ratio = 1.5, clipped to 1.05
+    # Actual delta = 2.0 kWh → ratio 2.0, above the 1.5 acceptance ceiling
     battery_state = BatteryState(
-        soc_kwh=6.5, soc_percent=65.0, power_kw=1.0, mode="charging"
+        soc_kwh=7.0, soc_percent=70.0, power_kw=1.0, mode="charging"
     )
     coord._update_charge_eff_calibration(battery_state)
 
-    assert coord._charge_eff_samples[0] == pytest.approx(1.05)
+    assert len(coord._charge_eff_samples) == 0
+
+
+def test_calibration_correction_is_clamped_for_use(hass):
+    """A believable over-delivery is sampled, but cannot raise the correction.
+
+    The window is symmetric enough around 1.0 that noise cancels in the mean;
+    the bound on what the optimizer is handed is applied to the mean instead.
+    """
+    coord = _make_coordinator(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
+    )
+    _mark_plan_executed(coord)
+
+    # Actual delta = 1.4 kWh → ratio 1.4, inside the window
+    battery_state = BatteryState(
+        soc_kwh=6.4, soc_percent=64.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state)
+
+    assert coord._charge_eff_samples[0] == pytest.approx(1.4)
+    assert coord._charge_eff_correction == pytest.approx(1.05)
 
 
 def test_calibration_not_applied_for_dc_coupled(hass):
@@ -4526,3 +4560,200 @@ async def test_pv_forecast_aligned_to_price_steps_on_mid_period_run(hass, monkey
     assert captured["durations"][:3] == pytest.approx([0.5, 1.0, 1.0])
     # Each step gets the production of its OWN window, not the next half hour.
     assert captured["pv"][:3] == pytest.approx([1.0, 5.0, 9.0])
+
+
+# ---------------------------------------------------------------------------
+# Efficiency calibration from the cumulative energy counters
+# ---------------------------------------------------------------------------
+
+
+def _coordinator_with_counters(hass, capacity_kwh=10.0, soc_state="50"):
+    """Coordinator whose battery subentry carries kWh throughput counters."""
+    coord = _make_coordinator(hass)
+    coord._battery_subentries = [
+        (
+            "bat1",
+            {
+                CONF_MAX_CHARGE_POWER_KW: 5.0,
+                CONF_MAX_DISCHARGE_POWER_KW: 5.0,
+                CONF_MIN_SOC_PERCENT: 10.0,
+                CONF_MAX_SOC_PERCENT: 90.0,
+                CONF_BATTERY_SOC_SENSOR: "sensor.test_soc",
+                CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.bat_charged",
+                CONF_BATTERY_ENERGY_DISCHARGED_SENSOR: "sensor.bat_discharged",
+            },
+        )
+    ]
+    coord._individual_battery_configs = [
+        ("bat1", BatteryConfig(capacity_kwh=capacity_kwh))
+    ]
+    hass.states.async_set("sensor.test_soc", soc_state, {"unit_of_measurement": "%"})
+    return coord
+
+
+def test_calibration_prefers_the_energy_counter_over_the_soc_delta(hass):
+    """The counter measures the same energy without the SoC sensor's step size."""
+    coord = _coordinator_with_counters(hass)
+    hass.states.async_set("sensor.bat_charged", "100.0", {"unit_of_measurement": "kWh"})
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    hass.states.async_set("sensor.bat_charged", "100.9", {"unit_of_measurement": "kWh"})
+    hass.states.async_set(
+        "sensor.bat_discharged", "50.0", {"unit_of_measurement": "kWh"}
+    )
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
+    )
+    _mark_plan_executed(coord)
+
+    # SoC sensor still reads 50 % (5.0 kWh) — a SoC-based sample would be 0.0.
+    battery_state = BatteryState(
+        soc_kwh=5.0, soc_percent=50.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    # 0.9 kWh counted against 1.0 kWh planned
+    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_uses_the_discharge_counter(hass):
+    coord = _coordinator_with_counters(hass)
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    hass.states.async_set("sensor.bat_charged", "100.0", {"unit_of_measurement": "kWh"})
+    hass.states.async_set(
+        "sensor.bat_discharged", "51.8", {"unit_of_measurement": "kWh"}
+    )
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["discharging"],
+        soc_schedule_kwh=[6.0, 4.0],  # planned drop = 2.0 kWh
+    )
+    _mark_plan_executed(coord)
+
+    battery_state = BatteryState(
+        soc_kwh=6.0, soc_percent=60.0, power_kw=-1.0, mode="discharging"
+    )
+    coord._update_discharge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert coord._discharge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_falls_back_to_soc_when_counters_absent(hass):
+    """No counters configured: the SoC delta still drives the calibration."""
+    coord = _make_coordinator(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],
+    )
+    _mark_plan_executed(coord)
+    battery_state = BatteryState(
+        soc_kwh=5.9, soc_percent=59.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_ignores_a_counter_reset(hass):
+    """A total_increasing counter that jumped backwards must not be used."""
+    coord = _coordinator_with_counters(hass)
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    # Meter replaced: the total restarted from zero.
+    hass.states.async_set("sensor.bat_charged", "0.4", {"unit_of_measurement": "kWh"})
+    hass.states.async_set(
+        "sensor.bat_discharged", "50.0", {"unit_of_measurement": "kWh"}
+    )
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],
+    )
+    _mark_plan_executed(coord)
+    # SoC says the step went fine, so the fallback path produces the sample.
+    battery_state = BatteryState(
+        soc_kwh=5.9, soc_percent=59.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+
+
+def test_calibration_ignores_an_unavailable_counter(hass):
+    coord = _coordinator_with_counters(hass)
+    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    hass.states.async_set("sensor.bat_charged", "unavailable")
+    assert coord._read_energy_totals()["charged"] is None
+
+
+def test_soc_quantum_raises_the_sampling_threshold(hass):
+    """A whole-percent SoC sensor cannot resolve a 0.1 kWh step on a 10 kWh pack."""
+    coord = _make_coordinator(hass)
+    coord._individual_battery_configs = [("bat1", BatteryConfig(capacity_kwh=10.0))]
+    coord._battery_subentries = [("bat1", {CONF_BATTERY_SOC_SENSOR: "sensor.test_soc"})]
+
+    hass.states.async_set("sensor.test_soc", "50", {"unit_of_measurement": "%"})
+    assert coord._soc_quantum_kwh() == pytest.approx(0.1)
+    # 4 x the quantum, well above the old fixed 0.1 kWh floor
+    assert coord._min_planned_delta_kwh(from_counters=False) == pytest.approx(0.4)
+
+    # A sensor with one decimal resolves ten times finer.
+    hass.states.async_set("sensor.test_soc", "50.5", {"unit_of_measurement": "%"})
+    assert coord._soc_quantum_kwh() == pytest.approx(0.01)
+    assert coord._min_planned_delta_kwh(from_counters=False) == pytest.approx(0.1)
+
+    # The counters are not limited by the SoC sensor at all.
+    assert coord._min_planned_delta_kwh(from_counters=True) == pytest.approx(0.1)
+
+
+def test_small_step_is_skipped_on_a_coarse_soc_sensor(hass):
+    """Below the resolution-derived floor no sample is taken at all."""
+    coord = _make_coordinator(hass)
+    coord._individual_battery_configs = [("bat1", BatteryConfig(capacity_kwh=10.0))]
+    coord._battery_subentries = [("bat1", {CONF_BATTERY_SOC_SENSOR: "sensor.test_soc"})]
+    hass.states.async_set("sensor.test_soc", "50", {"unit_of_measurement": "%"})
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 5.2],  # planned delta = 0.2 kWh < 0.4 kWh floor
+    )
+    _mark_plan_executed(coord)
+    battery_state = BatteryState(
+        soc_kwh=5.1, soc_percent=51.0, power_kw=1.0, mode="charging"
+    )
+    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert len(coord._charge_eff_samples) == 0
+
+
+def test_symmetric_noise_does_not_bias_the_correction(hass):
+    """Quantisation noise around a perfect battery must average out to 1.0.
+
+    The old code capped the ratio at 1.05 while allowing it down to 0.5, so
+    symmetric noise folded downward and applied a correction to a healthy
+    battery.
+    """
+    coord = _coordinator_with_counters(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"],
+        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
+    )
+    _mark_plan_executed(coord)
+    battery_state = BatteryState(
+        soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging"
+    )
+
+    charged = 100.0
+    for actual in (0.8, 1.2, 0.9, 1.1, 1.3, 0.7):
+        coord._energy_counter_snapshot = {"charged": charged, "discharged": 0.0}
+        charged += actual
+        hass.states.async_set(
+            "sensor.bat_charged", f"{charged}", {"unit_of_measurement": "kWh"}
+        )
+        hass.states.async_set(
+            "sensor.bat_discharged", "0.0", {"unit_of_measurement": "kWh"}
+        )
+        coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+
+    assert len(coord._charge_eff_samples) == 6
+    assert coord._charge_eff_correction == pytest.approx(1.0, abs=1e-6)


### PR DESCRIPTION
## Description

The charge and discharge efficiency corrections read the aggregated SoC delta and compared it against the planned one. Two problems with that.

**Resolution.** A SoC sensor reporting whole percent quantises at `capacity / 100` — 0.1 kWh on a 10 kWh pack, which is exactly the fixed floor the sampler used. A sample taken at the floor therefore carried up to ±50 % quantisation error on its numerator.

**Bias.** The ratio was capped at 1.05 but allowed down to 0.5, and out-of-range values were clipped *into* the mean rather than dropped:

```
old rule:  actual = clamp(actual, 0, 1.2 * planned)
           ratio  = clamp(actual / planned, 0.5, 1.05)
```

A healthy battery measured with ±0.05 kWh quantisation on a 0.1 kWh planned delta produces ratios spread roughly over [0.5, 1.5]. Everything above 1.05 folds back to 1.05; everything down to 0.5 is kept. The mean of that lands below 1.0, so the correction is applied and the DP plans less charge than the battery can actually take — for no physical reason.

## What changed

#153 put the cumulative kWh counters on each battery subentry, so the energy the battery actually moved over a step is now directly measurable.

- The calibration takes its observation from those counters when configured, snapshotting the totals alongside the plan they belong to. It falls back to the SoC delta otherwise, and also when a counter is unavailable or has jumped backwards (a `total_increasing` sensor that was reset or replaced) rather than producing a bogus delta.
- On the SoC path the minimum planned change worth sampling now scales with the resolution the sensor actually reports — read from the decimals in its state — instead of a fixed 0.1 kWh.
- Samples outside `[0.5, 1.5]` are dropped instead of clipped in, so measurement noise cancels in the mean. Only the resulting mean is clamped, to `[0.5, 1.05]`, before it is handed to the optimizer.

The window is wide enough to still contain genuine derating, and far enough above 1.0 that ordinary noise is not truncated on one side.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [x] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

Independent of #163; the two touch different code paths and either can merge first.
