### PR TITLE
feat: expose the learned battery and PV calibration

### DIFF
--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from bisect import bisect_left, bisect_right
 from datetime import datetime, timedelta
+from collections.abc import Iterable
 from typing import Any
 
 from collections import deque
@@ -49,6 +50,19 @@ from .helpers import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# What the last PV calibration attempt did per array. Published so a user can
+# tell an array that is genuinely on target from one that has never had the
+# chance to learn anything — most commonly because it has no measured
+# production sensor, or because its output never lands in the usable band.
+PV_CAL_SAMPLED = "sampled"
+PV_CAL_NO_MEASURED_SENSOR = "no_measured_production_sensor"
+PV_CAL_OUTSIDE_LOAD_BAND = "production_outside_usable_band"
+PV_CAL_METER_UNREADABLE = "production_counter_unavailable"
+PV_CAL_WINDOW_MISMATCH = "forecast_window_did_not_elapse"
+PV_CAL_CURTAILED = "pv_curtailed"
+PV_CAL_METER_RESET = "production_counter_reset"
+PV_CAL_IMPLAUSIBLE = "sample_dropped_implausible"
 
 
 class ForecastCoordinator(DataUpdateCoordinator):
@@ -140,6 +154,8 @@ class ForecastCoordinator(DataUpdateCoordinator):
         self._pv_cal_samples: dict[str, deque[tuple[float, float]]] = {}
         self._pv_cal_correction: dict[str, float] = {}
         self._pv_cal_snapshot: dict[str, Any] = {}
+        # Per array: why the most recent run did or did not take a sample.
+        self._pv_cal_last_result: dict[str, str] = {}
         self._pv_cal_store: storage.Store[dict[str, Any]] = storage.Store(
             hass, 1, f"battery_controller_{config.get('entry_id', 'unknown')}_pv_cal"
         )
@@ -221,6 +237,19 @@ class ForecastCoordinator(DataUpdateCoordinator):
             self._unsub_weather = None
         await super().async_shutdown()
 
+    @property
+    def pv_calibrated_array_ids(self) -> list[str]:
+        """The arrays the calibration reports on: every configured PV array.
+
+        Arrays with no measured production sensor are deliberately included.
+        "There is nothing to learn from" is the most common reason a forecast
+        is never corrected, and leaving those arrays out of the report is
+        exactly what makes that invisible.
+        """
+        return [
+            sid for sid in (*self.pv_ac_subentry_ids, *self.pv_dc_subentry_ids) if sid
+        ]
+
     def pv_correction(self, subentry_id: str) -> float:
         """Learned gain factor applied to one PV array's forecast (1.0 = nominal)."""
         return self._pv_cal_correction.get(subentry_id, 1.0)
@@ -228,6 +257,20 @@ class ForecastCoordinator(DataUpdateCoordinator):
     def pv_sample_count(self, subentry_id: str) -> int:
         """Number of observations behind pv_correction for one array."""
         return len(self._pv_cal_samples.get(subentry_id, ()))
+
+    def pv_correction_applied(self, subentry_id: str) -> bool:
+        """Whether one array's forecast is currently being corrected.
+
+        A correction is only derived once PV_CALIBRATION_MIN_SAMPLES
+        observations exist, so this stays False while the window fills.
+        """
+        return subentry_id in self._pv_cal_correction
+
+    def pv_last_result(self, subentry_id: str) -> str:
+        """What the last calibration attempt for one array did, and why."""
+        if subentry_id not in self._pv_measured_sensors:
+            return PV_CAL_NO_MEASURED_SENSOR
+        return self._pv_cal_last_result.get(subentry_id, PV_CAL_OUTSIDE_LOAD_BAND)
 
     async def _async_load_pv_calibration(self) -> None:
         """Restore per-array PV corrections from storage."""
@@ -310,25 +353,30 @@ class ForecastCoordinator(DataUpdateCoordinator):
         if not snapshot:
             return
 
+        planned_by_sid: dict[str, float] = snapshot["forecast_kwh"] or {}
         elapsed_min = (now_utc - snapshot["taken_at"]).total_seconds() / 60.0
         step_min = FORECAST_INTERVAL_MINUTES
         if not (0.5 * step_min <= elapsed_min <= 1.5 * step_min):
             # The window the forecast described is not the window that elapsed.
+            self._set_pv_results(planned_by_sid, PV_CAL_WINDOW_MISMATCH)
             return
 
         if self.pv_curtailed:
             # Production was deliberately suppressed; the shortfall is not a
             # forecast error.
+            self._set_pv_results(planned_by_sid, PV_CAL_CURTAILED)
             return
 
         changed = False
-        for sid, planned_kwh in (snapshot["forecast_kwh"] or {}).items():
+        for sid, planned_kwh in planned_by_sid.items():
             entity_id = self._pv_measured_sensors.get(sid)
             before = (snapshot["meter_kwh"] or {}).get(sid)
             if not entity_id or before is None or planned_kwh <= 0:
+                self._pv_cal_last_result[sid] = PV_CAL_METER_UNREADABLE
                 continue
             after = self._read_pv_meter_kwh(entity_id)
             if after is None:
+                self._pv_cal_last_result[sid] = PV_CAL_METER_UNREADABLE
                 continue
             measured_kwh = after - before
             if measured_kwh < 0:
@@ -339,6 +387,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
                     before,
                     after,
                 )
+                self._pv_cal_last_result[sid] = PV_CAL_METER_RESET
                 continue
             if measured_kwh > PV_CALIBRATION_MAX_SAMPLE_RATIO * planned_kwh:
                 _LOGGER.debug(
@@ -348,12 +397,14 @@ class ForecastCoordinator(DataUpdateCoordinator):
                     measured_kwh,
                     planned_kwh,
                 )
+                self._pv_cal_last_result[sid] = PV_CAL_IMPLAUSIBLE
                 continue
 
             samples = self._pv_cal_samples.setdefault(
                 sid, deque(maxlen=PV_CALIBRATION_WINDOW)
             )
             samples.append((measured_kwh, planned_kwh))
+            self._pv_cal_last_result[sid] = PV_CAL_SAMPLED
             total_measured = sum(m for m, _ in samples)
             total_planned = sum(f for _, f in samples)
             if len(samples) < PV_CALIBRATION_MIN_SAMPLES or total_planned <= 0:
@@ -379,6 +430,11 @@ class ForecastCoordinator(DataUpdateCoordinator):
         if changed:
             self.hass.async_create_task(self._async_save_pv_calibration())
 
+    def _set_pv_results(self, sids: Iterable[str], result: str) -> None:
+        """Record the same calibration outcome for several arrays at once."""
+        for sid in sids:
+            self._pv_cal_last_result[sid] = result
+
     def _snapshot_pv_calibration(
         self,
         now_utc: datetime,
@@ -399,6 +455,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
             kwp = kwp_by_sid.get(sid, 0.0)
             raw_kw = raw_first_step_kw.get(sid, 0.0)
             if kwp <= 0:
+                self._pv_cal_last_result[sid] = PV_CAL_OUTSIDE_LOAD_BAND
                 continue
             load_fraction = raw_kw / kwp
             if not (
@@ -406,9 +463,12 @@ class ForecastCoordinator(DataUpdateCoordinator):
                 <= load_fraction
                 <= PV_CALIBRATION_MAX_LOAD_FRACTION
             ):
+                # Night, deep cloud or near-clipping output: no usable signal.
+                self._pv_cal_last_result[sid] = PV_CAL_OUTSIDE_LOAD_BAND
                 continue
             meter = self._read_pv_meter_kwh(entity_id)
             if meter is None:
+                self._pv_cal_last_result[sid] = PV_CAL_METER_UNREADABLE
                 continue
             forecast_kwh[sid] = raw_kw * step_hours
             meter_kwh[sid] = meter
@@ -729,10 +789,12 @@ class ForecastCoordinator(DataUpdateCoordinator):
             "pv_dc_coupled": has_dc,
             "pv_calibration": {
                 sid: {
-                    "correction": round(self._pv_cal_correction.get(sid, 1.0), 4),
-                    "samples": len(self._pv_cal_samples.get(sid, ())),
+                    "correction": round(self.pv_correction(sid), 4),
+                    "samples": self.pv_sample_count(sid),
+                    "applied": self.pv_correction_applied(sid),
+                    "last_result": self.pv_last_result(sid),
                 }
-                for sid in self._pv_measured_sensors
+                for sid in self.pv_calibrated_array_ids
             },
             "forecast_interval_minutes": step_min,
             "forecast_start_utc": current_step,

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -126,8 +126,24 @@ _CALIBRATION_APPLY_MIN = 0.5
 _CALIBRATION_APPLY_MAX = 1.05
 # Number of observations averaged into one correction.
 _CALIBRATION_WINDOW = 20
+
+# What the last calibration attempt did, published so a user can tell a
+# correction that has genuinely been measured from one that has simply never
+# had the chance to learn anything.
+CALIBRATION_SAMPLED = "sampled"
+CALIBRATION_NO_RESULT = "no_previous_run"
+CALIBRATION_NO_PLAN = "direction_not_planned"
+CALIBRATION_PLAN_NOT_EXECUTED = "plan_not_executed"
+CALIBRATION_STEP_INCOMPLETE = "step_not_finished"
+CALIBRATION_DC_COUPLED = "dc_coupled_pv"
+CALIBRATION_DELTA_TOO_SMALL = "step_too_small_to_measure"
+CALIBRATION_DERATING = "step_crosses_derating_threshold"
+CALIBRATION_IMPLAUSIBLE = "sample_dropped_implausible"
 # A correction is only persisted (and logged) once it moves by more than this.
 _CALIBRATION_SIGNIFICANT_CHANGE = 0.005
+# Corrections at or above this are within measurement noise of nominal and are
+# stored but never handed to the optimizer.
+_CALIBRATION_APPLY_THRESHOLD = 0.995
 
 
 @dataclass(frozen=True)
@@ -374,6 +390,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # to avoid confounding with passive PV.
         self._charge_eff_samples: deque[float] = deque(maxlen=_CALIBRATION_WINDOW)
         self._charge_eff_correction: float = 1.0
+        # Why the most recent run did or did not take a sample.
+        self._charge_eff_last_result: str = CALIBRATION_NO_RESULT
 
         # Cumulative throughput counters as they stood when _last_result was
         # planned. The difference against the next read is the energy the
@@ -398,6 +416,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # within one step. It does not change the economic cost model.
         self._discharge_eff_samples: deque[float] = deque(maxlen=_CALIBRATION_WINDOW)
         self._discharge_eff_correction: float = 1.0
+        self._discharge_eff_last_result: str = CALIBRATION_NO_RESULT
 
         # Persistent storage for discharge efficiency calibration (survives reboots).
         self._discharge_eff_store: storage.Store[dict[str, Any]] = storage.Store(
@@ -492,6 +511,31 @@ class OptimizationCoordinator(DataUpdateCoordinator):
     def discharge_eff_sample_count(self) -> int:
         """Number of observations behind discharge_eff_correction."""
         return len(self._discharge_eff_samples)
+
+    @property
+    def charge_eff_applied(self) -> bool:
+        """Whether the charge correction currently changes the DP's plan.
+
+        The correction is only handed to the optimizer below 0.995 (see
+        _run_optimization): a value at or above that is within measurement
+        noise of nominal and is stored but never applied.
+        """
+        return self._charge_eff_correction < _CALIBRATION_APPLY_THRESHOLD
+
+    @property
+    def discharge_eff_applied(self) -> bool:
+        """Whether the discharge correction currently changes the DP's plan."""
+        return self._discharge_eff_correction < _CALIBRATION_APPLY_THRESHOLD
+
+    @property
+    def charge_eff_last_result(self) -> str:
+        """What the last charge-calibration attempt did, and why."""
+        return self._charge_eff_last_result
+
+    @property
+    def discharge_eff_last_result(self) -> str:
+        """What the last discharge-calibration attempt did, and why."""
+        return self._discharge_eff_last_result
 
     async def _handle_price_model_refresh(self, now: datetime) -> None:
         """Refresh historical price model from HA recorder (daily timer)."""
@@ -1643,7 +1687,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             stored.get("samples", []), maxlen=_CALIBRATION_WINDOW
         )
         correction = float(stored.get("correction", 1.0))
-        if correction < 0.995:
+        if correction < _CALIBRATION_APPLY_THRESHOLD:
             _LOGGER.info(
                 "Restored %s efficiency calibration: correction=%.3f, n=%d samples",
                 name,
@@ -1804,8 +1848,12 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         planned_delta: float,
         actual_delta: float,
         source: str,
-    ) -> float:
+    ) -> tuple[float, str]:
         """Fold one actual/planned observation into a correction factor.
+
+        Returns:
+            (correction, outcome) — the outcome names why the observation did
+            or did not move the correction.
 
         Samples outside the acceptance window are dropped rather than clipped
         into it. Clipping was not symmetric around 1.0 — the ratio was capped
@@ -1824,7 +1872,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 planned_delta,
                 actual_delta,
             )
-            return current_correction
+            return current_correction, CALIBRATION_IMPLAUSIBLE
 
         samples.append(ratio)
         mean = sum(samples) / len(samples)
@@ -1843,7 +1891,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 planned_delta,
                 actual_delta,
             )
-        return new_correction
+        return new_correction, CALIBRATION_SAMPLED
 
     def _previous_step_complete(self) -> bool:
         """Return whether the previously planned first step has elapsed.
@@ -1911,7 +1959,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         samples: deque[float],
         correction: float,
         energy_totals_now: dict[str, float | None] | None,
-    ) -> float:
+    ) -> tuple[float, str]:
         """Score the previous plan against reality and return the new correction.
 
         Both directions ask the same question: did the battery move as much
@@ -1932,25 +1980,33 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         The correction is the mean of the last _CALIBRATION_WINDOW ratios
         (actual/planned), clamped for use. It is applied as a multiplier on the
         DP's SoC transition for this direction only; the economic cost model is
-        untouched. Returns ``correction`` unchanged when no sample is taken.
+        untouched.
+
+        Returns:
+            (correction, outcome) — ``correction`` is returned unchanged when no
+            sample is taken, and ``outcome`` names the reason why. Several of
+            those reasons are permanent for a given setup (a DC-coupled system
+            never samples at all, and a control mode that does not execute the
+            DP plan never will either), so the reason is published rather than
+            leaving the user with a sample count stuck at zero.
         """
         result = self._last_result
         if result is None:
-            return correction
+            return correction, CALIBRATION_NO_RESULT
         if len(result.mode_schedule) < 1 or len(result.soc_schedule_kwh) < 2:
-            return correction
+            return correction, CALIBRATION_NO_RESULT
         if result.mode_schedule[0] != spec.action:
-            return correction
+            return correction, CALIBRATION_NO_PLAN
 
         # Only sample when the plan was actually commanded; mode resolution
         # (hybrid → zero_grid, commitment filter, zero_grid/manual control)
         # would otherwise drag the correction towards the 0.5 clip floor.
         if not self._planned_first_step_was_executed(spec.action):
-            return correction
+            return correction, CALIBRATION_PLAN_NOT_EXECUTED
         if not self._previous_step_complete():
-            return correction
+            return correction, CALIBRATION_STEP_INCOMPLETE
         if self.config.get(CONF_PV_DC_COUPLED, False):
-            return correction
+            return correction, CALIBRATION_DC_COUPLED
 
         prev_soc = result.soc_schedule_kwh[0]
         planned_next_soc = result.soc_schedule_kwh[1]
@@ -1972,7 +2028,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         )
         if planned_delta < self._min_planned_delta_kwh(counter_delta is not None):
             # Too small to measure reliably at this resolution; skip.
-            return correction
+            return correction, CALIBRATION_DELTA_TOO_SMALL
 
         bc = self.battery_config
         if spec.derate_limit_kw(bc) > 0:
@@ -1990,7 +2046,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                     spec.derate_threshold_pct(bc),
                     threshold_kwh,
                 )
-                return correction
+                return correction, CALIBRATION_DERATING
 
         if counter_delta is not None:
             actual_delta = counter_delta
@@ -2020,7 +2076,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Fold the previous charging step's outcome into the charge correction."""
         previous = self._charge_eff_correction
-        self._charge_eff_correction = self._update_eff_calibration(
+        (
+            self._charge_eff_correction,
+            self._charge_eff_last_result,
+        ) = self._update_eff_calibration(
             _CHARGE_CALIBRATION,
             battery_state,
             self._charge_eff_samples,
@@ -2066,7 +2125,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Fold the previous discharging step's outcome into the discharge correction."""
         previous = self._discharge_eff_correction
-        self._discharge_eff_correction = self._update_eff_calibration(
+        (
+            self._discharge_eff_correction,
+            self._discharge_eff_last_result,
+        ) = self._update_eff_calibration(
             _DISCHARGE_CALIBRATION,
             battery_state,
             self._discharge_eff_samples,
@@ -2758,7 +2820,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # nominal curve so a charging-speed problem is not double-counted as
         # extra energy cost or degradation.
         charge_eff_curve_override: EfficiencyCurve | None = None
-        if self._charge_eff_correction < 0.995:
+        if self.charge_eff_applied:
             charge_eff_curve_override = [
                 (p, min(1.0, eff * self._charge_eff_correction))
                 for p, eff in battery_config.charge_efficiency_curve_parsed
@@ -2780,7 +2842,7 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # Curve points may exceed 1.0 here; that is intentional — the override
         # only affects SoC state transitions, not the economic cost.
         discharge_eff_curve_override: EfficiencyCurve | None = None
-        if self._discharge_eff_correction < 0.995:
+        if self.discharge_eff_applied:
             discharge_eff_curve_override = [
                 (p, max(1e-6, eff / self._discharge_eff_correction))
                 for p, eff in battery_config.discharge_efficiency_curve_parsed
@@ -2942,8 +3004,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 "commitment_reason": commitment_reason,
                 "charge_eff_correction": round(self._charge_eff_correction, 4),
                 "charge_eff_samples": len(self._charge_eff_samples),
+                "charge_eff_last_result": self._charge_eff_last_result,
                 "discharge_eff_correction": round(self._discharge_eff_correction, 4),
                 "discharge_eff_samples": len(self._discharge_eff_samples),
+                "discharge_eff_last_result": self._discharge_eff_last_result,
             }
         )
         self._optimization_trigger_source = "unknown"
@@ -2985,7 +3049,11 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             "price_interval": price_interval,
             "charge_eff_correction": round(self._charge_eff_correction, 4),
             "charge_eff_samples": len(self._charge_eff_samples),
+            "charge_eff_applied": self.charge_eff_applied,
+            "charge_eff_last_result": self._charge_eff_last_result,
             "discharge_eff_correction": round(self._discharge_eff_correction, 4),
             "discharge_eff_samples": len(self._discharge_eff_samples),
+            "discharge_eff_applied": self.discharge_eff_applied,
+            "discharge_eff_last_result": self._discharge_eff_last_result,
             "timestamp": dt_util.utcnow(),
         }

--- a/custom_components/battery_controller/diagnostics.py
+++ b/custom_components/battery_controller/diagnostics.py
@@ -134,6 +134,12 @@ async def async_get_config_entry_diagnostics(
             "per_pv_array_forecasts": _remap_keys(
                 forecast_coord.data.get("per_pv_array_forecasts") or {}, name_map
             ),
+            # Per-array forecast calibration: the learned gain, how many
+            # observations back it, whether it is being applied, and — when it
+            # is not — why the array is not learning anything.
+            "pv_calibration": _remap_keys(
+                forecast_coord.data.get("pv_calibration") or {}, name_map
+            ),
             "forecast_interval_minutes": forecast_coord.data.get(
                 "forecast_interval_minutes", 60
             ),
@@ -196,8 +202,12 @@ async def async_get_config_entry_diagnostics(
             },
             "charge_eff_correction": data.get("charge_eff_correction"),
             "charge_eff_samples": data.get("charge_eff_samples"),
+            "charge_eff_applied": data.get("charge_eff_applied"),
+            "charge_eff_last_result": data.get("charge_eff_last_result"),
             "discharge_eff_correction": data.get("discharge_eff_correction"),
             "discharge_eff_samples": data.get("discharge_eff_samples"),
+            "discharge_eff_applied": data.get("discharge_eff_applied"),
+            "discharge_eff_last_result": data.get("discharge_eff_last_result"),
             "timestamp": str(data.get("timestamp")),
         }
 

--- a/custom_components/battery_controller/sensor.py
+++ b/custom_components/battery_controller/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.const import EntityCategory
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -75,6 +75,10 @@ async def async_setup_entry(
             BatteryControlModeSensor(optimization_coordinator, device, entry),
             # Diagnostics
             OptimizationStatusSensor(optimization_coordinator, device, entry),
+            ChargeEfficiencyCalibrationSensor(optimization_coordinator, device, entry),
+            DischargeEfficiencyCalibrationSensor(
+                optimization_coordinator, device, entry
+            ),
         ]
     )
 
@@ -102,7 +106,10 @@ async def async_setup_entry(
                 config_subentry_id=subentry.subentry_id,
             )
 
-    # Per-PV-array subentry sensors — diagnostic, disabled by default
+    # Per-PV-array subentry sensors. The forecast series is disabled by default
+    # (large list attributes); the calibration sensor is not — it is a single
+    # number, and it is the only place a user can see whether the array's
+    # forecast is being corrected and why.
     for subentry in entry.subentries.values():
         if subentry.subentry_type == PV_SUBENTRY_TYPE:
             pv_device = pv_devices.get(subentry.subentry_id, device)
@@ -114,7 +121,14 @@ async def async_setup_entry(
                         entry,
                         subentry.subentry_id,
                         subentry.title,
-                    )
+                    ),
+                    PVArrayCalibrationSensor(
+                        forecast_coordinator,
+                        pv_device,
+                        entry,
+                        subentry.subentry_id,
+                        subentry.title,
+                    ),
                 ],
                 config_subentry_id=subentry.subentry_id,
             )
@@ -852,3 +866,123 @@ class OptimizationStatusSensor(BatteryControllerSensor):
             }
         )
         return attrs
+
+
+class BatteryEfficiencyCalibrationSensor(BatteryControllerSensor):
+    """Base class for the learned battery efficiency corrections.
+
+    The correction is reported as a percentage of nominal: 100% means the
+    battery moves exactly as much energy within a step as the model assumes,
+    96% means it manages 4% less and the DP plans accordingly.
+
+    The number on its own is ambiguous — an untouched 100% looks identical to
+    a measured 100% — so ``samples`` and ``last_result`` are published
+    alongside it. Several values of ``last_result`` are permanent for a given
+    setup rather than a passing condition: a DC-coupled system never samples
+    at all, and a control mode that does not execute the DP schedule verbatim
+    (zero_grid, manual) never will either.
+    """
+
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_suggested_display_precision = 1
+
+    def _calibration(self) -> tuple[float, int, bool, str]:
+        """Return (correction, samples, applied, last_result) for this direction."""
+        raise NotImplementedError
+
+    @property
+    def native_value(self) -> float:
+        correction, _samples, _applied, _result = self._calibration()
+        return round(correction * 100, 2)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        correction, samples, applied, last_result = self._calibration()
+        return {
+            "correction_factor": round(correction, 4),
+            "samples": samples,
+            "applied": applied,
+            "last_result": last_result,
+        }
+
+
+class ChargeEfficiencyCalibrationSensor(BatteryEfficiencyCalibrationSensor):
+    """Learned correction on the charge-side SoC transition."""
+
+    _attr_translation_key = "charge_eff_correction"
+    _attr_name = "Charge Efficiency Correction"
+    _key = "charge_eff_correction"
+
+    def _calibration(self) -> tuple[float, int, bool, str]:
+        return (
+            self.coordinator.charge_eff_correction,
+            self.coordinator.charge_eff_sample_count,
+            self.coordinator.charge_eff_applied,
+            self.coordinator.charge_eff_last_result,
+        )
+
+
+class DischargeEfficiencyCalibrationSensor(BatteryEfficiencyCalibrationSensor):
+    """Learned correction on the discharge-side SoC transition."""
+
+    _attr_translation_key = "discharge_eff_correction"
+    _attr_name = "Discharge Efficiency Correction"
+    _key = "discharge_eff_correction"
+
+    def _calibration(self) -> tuple[float, int, bool, str]:
+        return (
+            self.coordinator.discharge_eff_correction,
+            self.coordinator.discharge_eff_sample_count,
+            self.coordinator.discharge_eff_applied,
+            self.coordinator.discharge_eff_last_result,
+        )
+
+
+class PVArrayCalibrationSensor(BatteryForecastSensor):
+    """Learned correction on one PV array's forecast.
+
+    100% means the array produces what the model predicts. Below that the
+    forecast is optimistic (soiling, a dead string, a wrong tilt or
+    orientation entry); above it the array outperforms the model. Shading is
+    a function of sun position rather than a constant gain, so it is not
+    something this can capture.
+
+    Reported per array because the causes are per array. ``applied`` stays
+    False until the sample window has filled, and ``last_result`` says why an
+    array is not learning — most often that it has no measured production
+    sensor configured.
+    """
+
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_suggested_display_precision = 1
+
+    def __init__(
+        self,
+        coordinator: ForecastCoordinator,
+        device: DeviceInfo,
+        entry: ConfigEntry,
+        subentry_id: str,
+        array_title: str,
+    ):
+        super().__init__(coordinator, device, entry, f"pv_calibration_{subentry_id}")
+        self._subentry_id = subentry_id
+        self._attr_name = f"PV Forecast Correction {array_title}"
+
+    @property
+    def native_value(self) -> float:
+        return round(self.coordinator.pv_correction(self._subentry_id) * 100, 2)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "correction_factor": round(
+                self.coordinator.pv_correction(self._subentry_id), 4
+            ),
+            "samples": self.coordinator.pv_sample_count(self._subentry_id),
+            "applied": self.coordinator.pv_correction_applied(self._subentry_id),
+            "last_result": self.coordinator.pv_last_result(self._subentry_id),
+        }

--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -371,6 +371,12 @@
       },
       "pv_array_forecast": {
         "name": "PV Forecast"
+      },
+      "charge_eff_correction": {
+        "name": "Charge Efficiency Correction"
+      },
+      "discharge_eff_correction": {
+        "name": "Discharge Efficiency Correction"
       }
     },
     "number": {

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -371,6 +371,12 @@
       },
       "pv_array_forecast": {
         "name": "PV Forecast"
+      },
+      "charge_eff_correction": {
+        "name": "Charge Efficiency Correction"
+      },
+      "discharge_eff_correction": {
+        "name": "Discharge Efficiency Correction"
       }
     },
     "number": {

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -296,6 +296,12 @@
       },
       "pv_array_forecast": {
         "name": "PV Voorspelling"
+      },
+      "charge_eff_correction": {
+        "name": "Laadefficiëntie-correctie"
+      },
+      "discharge_eff_correction": {
+        "name": "Ontlaadefficiëntie-correctie"
       }
     },
     "number": {

--- a/docs/__tests__/calibration_card.test.js
+++ b/docs/__tests__/calibration_card.test.js
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * What the analyzer says about the learned calibration.
+ *
+ * The numbers themselves are unambiguous only in one direction: a correction
+ * of 1.0 means "measured, and on target" when samples exist and "never
+ * measured anything" when they do not, and the second case is by far the more
+ * common one. Rendering both as a confident 100% is how a user concludes the
+ * integration has calibrated itself when in fact it never can — on a
+ * DC-coupled system, or on a PV array with no production meter, the sample
+ * count stays at zero forever.
+ *
+ * This drives the page's own render path against a synthetic diagnostics
+ * payload. The CDN bundles are stripped and Chart.js is stubbed: the assertion
+ * is about the text the card produces, not about drawing anything.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PAGE = path.join(__dirname, '..', 'analyzer', 'index.html');
+
+const DIAGNOSTICS = {
+  config_entry: { entry_id: 'e1', title: 't', data: {}, options: {}, subentries: {} },
+  battery_config: {
+    capacity_kwh: 10, usable_capacity_kwh: 8,
+    max_charge_power_kw: 5, max_discharge_power_kw: 5,
+    round_trip_efficiency: 0.9, charge_efficiency: 0.9487, discharge_efficiency: 0.9487,
+    min_soc_percent: 10, max_soc_percent: 90, min_soc_kwh: 1, max_soc_kwh: 9,
+    pv_dc_coupled: false, pv_dc_peak_power_kwp: 0, pv_dc_efficiency: 0.97,
+  },
+  weather: {},
+  forecast: {
+    current_pv_kw: 1.2, current_dc_pv_kw: 0,
+    current_consumption_kw: 0.5, current_net_load_kw: -0.7,
+    pv_calibration: {
+      // Learned and in use.
+      'South Array': { correction: 0.87, samples: 64, applied: true, last_result: 'sampled' },
+      // Can never learn: no production meter configured.
+      'East Array': { correction: 1.0, samples: 0, applied: false, last_result: 'no_measured_production_sensor' },
+    },
+  },
+  optimization: {
+    control_mode: 'hybrid', optimal_mode: 'idle', optimal_power_kw: 0,
+    current_price: 0.24, current_feed_in_price: 0.07, shadow_price_eur_kwh: 0.11,
+    // Learned and in use.
+    charge_eff_correction: 0.94, charge_eff_samples: 12,
+    charge_eff_applied: true, charge_eff_last_result: 'sampled',
+    // Can never learn: DC-coupled PV makes the SoC delta unusable.
+    discharge_eff_correction: 1.0, discharge_eff_samples: 0,
+    discharge_eff_applied: false, discharge_eff_last_result: 'dc_coupled_pv',
+    battery_state: { soc_kwh: 5, soc_percent: 50, power_kw: 0, mode: 'idle' },
+    schedule: {
+      price_forecast: [0.2, 0.3], power_schedule_kw: [0, 0],
+      mode_schedule: ['idle', 'idle'], soc_schedule_kwh: [5, 5], price_interval: 60,
+    },
+  },
+  entities: [],
+};
+
+describe('analyzer learned-calibration card', () => {
+  let card;
+
+  beforeAll(() => {
+    const markup = fs
+      .readFileSync(PAGE, 'utf8')
+      .replace(/<script\b[^>]*src=["']https?:[^"']*["'][^>]*><\/script>/g, '');
+    document.open();
+    document.write(markup);
+    document.close();
+
+    // Stand in for the CDN bundles the page loads in a browser.
+    window.Chart = function () { return { destroy() {}, update() {} }; };
+    window.Chart.register = () => {};
+    HTMLCanvasElement.prototype.getContext = () => ({});
+
+    window.parseAndLoad(JSON.stringify(DIAGNOSTICS));
+    card = document.getElementById('cfg-calibration').textContent;
+  });
+
+  test('shows a learned correction as applied', () => {
+    expect(card).toContain('Battery charge efficiency');
+    expect(card).toContain('94.0%');
+    expect(card).toContain('n=12');
+  });
+
+  test('does not present an unmeasured correction as 100%', () => {
+    // The discharge side has never sampled; "100.0% applied" would be a lie.
+    expect(card).toContain('not learned');
+    expect(card).not.toMatch(/100\.0% \(n=0\) applied/);
+  });
+
+  test('names the reason a correction cannot be learned', () => {
+    expect(card).toContain('dc coupled pv');
+    expect(card).toContain('no measured production sensor');
+  });
+
+  test('reports every PV array, including one that is not calibrated', () => {
+    expect(card).toContain('South Array');
+    expect(card).toContain('87.0%');
+    // An array left out of the report is exactly what hides the problem.
+    expect(card).toContain('East Array');
+  });
+
+  test('the efficiency card no longer claims 100% for an unmeasured correction', () => {
+    const eff = document.getElementById('cfg-eff').textContent;
+    expect(eff).toContain('Discharge eff correction');
+    expect(eff).toContain('not learned yet');
+  });
+});

--- a/docs/analyzer/index.html
+++ b/docs/analyzer/index.html
@@ -132,6 +132,17 @@
     </div>
   </div>
 
+  <!-- Learned calibration -->
+  <div class="bg-white rounded-xl border border-gray-200 p-5">
+    <h3 class="font-semibold text-gray-700 mb-3 text-sm">🎯 Learned Calibration</h3>
+    <div id="cfg-calibration"></div>
+    <div class="text-xs text-gray-400 mt-2">
+      Corrections the integration learned by comparing its own plan against what
+      actually happened. 100% means "as modelled". A correction only applies once
+      enough samples exist; until then the reason column says what is holding it up.
+    </div>
+  </div>
+
   <!-- Coordinator health + current values -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div class="bg-white rounded-xl border border-gray-200 p-5">
@@ -791,16 +802,22 @@ function renderDiagnostics(raw) {
     : null;
   const chgEffCorr = opt.charge_eff_correction ?? lastRun?.charge_eff_correction;
   const chgEffSamples = opt.charge_eff_samples ?? lastRun?.charge_eff_samples;
-  const chgEffCorrStr = chgEffCorr !== undefined
-    ? `${(chgEffCorr * 100).toFixed(1)}%` + (chgEffSamples !== undefined ? ` (n=${chgEffSamples})` : '')
-    : '—';
+  // A correction of 1.0 with no samples behind it has never been measured;
+  // rendering it as "100.0%" reads as a clean bill of health it has not earned.
+  const chgEffCorrStr = chgEffSamples === 0
+    ? 'not learned yet'
+    : chgEffCorr !== undefined
+      ? `${(chgEffCorr * 100).toFixed(1)}%` + (chgEffSamples !== undefined ? ` (n=${chgEffSamples})` : '')
+      : '—';
   const chgEffCorrClass = chgEffCorr !== undefined && chgEffCorr < 0.95 ? 'badge badge-fail'
     : chgEffCorr !== undefined && chgEffCorr < 0.995 ? 'badge badge-idle' : '';
   const disEffCorr = opt.discharge_eff_correction ?? lastRun?.discharge_eff_correction;
   const disEffSamples = opt.discharge_eff_samples ?? lastRun?.discharge_eff_samples;
-  const disEffCorrStr = disEffCorr !== undefined
-    ? `${(disEffCorr * 100).toFixed(1)}%` + (disEffSamples !== undefined ? ` (n=${disEffSamples})` : '')
-    : '—';
+  const disEffCorrStr = disEffSamples === 0
+    ? 'not learned yet'
+    : disEffCorr !== undefined
+      ? `${(disEffCorr * 100).toFixed(1)}%` + (disEffSamples !== undefined ? ` (n=${disEffSamples})` : '')
+      : '—';
   const disEffCorrClass = disEffCorr !== undefined && disEffCorr < 0.95 ? 'badge badge-fail'
     : disEffCorr !== undefined && disEffCorr < 0.995 ? 'badge badge-idle' : '';
   document.getElementById('cfg-eff').innerHTML =
@@ -812,6 +829,37 @@ function renderDiagnostics(raw) {
     kv('Degradation cost', (opts.degradation_cost_per_cycle ?? opts.degradation_cost_per_kwh) !== undefined ? `€ ${(opts.degradation_cost_per_cycle ?? opts.degradation_cost_per_kwh).toFixed(3)}/cycle` : '—') +
     kv('Min price spread', opts.min_price_spread !== undefined ? `€ ${opts.min_price_spread}/kWh` : '—') +
     kv('Fixed feed-in fallback', opts.fixed_feed_in_price !== undefined ? `€ ${opts.fixed_feed_in_price}/kWh` : '—');
+
+  // ── Learned calibration (battery efficiency + per-PV-array forecast gain)
+  const calRow = (label, entry) => {
+    if (!entry) return kv(label, '—');
+    const pct = entry.correction !== undefined && entry.correction !== null
+      ? `${(entry.correction * 100).toFixed(1)}%` : '—';
+    const n = entry.samples ?? 0;
+    // n=0 at 100% is "never measured", not "measured and on target". Saying
+    // that plainly is the whole point of this card.
+    const state = n === 0
+      ? '<span class="badge badge-idle">not learned</span>'
+      : entry.applied
+        ? '<span class="badge badge-ok">applied</span>'
+        : '<span class="badge badge-idle">learning</span>';
+    const why = entry.last_result && entry.last_result !== 'sampled'
+      ? ` <span class="text-gray-400">· ${entry.last_result.replace(/_/g, ' ')}</span>` : '';
+    return kv(label, `${pct} <span class="text-gray-400">(n=${n})</span> ${state}${why}`);
+  };
+  const pvCal = fc.pv_calibration || {};
+  document.getElementById('cfg-calibration').innerHTML =
+    calRow('Battery charge efficiency', {
+      correction: chgEffCorr, samples: chgEffSamples,
+      applied: opt.charge_eff_applied, last_result: opt.charge_eff_last_result,
+    }) +
+    calRow('Battery discharge efficiency', {
+      correction: disEffCorr, samples: disEffSamples,
+      applied: opt.discharge_eff_applied, last_result: opt.discharge_eff_last_result,
+    }) +
+    (Object.keys(pvCal).length
+      ? Object.entries(pvCal).map(([name, e]) => calRow(`PV forecast · ${name}`, e)).join('')
+      : kv('PV forecast', '<span class="text-gray-400">no PV arrays reported</span>'));
 
   const srcBadge = opt.price_forecast_source
     ? `<span class="badge ${opt.price_forecast_source==='live'?'badge-ok':opt.price_forecast_source==='current_only'?'badge-fail':'badge-idle'}">${opt.price_forecast_source}</span>`

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -151,6 +151,43 @@ During this convergence period you may notice:
 The longer the integration runs, the more accurate the underlying forecasts become and
 the more stable the resulting schedule.
 
+### Checking what has actually been learned
+
+Three corrections are learned from your own installation, and each one is published as a
+diagnostic sensor so you can see where it stands without downloading anything:
+
+| Sensor | What it measures |
+|---|---|
+| *Charge Efficiency Correction* | How much SoC the battery really gains within a step, against what the model assumed |
+| *Discharge Efficiency Correction* | The same for discharging |
+| *PV Forecast Correction &lt;array&gt;* | What each PV array really produces, against its forecast |
+
+All three read **100%** when reality matches the model. That is also the value they start
+at, so the number alone cannot tell you whether anything has been measured — the
+attributes say which:
+
+- `samples` — how many observations are behind the value. At `0`, nothing has been
+  learned yet.
+- `applied` — whether the correction is actually changing the plan. A PV correction needs
+  a full sample window first; a battery correction within measurement noise of nominal is
+  stored but never applied.
+- `last_result` — what the most recent attempt did, and if it took no sample, why not.
+
+Some of those reasons are permanent for a given setup rather than a passing condition,
+and they are the usual explanation for a sample count that never moves:
+
+| `last_result` | What it means |
+|---|---|
+| `dc_coupled_pv` | Battery calibration is skipped entirely on DC-coupled systems: passive PV charging during a step would be indistinguishable from the battery charging faster than modelled. |
+| `plan_not_executed` | The battery is not following the DP schedule verbatim, so the SoC change does not measure efficiency. Normal in [Zero Grid](control-modes.md#zero-grid) and [Manual](control-modes.md#manual) mode, and common in [Hybrid](control-modes.md#hybrid-recommended). |
+| `direction_not_planned` | The optimizer has not planned this direction recently. Simply waiting is the fix. |
+| `no_measured_production_sensor` | The PV array has no production counter configured, so there is nothing to compare its forecast against. |
+| `production_outside_usable_band` | The array is producing below 10% or above 80% of its rating — too little signal, or close enough to clipping that the shortfall is not a forecast error. |
+
+To reset a correction that has gone wrong, call the
+`battery_controller.reset_charge_efficiency_calibration`,
+`reset_discharge_efficiency_calibration` or `reset_pv_calibration` service.
+
 ---
 
 ## Known limitations

--- a/tests/test_coordinator_forecast.py
+++ b/tests/test_coordinator_forecast.py
@@ -14,6 +14,10 @@ from custom_components.battery_controller.const import (
     CONF_PV_MEASURED_PRODUCTION_SENSOR,
 )
 from custom_components.battery_controller.coordinator_forecast import (
+    PV_CAL_CURTAILED,
+    PV_CAL_METER_RESET,
+    PV_CAL_NO_MEASURED_SENSOR,
+    PV_CAL_SAMPLED,
     ForecastCoordinator,
 )
 from custom_components.battery_controller.helpers import battery_energy_sensor_ids
@@ -1492,3 +1496,127 @@ async def test_pv_calibration_reset(hass):
 
     assert coord.pv_correction("pv1") == pytest.approx(1.0)
     assert coord.pv_sample_count("pv1") == 0
+
+
+# ---------------------------------------------------------------------------
+# Reporting the calibration state
+#
+# A correction of 1.0 has two very different meanings — "measured and on
+# target" and "never measured anything" — and the second is by far the more
+# common. The reported state has to separate them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pv_report_names_an_array_with_no_production_meter(hass):
+    """Without a meter the array can never be calibrated; that must be visible."""
+    coord = _make_cal_coordinator(hass, pv_arrays=[_pv_array(measured=None)])
+
+    assert coord.pv_last_result("pv1") == PV_CAL_NO_MEASURED_SENSOR
+    assert coord.pv_correction_applied("pv1") is False
+
+
+@pytest.mark.asyncio
+async def test_pv_report_covers_arrays_that_are_not_being_calibrated(hass):
+    """An uncalibrated array must still appear, or its absence explains nothing."""
+    coord = _make_cal_coordinator(
+        hass,
+        pv_arrays=[
+            _pv_array(sid="pv1", measured="sensor.pv1_energy"),
+            _pv_array(sid="pv2", measured=None),
+        ],
+    )
+
+    assert coord.pv_calibrated_array_ids == ["pv1", "pv2"]
+
+
+@pytest.mark.asyncio
+async def test_pv_report_includes_dc_coupled_arrays(hass):
+    """DC arrays are calibrated the same way and belong in the same report."""
+    coord = _make_cal_coordinator(
+        hass, pv_arrays=[_pv_array(sid="pv_dc", dc=True, measured="sensor.dc_energy")]
+    )
+
+    assert coord.pv_calibrated_array_ids == ["pv_dc"]
+
+
+@pytest.mark.asyncio
+async def test_pv_report_distinguishes_learning_from_applied(hass):
+    """Samples are collected long before a correction is derived from them."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    meter = 100.0
+    for _ in range(3):
+        coord._pv_cal_snapshot = {
+            "taken_at": now,
+            "forecast_kwh": {"pv1": 0.5},
+            "meter_kwh": {"pv1": meter},
+        }
+        meter += 0.4
+        hass.states.async_set(
+            "sensor.pv1_energy", f"{meter}", {"unit_of_measurement": "kWh"}
+        )
+        now += timedelta(minutes=15)
+        coord._update_pv_calibration(now)
+
+    assert coord.pv_sample_count("pv1") == 3
+    assert coord.pv_correction_applied("pv1") is False
+    assert coord.pv_last_result("pv1") == PV_CAL_SAMPLED
+
+
+@pytest.mark.asyncio
+async def test_pv_report_names_curtailment_as_the_reason(hass):
+    """Curtailed production is skipped on purpose; the report must say which."""
+    coord = _make_cal_coordinator(hass)
+    coord.pv_curtailed = True
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    coord._pv_cal_snapshot = {
+        "taken_at": now,
+        "forecast_kwh": {"pv1": 0.5},
+        "meter_kwh": {"pv1": 100.0},
+    }
+    hass.states.async_set("sensor.pv1_energy", "100.0", {"unit_of_measurement": "kWh"})
+
+    coord._update_pv_calibration(now + timedelta(minutes=15))
+
+    assert coord.pv_last_result("pv1") == PV_CAL_CURTAILED
+
+
+@pytest.mark.asyncio
+async def test_pv_report_names_a_meter_reset_as_the_reason(hass):
+    """A counter that went backwards is a meter event, not a forecast error."""
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    coord._pv_cal_snapshot = {
+        "taken_at": now,
+        "forecast_kwh": {"pv1": 0.5},
+        "meter_kwh": {"pv1": 100.0},
+    }
+    hass.states.async_set("sensor.pv1_energy", "3.0", {"unit_of_measurement": "kWh"})
+
+    coord._update_pv_calibration(now + timedelta(minutes=15))
+
+    assert coord.pv_sample_count("pv1") == 0
+    assert coord.pv_last_result("pv1") == PV_CAL_METER_RESET
+
+
+@pytest.mark.asyncio
+async def test_pv_calibration_is_published_for_every_array(hass):
+    """The coordinator's own data carries the report, so entities can read it."""
+    coord = _make_cal_coordinator(
+        hass,
+        pv_arrays=[
+            _pv_array(sid="pv1", measured="sensor.pv1_energy"),
+            _pv_array(sid="pv2", measured=None),
+        ],
+    )
+    coord.net_load_model = MagicMock()
+    coord.net_load_model.forecast = MagicMock(return_value=(None, [0.5] * 48, None))
+
+    result = await coord._async_update_data()
+
+    report = result["pv_calibration"]
+    assert set(report) == {"pv1", "pv2"}
+    assert report["pv2"]["last_result"] == PV_CAL_NO_MEASURED_SENSOR
+    assert report["pv1"]["applied"] is False
+    assert report["pv1"]["correction"] == pytest.approx(1.0)

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -44,6 +44,13 @@ from custom_components.battery_controller.coordinator_optimization import (
 from custom_components.battery_controller.helpers import (
     extract_price_forecast_with_timestamps,
 )
+from custom_components.battery_controller.coordinator_optimization import (
+    CALIBRATION_DC_COUPLED,
+    CALIBRATION_NO_PLAN,
+    CALIBRATION_NO_RESULT,
+    CALIBRATION_PLAN_NOT_EXECUTED,
+    CALIBRATION_SAMPLED,
+)
 from custom_components.battery_controller.optimizer import OptimizationResult
 
 from .conftest import make_optimization_coordinator
@@ -3986,3 +3993,98 @@ def test_symmetric_noise_does_not_bias_the_correction(hass):
 
     assert coord.charge_eff_sample_count == 6
     assert coord.charge_eff_correction == pytest.approx(1.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Why a calibration is not learning
+#
+# A sample count stuck at zero has several causes, and some of them are
+# permanent for a given setup rather than a passing condition. The reason is
+# published so the user is not left guessing at an untouched 100%.
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_reports_a_taken_sample(hass):
+    """The happy path names itself, so 'no reason given' is never ambiguous."""
+    coord = _make_coordinator(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"], soc_schedule_kwh=[5.0, 6.0]
+    )
+    _mark_plan_executed(coord)
+
+    coord._update_charge_eff_calibration(
+        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
+    )
+
+    assert coord.charge_eff_last_result == CALIBRATION_SAMPLED
+
+
+def test_calibration_reports_dc_coupling_as_the_blocker(hass):
+    """A DC-coupled system never samples; that is by design, not a fault."""
+    coord = _make_coordinator(hass)
+    coord.config[CONF_PV_DC_COUPLED] = True
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"], soc_schedule_kwh=[5.0, 6.0]
+    )
+    _mark_plan_executed(coord)
+
+    coord._update_charge_eff_calibration(
+        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
+    )
+
+    assert coord.charge_eff_sample_count == 0
+    assert coord.charge_eff_last_result == CALIBRATION_DC_COUPLED
+
+
+def test_calibration_reports_a_plan_that_was_never_executed(hass):
+    """In zero_grid or manual the DP plan is not what runs, so nothing is learnt."""
+    coord = _make_coordinator(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"], soc_schedule_kwh=[5.0, 6.0]
+    )
+    # The controller was left on a different setpoint than the plan asked for.
+    coord._effective_mode = "zero_grid"
+    coord._controller_schedule_w = 0.0
+
+    coord._update_charge_eff_calibration(
+        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
+    )
+
+    assert coord.charge_eff_sample_count == 0
+    assert coord.charge_eff_last_result == CALIBRATION_PLAN_NOT_EXECUTED
+
+
+def test_calibration_reports_that_the_direction_was_not_planned(hass):
+    """Discharge calibration is idle while the DP is charging, and says so."""
+    coord = _make_coordinator(hass)
+    coord._last_result = _make_fake_result(
+        mode_schedule=["charging"], soc_schedule_kwh=[5.0, 6.0]
+    )
+    _mark_plan_executed(coord)
+
+    coord._update_discharge_eff_calibration(
+        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
+    )
+
+    assert coord.discharge_eff_last_result == CALIBRATION_NO_PLAN
+
+
+def test_calibration_starts_out_admitting_it_knows_nothing(hass):
+    """Before the first run there is no evidence, and the sensor must not imply any."""
+    coord = _make_coordinator(hass)
+
+    assert coord.charge_eff_last_result == CALIBRATION_NO_RESULT
+    assert coord.discharge_eff_last_result == CALIBRATION_NO_RESULT
+    assert coord.charge_eff_applied is False
+    assert coord.discharge_eff_applied is False
+
+
+def test_a_correction_within_noise_of_nominal_is_reported_as_not_applied(hass):
+    """1.0 is stored but never handed to the optimizer; applied must reflect that."""
+    coord = _make_coordinator(hass)
+
+    coord._charge_eff_correction = 0.999
+    assert coord.charge_eff_applied is False
+
+    coord._charge_eff_correction = 0.94
+    assert coord.charge_eff_applied is True

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -189,3 +189,83 @@ async def test_diagnostics_entity_state_none(
 
     assert diagnostics["entities"][0]["state"] is None
     assert diagnostics["entities"][0]["attributes"] == {}
+
+
+async def test_diagnostics_carries_the_calibration_report(
+    hass: HomeAssistant, mock_config_entry: MagicMock
+):
+    """The learned calibration is the whole reason this dump gets requested.
+
+    Without it in the diagnostics there is no way — short of reading the
+    .storage files by hand — to see whether the integration has learned
+    anything about this installation, or why it has not.
+    """
+    mock_config_entry.subentries = {
+        "pv1": MagicMock(title="South Array", subentry_type="pv", data={})
+    }
+
+    weather_coord = MagicMock()
+    weather_coord.data = None
+
+    forecast_coord = MagicMock()
+    forecast_coord.data = {
+        "pv_calibration": {
+            "pv1": {
+                "correction": 0.87,
+                "samples": 64,
+                "applied": True,
+                "last_result": "sampled",
+            }
+        },
+        "timestamp": "2024-01-01T00:00:00",
+    }
+    forecast_coord.last_update_success = True
+    del forecast_coord.consumption_model
+
+    optimization_coord = MagicMock()
+    optimization_coord.data = {
+        "charge_eff_correction": 0.94,
+        "charge_eff_samples": 12,
+        "charge_eff_applied": True,
+        "charge_eff_last_result": "sampled",
+        "discharge_eff_correction": 1.0,
+        "discharge_eff_samples": 0,
+        "discharge_eff_applied": False,
+        "discharge_eff_last_result": "dc_coupled_pv",
+        "timestamp": "2024-01-01T00:00:00",
+    }
+    optimization_coord.last_update_success = True
+    optimization_coord.battery_config = MagicMock(charge_efficiency=0.95)
+
+    mock_config_entry.runtime_data = BatteryControllerData(
+        weather_coordinator=weather_coord,
+        forecast_coordinator=forecast_coord,
+        optimization_coordinator=optimization_coord,
+        config={},
+        device=MagicMock(),
+        battery_devices={},
+        pv_devices={},
+    )
+
+    with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
+        mock_er_get.return_value = MagicMock()
+        with patch(
+            "homeassistant.helpers.entity_registry.async_entries_for_config_entry"
+        ) as mock_entries:
+            mock_entries.return_value = []
+            diagnostics = await async_get_config_entry_diagnostics(
+                hass, mock_config_entry
+            )
+
+    opt = diagnostics["optimization"]
+    assert opt["charge_eff_correction"] == 0.94
+    assert opt["charge_eff_applied"] is True
+    # A correction of 1.0 with no samples is not a clean bill of health, and the
+    # reason travels with it so the reader can tell the difference.
+    assert opt["discharge_eff_samples"] == 0
+    assert opt["discharge_eff_last_result"] == "dc_coupled_pv"
+
+    # Keyed by the array's title, not its opaque subentry ID.
+    pv_cal = diagnostics["forecast"]["pv_calibration"]
+    assert pv_cal["South Array"]["correction"] == 0.87
+    assert pv_cal["South Array"]["samples"] == 64

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,10 +32,13 @@ from custom_components.battery_controller.sensor import (
     BatterySoCSensor,
     BatterySubentrySetpointSensor,
     BatterySubentrySoCSensor,
+    ChargeEfficiencyCalibrationSensor,
     ConsumptionForecastSensor,
     CurrentGridPowerSensor,
+    DischargeEfficiencyCalibrationSensor,
     NetGridForecastSensor,
     OptimizationStatusSensor,
+    PVArrayCalibrationSensor,
     PVArrayForecastSensor,
     PVForecastSensor,
     SolarIrradianceSensor,
@@ -1109,7 +1112,7 @@ async def test_sensor_async_setup_entry_no_subentries():
 
     # Main entity list added
     assert len(added_calls) >= 1
-    assert len(added_calls[0][0]) == 16  # 16 main sensors
+    assert len(added_calls[0][0]) == 18  # 18 main sensors
 
 
 @pytest.mark.asyncio
@@ -1196,7 +1199,8 @@ async def test_sensor_async_setup_entry_with_pv_subentry():
         (c for c in added_calls if c[1].get("config_subentry_id") == "pv1"), None
     )
     assert pv_call is not None
-    assert len(pv_call[0]) == 1
+    # Forecast series + calibration sensor
+    assert len(pv_call[0]) == 2
 
 
 @pytest.mark.asyncio
@@ -1294,3 +1298,131 @@ def test_native_value_is_none_without_coordinator_data(sensor_cls, kind):
 def test_extra_attributes_empty_without_coordinator_data(sensor_cls, kind):
     """Attributes stay empty rather than exposing half-built values."""
     assert _build(sensor_cls, kind).extra_state_attributes == {}
+
+
+# ---------------------------------------------------------------------------
+# Calibration sensors
+#
+# These do not read coordinator.data: a correction exists from the moment the
+# integration starts (restored from storage), long before the first successful
+# optimizer run, so they read the coordinator's accessors directly.
+# ---------------------------------------------------------------------------
+
+
+def _make_calibration_coord(
+    correction=0.94, samples=7, applied=True, last_result="sampled"
+):
+    coord = _make_opt_coord()
+    coord.charge_eff_correction = correction
+    coord.charge_eff_sample_count = samples
+    coord.charge_eff_applied = applied
+    coord.charge_eff_last_result = last_result
+    coord.discharge_eff_correction = correction
+    coord.discharge_eff_sample_count = samples
+    coord.discharge_eff_applied = applied
+    coord.discharge_eff_last_result = last_result
+    return coord
+
+
+@pytest.mark.parametrize(
+    "sensor_cls",
+    [ChargeEfficiencyCalibrationSensor, DischargeEfficiencyCalibrationSensor],
+    ids=lambda v: v.__name__,
+)
+def test_efficiency_calibration_reports_percentage(sensor_cls):
+    """The correction factor is published as a percentage of nominal."""
+    sensor = sensor_cls(_make_calibration_coord(0.94), _make_device(), _make_entry())
+
+    assert sensor.native_value == pytest.approx(94.0)
+
+
+@pytest.mark.parametrize(
+    "sensor_cls",
+    [ChargeEfficiencyCalibrationSensor, DischargeEfficiencyCalibrationSensor],
+    ids=lambda v: v.__name__,
+)
+def test_efficiency_calibration_publishes_sample_count_and_reason(sensor_cls):
+    """A bare percentage cannot be read; the evidence behind it travels with it."""
+    coord = _make_calibration_coord(
+        correction=1.0, samples=0, applied=False, last_result="dc_coupled_pv"
+    )
+    sensor = sensor_cls(coord, _make_device(), _make_entry())
+
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["samples"] == 0
+    assert attrs["applied"] is False
+    assert attrs["last_result"] == "dc_coupled_pv"
+    assert attrs["correction_factor"] == pytest.approx(1.0)
+
+
+def test_efficiency_calibration_sensors_have_distinct_unique_ids():
+    """Both directions must survive side by side in the entity registry."""
+    coord = _make_calibration_coord()
+    entry = _make_entry()
+
+    charge = ChargeEfficiencyCalibrationSensor(coord, _make_device(), entry)
+    discharge = DischargeEfficiencyCalibrationSensor(coord, _make_device(), entry)
+
+    assert charge.unique_id != discharge.unique_id
+
+
+def _make_pv_calibration_coord(
+    correction=1.12, samples=40, applied=True, last_result="sampled"
+):
+    coord = _make_forecast_coord()
+    coord.pv_correction = MagicMock(return_value=correction)
+    coord.pv_sample_count = MagicMock(return_value=samples)
+    coord.pv_correction_applied = MagicMock(return_value=applied)
+    coord.pv_last_result = MagicMock(return_value=last_result)
+    return coord
+
+
+def test_pv_array_calibration_reports_percentage():
+    """A array producing 12% above forecast reads as 112%."""
+    sensor = PVArrayCalibrationSensor(
+        _make_pv_calibration_coord(1.12), _make_device(), _make_entry(), "pv1", "South"
+    )
+
+    assert sensor.native_value == pytest.approx(112.0)
+
+
+def test_pv_array_calibration_explains_an_array_that_never_learns():
+    """Without a production meter an array sits at 100% forever; say so."""
+    coord = _make_pv_calibration_coord(
+        correction=1.0,
+        samples=0,
+        applied=False,
+        last_result="no_measured_production_sensor",
+    )
+    sensor = PVArrayCalibrationSensor(
+        coord, _make_device(), _make_entry(), "pv1", "South"
+    )
+
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["applied"] is False
+    assert attrs["last_result"] == "no_measured_production_sensor"
+
+
+def test_pv_array_calibration_is_scoped_to_its_own_array():
+    """Each sensor must ask about its own subentry, not the first one."""
+    coord = _make_pv_calibration_coord()
+    sensor = PVArrayCalibrationSensor(
+        coord, _make_device(), _make_entry(), "pv_east", "East"
+    )
+
+    sensor.native_value
+
+    coord.pv_correction.assert_called_with("pv_east")
+
+
+def test_pv_array_calibration_sensors_have_distinct_unique_ids():
+    """Two arrays must not collide in the entity registry."""
+    coord = _make_pv_calibration_coord()
+    entry = _make_entry()
+
+    east = PVArrayCalibrationSensor(coord, _make_device(), entry, "pv_east", "East")
+    west = PVArrayCalibrationSensor(coord, _make_device(), entry, "pv_west", "West")
+
+    assert east.unique_id != west.unique_id


### PR DESCRIPTION
## Description

The integration learns three corrections from the installation it runs on — charge efficiency, discharge efficiency, and a per-array PV forecast gain — and until now **none of them were visible in Home Assistant**. The battery ones reached the diagnostics download and the analyzer; the PV one reached nothing at all: `coordinator_forecast.py` computed `pv_calibration` into its data dict and no consumer ever read it, so the only way to interact with it was the reset service, blind.

### New entities

| Sensor | Device | State |
|---|---|---|
| Charge Efficiency Correction | main | correction as % of nominal |
| Discharge Efficiency Correction | main | correction as % of nominal |
| PV Forecast Correction *&lt;array&gt;* | that PV array | correction as % of nominal |

All diagnostic. They use the `charge_eff_correction` / `pv_correction()` accessors that already existed on the coordinators for exactly this purpose and were reachable only from tests.

### Why a bare number is not enough

100% means two different things — "measured, and on target" and "never measured anything" — and the second is the common case:

- battery calibration **never** samples on a DC-coupled system, or under a control mode that does not execute the DP plan verbatim (`zero_grid`, `manual`, and often `hybrid`);
- a PV array with no measured production sensor can never be calibrated at all.

So each correction also publishes `samples`, `applied` (a battery correction within noise of nominal is stored but never handed to the optimizer; a PV correction needs a full sample window first) and `last_result` — the reason the most recent attempt took no sample. The reasons are tracked through the early returns in `_update_eff_calibration` and through the PV snapshot/score pair.

`pv_calibration` now also covers **every** configured array rather than only those with a meter — leaving the uncalibrated ones out of the report is precisely what hides the cause.

### Diagnostics + analyzer

- `diagnostics.py` gains `forecast.pv_calibration` (keyed by array title, not subentry ID) and the new battery fields.
- New **Learned Calibration** card in the analyzer covering both batteries and every array.
- The efficiency card no longer renders an unmeasured correction as `100.0% (n=0)` — it now says `not learned yet`.

Rendered from a synthetic diagnostics payload:

```
Battery charge efficiency       94.0% (n=12)  applied
Battery discharge efficiency   100.0% (n=0)   not learned · dc coupled pv
PV forecast · South Array       87.0% (n=64)  applied
PV forecast · East Array       100.0% (n=0)   not learned · no measured production sensor
```

### Not included

A per-battery efficiency correction. The DP works on the aggregated battery configuration and there is only one correction per direction; a per-battery figure would suggest a number that does not exist.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [x] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`)
- [x] Tests added or updated where applicable — new cases in `test_sensor.py`, `test_coordinator_optimization.py`, `test_coordinator_forecast.py`, `test_diagnostics.py`, plus a new jsdom test that drives the analyzer's own render path and asserts an unmeasured correction is never shown as 100%
- [x] Documentation updated if needed — `docs/how-it-works.md` documents the three sensors, their attributes and what each blocking reason means. No algorithm change, so `docs/algorithm.md`, `optimizer.py` and its two mirror implementations are untouched; `simulate_diagnostics.py` reads the diagnostics fields it already knew about and is unaffected by the additions.
- [ ] CI is green — pending
- [x] PR targets the `dev` branch

## Logs

```
python -m pytest tests/    → 940 passed, coverage 95.64% (floor 90%)
npx jest                   → 78 passed (4 suites)
pre-commit run --all-files → all hooks pass (mypy hook needs py3.14, run separately)
mypy custom_components/battery_controller/ → Success: no issues found in 19 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mvPfsVaWUqdFdkWczxfGa
