### PR TITLE
fix: anchor the historical price model on real timestamps

### DIFF
--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -73,7 +73,6 @@ from .helpers import (
     compute_step_durations_hours,
     extract_price_forecast_with_timestamps,
     get_sensor_value,
-    resample_forecast,
     resample_to_steps,
     state_has_value,
     usable_state,
@@ -2176,52 +2175,93 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         ):
             self.hass.async_create_task(self._async_save_discharge_eff_calibration())
 
+    def _weather_hour_offset(self, weather: dict[str, Any], target: datetime) -> int:
+        """Index into the weather series for the hour containing ``target``.
+
+        The weather series is anchored to the hour of its own last fetch, which
+        is up to one refresh interval behind the optimizer run. Deriving the
+        offset from that anchor — rather than assuming element 0 is the current
+        hour — keeps the model's GHI/wind features on the hours they describe.
+        """
+        start = weather.get("forecast_start_utc")
+        if isinstance(start, str):
+            start = dt_util.parse_datetime(start)
+        if not isinstance(start, datetime):
+            # No anchor published: fall back to the current hour, which is what
+            # the weather coordinator writes when it does publish one.
+            start = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        offset = int(
+            (dt_util.as_utc(target) - dt_util.as_utc(start)).total_seconds() // 3600
+        )
+        return max(0, offset)
+
+    def _model_series(
+        self,
+        model: PriceForecastModel,
+        step_starts: list[datetime],
+        step_durations_hours: list[float],
+    ) -> list[float]:
+        """Project the historical model's hourly prediction onto step windows.
+
+        The model is asked for the hours the steps actually occupy, its weather
+        features are sliced to the same instant, and its hourly output is
+        projected back onto the step windows. Anchoring on real timestamps is
+        what keeps the prediction on the hours it describes: deriving the anchor
+        from a step count instead placed the series up to a full hour late
+        whenever the steps did not start on the hour — which is every run with a
+        15-minute price sensor, and moved the next day's charge and discharge
+        windows with it.
+        """
+        if not step_starts:
+            return []
+        weather = self.weather_coordinator.data or {}
+        # The model buckets by local hour-of-day and weekday, so the anchor is
+        # the start of the local hour containing the first step.
+        model_start = dt_util.as_local(step_starts[0]).replace(
+            minute=0, second=0, microsecond=0
+        )
+        last_duration = step_durations_hours[-1] if step_durations_hours else 1.0
+        horizon_end = step_starts[-1] + timedelta(hours=last_duration)
+        span_s = (horizon_end - model_start).total_seconds()
+        total_hours = max(1, int(-(-span_s // 3600)))  # ceiling
+        offset = self._weather_hour_offset(weather, model_start)
+        ghi = weather.get("radiation_forecast", [])
+        wind = weather.get("wind_speed_forecast", [])
+        raw = model.forecast(
+            hours=total_hours,
+            start_time=model_start,
+            ghi_forecast=ghi[offset:] if ghi else None,
+            wind_forecast=wind[offset:] if wind else None,
+        )
+        series = resample_to_steps(
+            raw, model_start, 60, step_starts, step_durations_hours
+        )
+        # A step past the end of the model output keeps the last known value:
+        # both callers need one value per step, and the model can only run out
+        # at the very end of the horizon.
+        while len(series) < len(step_starts):
+            series.append(series[-1] if series else 0.0)
+        return series[: len(step_starts)]
+
     def _model_extension(
         self,
         model: PriceForecastModel,
-        steps_covered: int,
+        extension_start: datetime,
         steps_needed: int,
         interval_minutes: int,
     ) -> list[float]:
         """Extend a price series past the live forecast with a historical model.
 
-        ``steps_covered`` steps are already covered, so the model is asked for
-        the hours after them and the weather series are sliced to the same
-        offset — the model's GHI/wind features must line up with the hours it
-        is predicting.
+        ``extension_start`` is the start of the first step the extension fills;
+        the steps after it follow at one price period each.
         """
-        hours_already = int(steps_covered * interval_minutes / 60)
-        hours_for_model = (steps_needed * interval_minutes + 59) // 60  # ceiling
-        extension_start = dt_util.now().replace(
-            minute=0, second=0, microsecond=0
-        ) + timedelta(hours=hours_already)
-        weather = self.weather_coordinator.data or {}
-        ghi = weather.get("radiation_forecast", [])
-        wind = weather.get("wind_speed_forecast", [])
-        raw = model.forecast(
-            hours=hours_for_model,
-            start_time=extension_start,
-            ghi_forecast=ghi[hours_already:] if ghi else None,
-            wind_forecast=wind[hours_already:] if wind else None,
+        step_starts = [
+            extension_start + timedelta(minutes=i * interval_minutes)
+            for i in range(steps_needed)
+        ]
+        return self._model_series(
+            model, step_starts, [interval_minutes / 60.0] * steps_needed
         )
-        return resample_forecast(raw, 60, interval_minutes)[:steps_needed]
-
-    def _model_reference_series(
-        self, model: PriceForecastModel, n_steps: int, interval_minutes: int
-    ) -> list[float]:
-        """What the historical model predicts for the horizon being optimized.
-
-        Published alongside the live prices so users can compare prediction
-        against actual; it never feeds the optimizer.
-        """
-        weather = self.weather_coordinator.data or {}
-        total_hours = (n_steps * interval_minutes + 59) // 60
-        raw = model.forecast(
-            hours=total_hours,
-            ghi_forecast=weather.get("radiation_forecast"),
-            wind_forecast=weather.get("wind_speed_forecast"),
-        )
-        return resample_forecast(raw, 60, interval_minutes)[:n_steps]
 
     def _resolve_effective_mode(
         self,
@@ -2688,11 +2728,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if len(resampled_prices) < min_horizon_steps and self._price_model.has_data():
             steps_needed = min_horizon_steps - len(resampled_prices)
             original_steps = len(resampled_prices)
+            # The extension starts one price period after the last live step,
+            # and the model must be anchored on that same instant.
+            last_ts = price_start_times[-1] if price_start_times else now_utc
+            extension_start = last_ts + timedelta(minutes=price_interval)
             resampled_prices = resampled_prices + self._model_extension(
-                self._price_model, original_steps, steps_needed, price_interval
+                self._price_model, extension_start, steps_needed, price_interval
             )
             # Synthesise timestamps for the extension steps
-            last_ts = price_start_times[-1] if price_start_times else now_utc
             for i in range(1, len(resampled_prices) - original_steps + 1):
                 price_start_times.append(
                     last_ts + timedelta(minutes=i * price_interval)
@@ -2703,14 +2746,6 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 "Extended price horizon from %d to %d steps with historical model",
                 original_steps,
                 len(resampled_prices),
-            )
-
-        # Generate model forecast for price accuracy comparison.
-        # Always computed when live prices are used, so users can compare prediction vs actual.
-        price_forecast_model: list[float] | None = None
-        if self._price_model.has_data() and price_forecast_source.startswith("live"):
-            price_forecast_model = self._model_reference_series(
-                self._price_model, len(resampled_prices), price_interval
             )
 
         # Compute per-step durations: first step = remaining time in current price period,
@@ -2743,6 +2778,16 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 step_starts[-1] + timedelta(minutes=price_interval)
                 if step_starts
                 else now_utc
+            )
+
+        # Generate model forecast for price accuracy comparison. Always computed
+        # when live prices are used, so users can compare prediction vs actual.
+        # Projected onto the DP step windows, which is why it is built here and
+        # not next to the horizon extension above.
+        price_forecast_model: list[float] | None = None
+        if self._price_model.has_data() and price_forecast_source.startswith("live"):
+            price_forecast_model = self._model_series(
+                self._price_model, step_starts, step_durations_hours
             )
 
         resampled_feed_in = None
@@ -2821,13 +2866,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if resampled_feed_in and len(resampled_feed_in) < n_steps:
             steps_needed = n_steps - len(resampled_feed_in)
             if feed_in_is_dynamic and self._feed_in_price_model.has_data():
-                # Own feed-in model has historical data — use it directly.
+                # Own feed-in model has historical data — use it directly. The
+                # feed-in series is already projected onto the DP step windows,
+                # so the extension picks up at the first step it does not cover.
                 resampled_feed_in.extend(
-                    self._model_extension(
+                    self._model_series(
                         self._feed_in_price_model,
-                        len(resampled_feed_in),
-                        steps_needed,
-                        price_interval,
+                        step_starts[len(resampled_feed_in) :],
+                        step_durations_hours[len(resampled_feed_in) :],
                     )
                 )
                 _LOGGER.debug(
@@ -2854,8 +2900,8 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             and price_forecast_source.startswith("live")
             and self._feed_in_price_model.has_data()
         ):
-            feed_in_price_forecast_model = self._model_reference_series(
-                self._feed_in_price_model, len(resampled_prices), price_interval
+            feed_in_price_forecast_model = self._model_series(
+                self._feed_in_price_model, step_starts, step_durations_hours
             )
 
         # Get current battery state

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -591,8 +591,19 @@ PV production and household consumption forecasts are emitted by the forecast co
 
 The optimization coordinator resamples from the pipeline's native interval (published as `forecast_interval_minutes` in the coordinator data; 60 is assumed for data from older versions) to the price interval:
 
-- `resample_forecast(pv_forecast_kw, forecast_interval_minutes, price_interval)` — repetition when upsampling, weighted-average when downsampling
-- Because the forecast series starts at the current quarter-hour (not the current hour), step k of the forecast aligns with price period k for 15-minute price intervals — previously hourly-based series could be misaligned by up to 45 minutes at hour boundaries
+- `resample_to_steps(pv_forecast_kw, forecast_start_utc, forecast_interval_minutes, step_starts, step_durations_hours)` — each DP step takes the duration-weighted average of the source intervals its own window overlaps
+- The projection is by timestamp, not by interval length, because the two series have different anchors: the forecast series starts at the current quarter-hour, while step k starts at a price-period boundary and step 0 is the shortened remainder of the current period. Resampling by interval length alone shifted the whole series by up to 45 minutes at hour boundaries
+
+### Historical-model alignment
+
+The historical price model predicts **per local hour** (its lookup key is hour-of-day × weekday × GHI bin × wind bin). Both places its output is used are anchored on real timestamps rather than on a step count:
+
+- **Horizon extension** — the model starts at the first step the live forecast does not cover (`last live period start + price_interval`), and its hourly output is projected onto those step windows with `resample_to_steps`.
+- **Reference series** (`price_forecast_predicted` / `feed_in_price_forecast_predicted`, published for prediction-vs-actual comparison; never an optimizer input) — the model starts at the local hour containing step 0 and is projected onto the DP's own step grid.
+
+The weather features are sliced from the weather coordinator's own `forecast_start_utc`, so the GHI/wind values handed to the model belong to the hours it is predicting even when the weather series was fetched in an earlier hour.
+
+Anchoring on a step count instead breaks this whenever the live prices do not cover a whole number of hours from the top of the current hour — the normal case for a 15-minute price sensor publishing through midnight — and shifts the entire modelled tail up to a full hour, which moves the next day's charge and discharge windows with it.
 
 ### Past-entry exclusion for timestamp-bearing sensors
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -92,6 +92,10 @@ flowchart TD
 ```
 
 The same model **extends the planning horizon** when live prices cover less than 24 hours.
+The modelled hours are anchored to the first hour the live prices do not cover, so the
+predicted price curve stays on the clock — the cheap and expensive windows it fills in sit
+at the hours the model actually predicts for them.
+
 It builds lookup tables from data in the Home Assistant recorder, keyed on:
 
 - hour of day

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -71,7 +71,6 @@ class OptimizationRunHarness:
         self.entry_options: dict[str, Any] = {}
         self.price_model_has_data = False
         self.feed_in_model_has_data = False
-        self.passthrough_resample = True
         # Leave compute_step_durations_hours alone when a test is about
         # the real step windows (a shortened first step, for instance).
         self.real_step_durations = False
@@ -174,11 +173,6 @@ class OptimizationRunHarness:
             mp.setattr(
                 f"{module}.compute_step_durations_hours", lambda *a: self._durations()
             )
-        if self.passthrough_resample:
-            mp.setattr(
-                f"{module}.resample_forecast", lambda values, src, dst: list(values)
-            )
-
         mp.setattr(coord, "_refresh_battery_config", lambda: None)
         mp.setattr(coord, "get_current_battery_state", lambda: self.battery_state)
         mp.setattr(coord, "_get_realtime_grid_w", lambda: self.grid_w)

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -60,6 +60,7 @@ from custom_components.battery_controller.const import CONF_BATTERY_POWER_SENSOR
 from custom_components.battery_controller.const import CONF_MANUAL_POWER_SETPOINT_W
 from custom_components.battery_controller.const import MODE_MANUAL
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
 from unittest.mock import AsyncMock
 from unittest.mock import patch as upatch
 
@@ -3312,10 +3313,6 @@ async def _run_hybrid_charge_case(hass, monkeypatch, grid_w: float):
         lambda *a: [1.0, 1.0],
     )
     monkeypatch.setattr(
-        "custom_components.battery_controller.coordinator_optimization.resample_forecast",
-        lambda values, src, dst: list(values),
-    )
-    monkeypatch.setattr(
         "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
         lambda: fixed_now,
     )
@@ -3419,10 +3416,6 @@ async def _run_hybrid_mode_sequence(
     monkeypatch.setattr(
         "custom_components.battery_controller.coordinator_optimization.compute_step_durations_hours",
         lambda *a: [1.0, 1.0],
-    )
-    monkeypatch.setattr(
-        "custom_components.battery_controller.coordinator_optimization.resample_forecast",
-        lambda values, src, dst: list(values),
     )
     monkeypatch.setattr(
         "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
@@ -3921,7 +3914,6 @@ async def test_pv_forecast_aligned_to_price_steps_on_mid_period_run(
     h.price_start_times = [
         datetime(2026, 3, 21, 10 + i, 0, 0, tzinfo=timezone.utc) for i in range(3)
     ]
-    h.passthrough_resample = False
     h.real_step_durations = True
     h.forecast_data = {
         # Quarter-hourly from 10:30: 1 kW until 11:00, then 5 kW, then 9 kW.
@@ -3941,6 +3933,150 @@ async def test_pv_forecast_aligned_to_price_steps_on_mid_period_run(
     assert h.captured["durations"][:3] == pytest.approx([0.5, 1.0, 1.0])
     # Each step gets the production of its OWN window, not the next half hour.
     assert h.captured["pv"][:3] == pytest.approx([1.0, 5.0, 9.0])
+
+
+# ---------------------------------------------------------------------------
+# Historical price model alignment
+# ---------------------------------------------------------------------------
+
+
+def _hour_coded_model(recorder: list[dict] | None = None):
+    """Price model whose forecast encodes the local hour it is predicting.
+
+    Local hour H becomes 1.0 + H/100 EUR/kWh, so any misalignment between the
+    hours the model is asked for and the steps its answer lands on is directly
+    readable from the resulting series. The model buckets by local hour-of-day,
+    which is why the coding is local too.
+    """
+
+    def _forecast(hours, start_time=None, ghi_forecast=None, wind_forecast=None):
+        if recorder is not None:
+            recorder.append(
+                {
+                    "hours": hours,
+                    "start_time": start_time,
+                    "ghi_forecast": ghi_forecast,
+                    "wind_forecast": wind_forecast,
+                }
+            )
+        # Same default as PriceForecastModel.forecast: the current local hour.
+        start = start_time or dt_util.now().replace(minute=0, second=0, microsecond=0)
+        return [1.0 + (start + timedelta(hours=h)).hour / 100 for h in range(hours)]
+
+    model = MagicMock()
+    model.has_data = lambda: True
+    model.forecast = _forecast
+    return model
+
+
+def _quarter_hourly_day_ahead_run(h) -> None:
+    """Set up a run like a 15-minute price sensor published through midnight.
+
+    13:22 local, prices known through 23:45 local: 43 live steps covering a
+    non-integral number of hours from the top of the current hour. The
+    remaining 101 steps of the 36-hour horizon come from the price model.
+    """
+    h.now = datetime(2026, 8, 12, 11, 22, 34, tzinfo=timezone.utc)
+    h.price_interval = 15
+    h.price_start_times = [
+        datetime(2026, 8, 12, 11, 15, tzinfo=timezone.utc) + timedelta(minutes=15 * i)
+        for i in range(43)
+    ]
+    h.prices = [0.20] * 43
+    h.price_model_has_data = True
+    h.real_step_durations = True
+    h.forecast_data = {
+        "pv_forecast_kw": [0.0] * 144,
+        "consumption_forecast_kw": [0.5] * 144,
+        "forecast_interval_minutes": 15,
+        "forecast_start_utc": h.now,
+        "current_pv_kw": 0.0,
+        "current_dc_pv_kw": 0.0,
+        "current_consumption_kw": 0.5,
+    }
+    h.result = _make_fake_result(
+        mode_schedule=["idle"] * 144, soc_schedule_kwh=[5.0] * 145
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_extension_lands_on_the_hours_it_predicts(hass, optimization_run):
+    """The modelled tail must not be shifted off the steps it fills.
+
+    A 15-minute price sensor publishing through the end of the day leaves a
+    live series covering a non-integral number of hours from the top of the
+    current hour. Deriving the model's start from that step count (instead of
+    from the first uncovered step's own timestamp) placed the whole modelled
+    tail an hour late, moving the next day's charge and discharge windows with
+    it.
+    """
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    h = optimization_run()
+    _quarter_hourly_day_ahead_run(h)
+    h.coord._price_model = _hour_coded_model()
+
+    data = await h.run()
+
+    prices = h.captured["prices"]
+    # 36 hours of horizon at 15 minutes per step.
+    assert len(prices) == 144
+    # Steps 0..42 are the live prices; the model fills the rest, starting at
+    # the step right after the last live one — 00:00 local, not 23:00.
+    assert prices[:43] == [0.20] * 43
+    assert prices[43:47] == pytest.approx([1.00] * 4)
+    # Each following hour keeps its own value, four steps at a time.
+    assert prices[47:51] == pytest.approx([1.01] * 4)
+    assert prices[51:55] == pytest.approx([1.02] * 4)
+    # And the tail of the horizon is still on the hour: step 143 starts at
+    # 01:00 local on the day after tomorrow.
+    assert prices[143] == pytest.approx(1.01)
+
+    # The reference series published for comparison follows the same grid.
+    model_series = data["price_forecast_model"]
+    assert len(model_series) == 144
+    # Step 0 is the 13:22-13:30 remainder of the current period, still hour 13.
+    assert model_series[0] == pytest.approx(1.13)
+    # Step 3 starts at 14:00 — the hour must turn over with the clock, not one
+    # step later because step 0 was a partial period.
+    assert model_series[2] == pytest.approx(1.13)
+    assert model_series[3] == pytest.approx(1.14)
+    assert model_series[43] == pytest.approx(1.00)
+
+
+@pytest.mark.asyncio
+async def test_model_extension_slices_weather_from_its_own_anchor(
+    hass, optimization_run
+):
+    """GHI/wind must be sliced relative to the weather series' own start.
+
+    The weather coordinator refreshes on its own schedule and anchors its
+    series to the hour of its last fetch, which can be an hour behind the
+    optimizer run. Assuming element 0 is the current hour fed the model the
+    wrong hours' weather.
+    """
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    calls: list[dict] = []
+    h = optimization_run()
+    _quarter_hourly_day_ahead_run(h)
+    h.coord._price_model = _hour_coded_model(calls)
+    # Weather last fetched at 10:00 UTC — an hour before the run. Element i is
+    # the hour 10:00 + i, so the extension starting at 22:00 UTC needs element
+    # 12 and the reference series, starting at 11:00 UTC, element 1.
+    h.coord.weather_coordinator.data = {
+        "forecast_start_utc": datetime(2026, 8, 12, 10, 0, tzinfo=timezone.utc),
+        "radiation_forecast": [float(i) for i in range(48)],
+        "wind_speed_forecast": [float(i) / 10 for i in range(48)],
+    }
+
+    await h.run()
+
+    by_start = {dt_util.as_utc(c["start_time"]): c for c in calls}
+    extension = by_start[datetime(2026, 8, 12, 22, 0, tzinfo=timezone.utc)]
+    assert extension["ghi_forecast"][0] == pytest.approx(12.0)
+    assert extension["wind_forecast"][0] == pytest.approx(1.2)
+    reference = by_start[datetime(2026, 8, 12, 11, 0, tzinfo=timezone.utc)]
+    assert reference["ghi_forecast"][0] == pytest.approx(1.0)
+    assert reference["wind_forecast"][0] == pytest.approx(0.1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The next day's charge and discharge windows were shifted a full hour whenever the modelled part of the horizon was in play. Diagnosed from a diagnostics dump: for all 101 model-filled steps, `price_forecast[H] == model_prediction[H − 1 hour]`, exactly, with zero exceptions. The plan charged 13:00–17:00 while the model's cheap block was 12:00–16:00, and put the heaviest discharge at 22:00 instead of the predicted 21:00 peak.

**Cause.** The horizon extension anchored the model on a step count from the top of the current hour:

```python
hours_already = int(steps_covered * interval_minutes / 60)
extension_start = now.replace(minute=0) + timedelta(hours=hours_already)
```

With a 15-minute price sensor publishing through midnight, neither half holds. A run at 13:22 with prices known through 23:45 has 43 live steps starting at 13:15, so the extension begins at 00:00 — but the anchor is 13:00 and `int(10.75)` drops to 10, asking the model for 23:00 onward. The GHI/wind slice used the same step count while the weather series is anchored to its own last fetch, so a weather refresh in the previous hour shifted the model's features as well. With hourly prices the arithmetic happened to come out exact, which is why this stayed hidden.

**Fix.** Both uses of the model — the horizon extension and the reference series published for prediction-vs-actual comparison — now go through one helper that takes the step windows it must fill, anchors the model on the local hour containing the first of them, slices the weather from the weather coordinator's own `forecast_start_utc`, and projects the hourly output back onto those windows with `resample_to_steps`. That also fixes the reference series (`price_forecast_predicted`) being one step late whenever step 0 is the shortened remainder of the current price period.

The DP itself is untouched; only the price series handed to it changes. The same helper now serves the feed-in model's horizon extension, which had the identical step-count anchor.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

Two regression tests reproduce the reported run (13:22 Europe/Amsterdam, 43 live quarter-hourly steps, 101 modelled) against a price model whose forecast encodes the local hour it predicts, so any misalignment is readable straight off the series:

- `test_model_extension_lands_on_the_hours_it_predicts` — the modelled tail starts at 00:00 local, each hour holds its own value for four steps, and the reference series turns over with the clock rather than one step late. Fails on the old code with `1.21` where `1.00` belongs.
- `test_model_extension_slices_weather_from_its_own_anchor` — with the weather fetched an hour before the run, the extension gets element 12 and the reference series element 1.

`946 passed`; `pre-commit run --all-files` clean (mypy hook needs Python 3.14, run separately: `Success: no issues found in 19 source files`).

Docs: `docs/algorithm.md` gains a *Historical-model alignment* subsection stating the invariant, and the neighbouring resampling bullets were corrected to describe `resample_to_steps`, which the code has used for a while. `docs/how-it-works.md` notes the anchoring in the price-model section.

