### PR TITLE
fix: measure each battery's efficiency, and let the PV gain be evidence

### DIFF
--- a/custom_components/battery_controller/const.py
+++ b/custom_components/battery_controller/const.py
@@ -322,9 +322,18 @@ MAX_PLAUSIBLE_CONSUMPTION_KW = 50.0
 # see docs/algorithm.md.
 # Samples are only taken in a middle band of the array's rating: below the
 # floor the signal is smaller than the noise, above the ceiling inverter
-# clipping and thermal derating dominate and are not forecast errors.
+# clipping dominates and is not a forecast error.
+#
+# The ceiling is a proxy for where an inverter starts clipping, so it has to sit
+# above what an array genuinely reaches. A well-oriented array peaks near 0.85
+# of its rating on a clear summer day, so the old 0.80 ceiling excluded exactly
+# the steps with the best signal-to-noise ratio: a south array learned nothing
+# at midday and everything from its oblique, diffuse-dominated hours — where the
+# transposition model is weakest — and that error then became the gain applied
+# all day. Typical DC/AC ratios of 1.1-1.2 put real clipping at 0.83-0.91, so
+# 0.90 keeps clipped steps out while letting the informative ones in.
 PV_CALIBRATION_MIN_LOAD_FRACTION = 0.10
-PV_CALIBRATION_MAX_LOAD_FRACTION = 0.80
+PV_CALIBRATION_MAX_LOAD_FRACTION = 0.90
 # Energy-weighted over this many samples (a few days of daylight at 15 min),
 # so cloudy low-signal steps cannot dominate the estimate.
 PV_CALIBRATION_WINDOW = 200
@@ -334,8 +343,18 @@ PV_CALIBRATION_MAX_SAMPLE_RATIO = 5.0
 # Bounds on the factor actually applied to a forecast.
 PV_CALIBRATION_APPLY_MIN = 0.5
 PV_CALIBRATION_APPLY_MAX = 1.5
+# A correction this close to nominal is within measurement noise: the forecast
+# is left alone and the array is reported as uncorrected. One constant for both
+# so what the sensor claims and what the forecast does cannot drift apart.
+PV_CALIBRATION_APPLY_EPSILON = 0.005
 # Minimum samples before the correction is used at all.
-PV_CALIBRATION_MIN_SAMPLES = 20
+#
+# What separates a gain error from the weather is sample count: an array that
+# only ever samples in one part of the day picks up the radiation forecast's
+# bias for those hours, and at 20 samples (5 hours of production, one afternoon)
+# that bias *is* the correction. 60 in-band quarter-hours span several days, so
+# cloud timing averages out and what is left is the systematic part.
+PV_CALIBRATION_MIN_SAMPLES = 60
 
 # Real-time control thresholds
 BATTERY_MODE_THRESHOLD_W = 50.0  # W — battery power above/below this sets mode

--- a/custom_components/battery_controller/coordinator_forecast.py
+++ b/custom_components/battery_controller/coordinator_forecast.py
@@ -28,6 +28,7 @@ from .const import (
     DC_TO_AC_INVERTER_EFFICIENCY,
     DOMAIN,
     FORECAST_INTERVAL_MINUTES,
+    PV_CALIBRATION_APPLY_EPSILON,
     PV_CALIBRATION_APPLY_MAX,
     PV_CALIBRATION_APPLY_MIN,
     PV_CALIBRATION_MAX_LOAD_FRACTION,
@@ -63,6 +64,11 @@ PV_CAL_WINDOW_MISMATCH = "forecast_window_did_not_elapse"
 PV_CAL_CURTAILED = "pv_curtailed"
 PV_CAL_METER_RESET = "production_counter_reset"
 PV_CAL_IMPLAUSIBLE = "sample_dropped_implausible"
+
+
+def _pv_gain_is_significant(correction: float) -> bool:
+    """Whether a learned gain is far enough from nominal to change anything."""
+    return abs(correction - 1.0) > PV_CALIBRATION_APPLY_EPSILON
 
 
 class ForecastCoordinator(DataUpdateCoordinator):
@@ -261,10 +267,14 @@ class ForecastCoordinator(DataUpdateCoordinator):
     def pv_correction_applied(self, subentry_id: str) -> bool:
         """Whether one array's forecast is currently being corrected.
 
-        A correction is only derived once PV_CALIBRATION_MIN_SAMPLES
-        observations exist, so this stays False while the window fills.
+        This answers the question the user actually has — is my forecast being
+        changed right now — so it shares its gate with ``_sum_arrays``: a
+        correction has to be derived *and* be far enough from nominal to matter.
+        Membership of ``_pv_cal_correction`` alone was not enough. A correction
+        is only derived once PV_CALIBRATION_MIN_SAMPLES observations exist, so
+        this stays False while the window fills.
         """
-        return subentry_id in self._pv_cal_correction
+        return _pv_gain_is_significant(self.pv_correction(subentry_id))
 
     def pv_last_result(self, subentry_id: str) -> str:
         """What the last calibration attempt for one array did, and why."""
@@ -273,7 +283,15 @@ class ForecastCoordinator(DataUpdateCoordinator):
         return self._pv_cal_last_result.get(subentry_id, PV_CAL_OUTSIDE_LOAD_BAND)
 
     async def _async_load_pv_calibration(self) -> None:
-        """Restore per-array PV corrections from storage."""
+        """Restore per-array PV corrections from storage.
+
+        Only a correction that the sample floor actually backs is restored. The
+        samples of every array are persisted — including arrays still filling
+        their window — and reading those entries back unconditionally handed
+        each of them a correction of 1.0, which made ``pv_correction_applied``
+        report True for an array that had never derived anything. The value was
+        harmless; the claim was not.
+        """
         stored = await self._pv_cal_store.async_load()
         if not stored:
             return
@@ -283,7 +301,8 @@ class ForecastCoordinator(DataUpdateCoordinator):
                 ((float(m), float(f)) for m, f in samples),
                 maxlen=PV_CALIBRATION_WINDOW,
             )
-            self._pv_cal_correction[sid] = float(entry.get("correction", 1.0))
+            if len(self._pv_cal_samples[sid]) >= PV_CALIBRATION_MIN_SAMPLES:
+                self._pv_cal_correction[sid] = float(entry.get("correction", 1.0))
         active = {
             sid: round(c, 3)
             for sid, c in self._pv_cal_correction.items()
@@ -360,6 +379,13 @@ class ForecastCoordinator(DataUpdateCoordinator):
             # The window the forecast described is not the window that elapsed.
             self._set_pv_results(planned_by_sid, PV_CAL_WINDOW_MISMATCH)
             return
+        # Within that band the window still rarely lasts exactly one step: a
+        # weather update refreshes this coordinator off its own cadence, so the
+        # meter delta can cover 20 minutes while the snapshot describes 15. The
+        # planned energy is the first step's power held over the window, so it
+        # has to be stretched to the window that was actually measured —
+        # otherwise a late run alone reads as a +33 % array.
+        elapsed_scale = elapsed_min / step_min
 
         if self.pv_curtailed:
             # Production was deliberately suppressed; the shortfall is not a
@@ -368,7 +394,8 @@ class ForecastCoordinator(DataUpdateCoordinator):
             return
 
         changed = False
-        for sid, planned_kwh in planned_by_sid.items():
+        for sid, snapshot_kwh in planned_by_sid.items():
+            planned_kwh = snapshot_kwh * elapsed_scale
             entity_id = self._pv_measured_sensors.get(sid)
             before = (snapshot["meter_kwh"] or {}).get(sid)
             if not entity_id or before is None or planned_kwh <= 0:
@@ -729,7 +756,7 @@ class ForecastCoordinator(DataUpdateCoordinator):
                     raw_first_step_kw[sid] = series[0] if series else 0.0
                     kwp_by_sid[sid] = model.peak_power_kwp
                 gain = self.pv_correction(sid)
-                if gain != 1.0:
+                if _pv_gain_is_significant(gain):
                     series = [v * gain for v in series]
                 if sid:
                     per_pv_array_forecasts[sid] = [

--- a/custom_components/battery_controller/coordinator_optimization.py
+++ b/custom_components/battery_controller/coordinator_optimization.py
@@ -21,16 +21,22 @@ from homeassistant.util import dt as dt_util
 from .battery_dispatch import BatteryDispatcher
 from .battery_model import BatteryConfig, BatteryState, aggregate_battery_configs
 from .efficiency_calibration import (
+    CALIBRATION_APPLY_THRESHOLD,
     CALIBRATION_DC_COUPLED,
     CALIBRATION_DELTA_TOO_SMALL,
     CALIBRATION_DERATING,
     CALIBRATION_NO_PLAN,
     CALIBRATION_NO_RESULT,
+    CALIBRATION_NOT_DISPATCHED,
     CALIBRATION_PLAN_NOT_EXECUTED,
     CALIBRATION_STEP_INCOMPLETE,
     CHARGE_CALIBRATION,
     DISCHARGE_CALIBRATION,
+    BatteryCalibration,
+    CalibrationSpec,
     DirectionCalibration,
+    aggregate_correction,
+    aggregate_last_result,
     charge_curve_override,
     counter_delta_kwh,
     discharge_curve_override,
@@ -53,6 +59,9 @@ from .const import (
     CONF_FIXED_FEED_IN_PRICE,
     CONF_MANUAL_POWER_SETPOINT_W,
     CONF_MIN_PRICE_SPREAD,
+    CONF_NAME,
+    CONF_TIME_STEP_MINUTES,
+    DEFAULT_TIME_STEP_MINUTES,
     CONF_POWER_CONSUMPTION_SENSORS,
     CONF_POWER_PRODUCTION_SENSORS,
     CONF_PRICE_SENSOR,
@@ -298,34 +307,132 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         self._optimizer_run_log: deque[dict[str, Any]] = deque(maxlen=96)
         self._setpoint_log: deque[dict[str, Any]] = deque(maxlen=576)
 
-        # Efficiency calibration, one per direction: a rolling window of
-        # (actual_delta / planned_delta) samples collected on steps that planned
-        # that direction. The smoothed correction scales the DP's SoC transition
-        # for that direction only — never the economic cost model — so a
-        # charging-speed problem is not double-counted as extra energy cost.
-        # Only non-DC-coupled systems are sampled, to avoid confounding with
-        # passive PV. See efficiency_calibration.py.
-        entry_id = config.get("entry_id", "unknown")
-        self._charge_calibration = DirectionCalibration(
-            spec=CHARGE_CALIBRATION,
-            store=storage.Store(hass, 1, f"battery_controller_{entry_id}_charge_eff"),
-        )
-        self._discharge_calibration = DirectionCalibration(
-            spec=DISCHARGE_CALIBRATION,
-            store=storage.Store(
-                hass, 1, f"battery_controller_{entry_id}_discharge_eff"
-            ),
+        # Efficiency calibration, one per direction per battery: a rolling
+        # window of (actual_delta / planned_delta) samples collected on steps
+        # that planned that direction for that pack. The smoothed correction
+        # scales the DP's SoC transition for that direction only — never the
+        # economic cost model — so a charging-speed problem is not
+        # double-counted as extra energy cost. Only non-DC-coupled systems are
+        # sampled, to avoid confounding with passive PV. The DP plans one fleet
+        # SoC, so it is handed the capacity-weighted aggregate of these.
+        # See efficiency_calibration.py.
+        self._battery_calibrations: dict[str, BatteryCalibration] = {
+            sid: self._build_battery_calibration(sid, data)
+            for sid, data in self._battery_subentries
+        }
+
+        # Cumulative throughput counters per battery as they stood when
+        # _last_result was planned, and the SoC each pack held at that moment.
+        # The difference against the next read is the energy that battery
+        # actually moved over the step — a far finer measurement than the SoC
+        # delta, which on a whole-percent sensor quantises at capacity/100
+        # (0.1 kWh on a 10 kWh pack).
+        self._energy_counter_snapshot: dict[str, dict[str, float | None]] = {}
+        self._soc_snapshot_kwh: dict[str, float] = {}
+        # The setpoint each battery was given for the step being scored. The
+        # dispatcher concentrates on one pack at a time, so this is what says
+        # whose plan the measured throughput belongs to.
+        self._last_battery_setpoints: dict[str, float] = {}
+
+    def _build_battery_calibration(
+        self, subentry_id: str, data: dict[str, Any]
+    ) -> BatteryCalibration:
+        """Create one battery's two calibrations, with their own storage keys.
+
+        ``legacy_store`` points at the fleet-wide key these used to share, so a
+        system that has already learned something keeps it as a starting point
+        instead of restarting from nominal. See DirectionCalibration.async_load.
+        """
+        entry_id = self.config.get("entry_id", "unknown")
+        label = str(data.get(CONF_NAME) or subentry_id)
+
+        def _for(spec: CalibrationSpec) -> DirectionCalibration:
+            return DirectionCalibration(
+                spec=spec,
+                store=storage.Store(
+                    self.hass,
+                    1,
+                    f"battery_controller_{entry_id}_{subentry_id}_{spec.name}_eff",
+                ),
+                label=label,
+                legacy_store=storage.Store(
+                    self.hass, 1, f"battery_controller_{entry_id}_{spec.name}_eff"
+                ),
+            )
+
+        return BatteryCalibration(
+            subentry_id=subentry_id,
+            charge=_for(CHARGE_CALIBRATION),
+            discharge=_for(DISCHARGE_CALIBRATION),
         )
 
-        # Cumulative throughput counters as they stood when _last_result was
-        # planned. The difference against the next read is the energy the
-        # battery actually moved over that step — a far finer measurement than
-        # the SoC delta, which on a whole-percent sensor quantises at
-        # capacity/100 (0.1 kWh on a 10 kWh pack).
-        self._energy_counter_snapshot: dict[str, float | None] = {
-            "charged": None,
-            "discharged": None,
+    @property
+    def battery_calibrations(self) -> dict[str, BatteryCalibration]:
+        """Per-battery efficiency calibration, keyed by subentry id."""
+        return self._battery_calibrations
+
+    def battery_calibration_state(
+        self, subentry_id: str, action: str
+    ) -> tuple[float, int, bool, str]:
+        """One battery's (correction, samples, applied, last_result).
+
+        The entity-facing view. ``applied`` is per battery here — whether this
+        pack's own measurement is far enough from nominal to matter — while the
+        fleet sensors report whether the aggregate changes the DP's plan.
+        """
+        calibration = self._battery_calibrations.get(subentry_id)
+        if calibration is None:
+            return (1.0, 0, False, CALIBRATION_NO_RESULT)
+        direction = calibration.for_action(action)
+        return (
+            direction.correction,
+            direction.sample_count,
+            direction.applied,
+            direction.last_result,
+        )
+
+    def battery_calibration_report(self) -> dict[str, dict[str, Any]]:
+        """Every battery's calibration, for diagnostics."""
+        report: dict[str, dict[str, Any]] = {}
+        for sid, data in self._battery_subentries:
+            calibration = self._battery_calibrations.get(sid)
+            if calibration is None:
+                continue
+            entry: dict[str, Any] = {"name": data.get(CONF_NAME) or sid}
+            for direction in calibration.both():
+                entry[direction.spec.name] = {
+                    "correction": round(direction.correction, 4),
+                    "samples": direction.sample_count,
+                    "applied": direction.applied,
+                    "last_result": direction.last_result,
+                }
+            report[sid] = entry
+        return report
+
+    def _direction_calibrations(self, action: str) -> list[DirectionCalibration]:
+        """One direction's calibration for every battery, in configured order."""
+        return [
+            self._battery_calibrations[sid].for_action(action)
+            for sid, _ in self._battery_subentries
+            if sid in self._battery_calibrations
+        ]
+
+    def _aggregate_correction(self, action: str) -> float:
+        """The fleet correction the DP plans with, for one direction."""
+        capacity = {
+            sid: cfg.capacity_kwh for sid, cfg in self._individual_battery_configs
         }
+        weighted: list[tuple[float, float]] = []
+        for sid, _ in self._battery_subentries:
+            calibration = self._battery_calibrations.get(sid)
+            if calibration is None:
+                continue
+            direction = calibration.for_action(action)
+            # A pack that has never sampled carries no evidence, so it gets no
+            # weight rather than a nominal 1.0 that would dilute its sibling.
+            weight = capacity.get(sid, 0.0) if direction.sample_count else 0.0
+            weighted.append((direction.correction, weight))
+        return aggregate_correction(weighted)
 
     @property
     def control_mode(self) -> str:
@@ -395,51 +502,62 @@ class OptimizationCoordinator(DataUpdateCoordinator):
     def charge_eff_correction(self) -> float:
         """Learned multiplier on the charge-side SoC transition (1.0 = nominal).
 
-        Already published in ``data`` and in diagnostics; exposed here so the
-        current value can be read without a completed run, the same way
-        control_mode and optimization_enabled are.
+        The fleet figure the DP plans with: the capacity-weighted aggregate of
+        the per-battery corrections. Already published in ``data`` and in
+        diagnostics; exposed here so the current value can be read without a
+        completed run, the same way control_mode and optimization_enabled are.
         """
-        return self._charge_calibration.correction
+        return self._aggregate_correction(ACTION_CHARGING)
 
     @property
     def charge_eff_sample_count(self) -> int:
-        """Number of observations behind charge_eff_correction."""
-        return self._charge_calibration.sample_count
+        """Observations behind charge_eff_correction, across all batteries."""
+        return sum(
+            cal.sample_count for cal in self._direction_calibrations(ACTION_CHARGING)
+        )
 
     @property
     def discharge_eff_correction(self) -> float:
         """Learned multiplier on the discharge-side SoC transition."""
-        return self._discharge_calibration.correction
+        return self._aggregate_correction(ACTION_DISCHARGING)
 
     @property
     def discharge_eff_sample_count(self) -> int:
-        """Number of observations behind discharge_eff_correction."""
-        return self._discharge_calibration.sample_count
+        """Observations behind discharge_eff_correction, across all batteries."""
+        return sum(
+            cal.sample_count for cal in self._direction_calibrations(ACTION_DISCHARGING)
+        )
 
     @property
     def charge_eff_applied(self) -> bool:
         """Whether the charge correction currently changes the DP's plan.
 
-        The correction is only handed to the optimizer below 0.995: a value at
-        or above that is within measurement noise of nominal and is stored but
-        never applied. Same gate as charge_curve_override().
+        The aggregate is only handed to the optimizer below 0.995: a value at or
+        above that is within measurement noise of nominal and is stored but
+        never applied. Same gate as charge_curve_override(). Judged on the
+        aggregate, because that is what the DP is given — a single derated pack
+        can be applied on its own sensor and still leave the fleet at nominal.
         """
-        return self._charge_calibration.applied
+        return self.charge_eff_correction < CALIBRATION_APPLY_THRESHOLD
 
     @property
     def discharge_eff_applied(self) -> bool:
         """Whether the discharge correction currently changes the DP's plan."""
-        return self._discharge_calibration.applied
+        return self.discharge_eff_correction < CALIBRATION_APPLY_THRESHOLD
 
     @property
     def charge_eff_last_result(self) -> str:
         """What the last charge-calibration attempt did, and why."""
-        return self._charge_calibration.last_result
+        return aggregate_last_result(
+            cal.last_result for cal in self._direction_calibrations(ACTION_CHARGING)
+        )
 
     @property
     def discharge_eff_last_result(self) -> str:
         """What the last discharge-calibration attempt did, and why."""
-        return self._discharge_calibration.last_result
+        return aggregate_last_result(
+            cal.last_result for cal in self._direction_calibrations(ACTION_DISCHARGING)
+        )
 
     @property
     def _individual_battery_configs(self) -> list[tuple[str, BatteryConfig]]:
@@ -460,56 +578,6 @@ class OptimizationCoordinator(DataUpdateCoordinator):
     @_per_battery_states.setter
     def _per_battery_states(self, value: dict[str, BatteryState]) -> None:
         self._dispatcher.states = value
-
-    @property
-    def _charge_eff_samples(self) -> deque[float]:
-        """Charge-side sample window, owned by DirectionCalibration."""
-        return self._charge_calibration.samples
-
-    @_charge_eff_samples.setter
-    def _charge_eff_samples(self, value: deque[float]) -> None:
-        self._charge_calibration.samples = value
-
-    @property
-    def _charge_eff_correction(self) -> float:
-        return self._charge_calibration.correction
-
-    @_charge_eff_correction.setter
-    def _charge_eff_correction(self, value: float) -> None:
-        self._charge_calibration.correction = value
-
-    @property
-    def _discharge_eff_samples(self) -> deque[float]:
-        """Discharge-side sample window, owned by DirectionCalibration."""
-        return self._discharge_calibration.samples
-
-    @_discharge_eff_samples.setter
-    def _discharge_eff_samples(self, value: deque[float]) -> None:
-        self._discharge_calibration.samples = value
-
-    @property
-    def _discharge_eff_correction(self) -> float:
-        return self._discharge_calibration.correction
-
-    @_discharge_eff_correction.setter
-    def _discharge_eff_correction(self, value: float) -> None:
-        self._discharge_calibration.correction = value
-
-    @property
-    def _charge_eff_last_result(self) -> str:
-        return self._charge_calibration.last_result
-
-    @_charge_eff_last_result.setter
-    def _charge_eff_last_result(self, value: str) -> None:
-        self._charge_calibration.last_result = value
-
-    @property
-    def _discharge_eff_last_result(self) -> str:
-        return self._discharge_calibration.last_result
-
-    @_discharge_eff_last_result.setter
-    def _discharge_eff_last_result(self, value: str) -> None:
-        self._discharge_calibration.last_result = value
 
     async def _handle_price_model_refresh(self, now: datetime) -> None:
         """Refresh historical price model from HA recorder (daily timer)."""
@@ -1473,28 +1541,70 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 self.hass.async_create_task(self.async_request_refresh())
 
     async def _async_load_charge_eff_calibration(self) -> None:
-        """Load persisted charge efficiency calibration from storage."""
-        await self._charge_calibration.async_load()
+        """Load every battery's persisted charge calibration from storage."""
+        await asyncio.gather(
+            *(cal.async_load() for cal in self._direction_calibrations(ACTION_CHARGING))
+        )
 
     async def _async_save_charge_eff_calibration(self) -> None:
-        """Persist current charge efficiency calibration to storage."""
-        await self._charge_calibration.async_save()
+        """Persist every battery's charge calibration to storage."""
+        await asyncio.gather(
+            *(cal.async_save() for cal in self._direction_calibrations(ACTION_CHARGING))
+        )
 
     async def async_reset_charge_eff_calibration(self) -> None:
-        """Reset charge-efficiency calibration to the nominal uncorrected state."""
-        await self._charge_calibration.async_reset()
+        """Reset every battery's charge calibration to the nominal state."""
+        await asyncio.gather(
+            *(
+                cal.async_reset()
+                for cal in self._direction_calibrations(ACTION_CHARGING)
+            )
+        )
 
     async def _async_load_discharge_eff_calibration(self) -> None:
-        """Load persisted discharge efficiency calibration from storage."""
-        await self._discharge_calibration.async_load()
+        """Load every battery's persisted discharge calibration from storage."""
+        await asyncio.gather(
+            *(
+                cal.async_load()
+                for cal in self._direction_calibrations(ACTION_DISCHARGING)
+            )
+        )
 
     async def _async_save_discharge_eff_calibration(self) -> None:
-        """Persist current discharge efficiency calibration to storage."""
-        await self._discharge_calibration.async_save()
+        """Persist every battery's discharge calibration to storage."""
+        await asyncio.gather(
+            *(
+                cal.async_save()
+                for cal in self._direction_calibrations(ACTION_DISCHARGING)
+            )
+        )
 
     async def async_reset_discharge_eff_calibration(self) -> None:
-        """Reset discharge-efficiency calibration to the nominal uncorrected state."""
-        await self._discharge_calibration.async_reset()
+        """Reset every battery's discharge calibration to the nominal state."""
+        await asyncio.gather(
+            *(
+                cal.async_reset()
+                for cal in self._direction_calibrations(ACTION_DISCHARGING)
+            )
+        )
+
+    def _read_counter_kwh(self, sensor_id: str) -> float | None:
+        """Read one cumulative energy counter, in kWh."""
+        state = usable_state(self.hass, sensor_id)
+        if state is None:
+            return None
+        try:
+            value = float(state.state)
+        except (ValueError, TypeError):
+            return None
+        unit = str(state.attributes.get("unit_of_measurement") or "kWh")
+        if unit == "Wh":
+            return value / 1000.0
+        if unit == "MWh":
+            return value * 1000.0
+        if unit != "kWh":
+            self._warn_unit_once(sensor_id, unit, "treating value as kWh")
+        return value
 
     def _read_energy_total_kwh(self, conf_key: str) -> float | None:
         """Sum the configured cumulative energy counters, in kWh.
@@ -1508,62 +1618,73 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             return None
         total = 0.0
         for sensor_id in sensor_ids:
-            state = usable_state(self.hass, sensor_id)
-            if state is None:
+            value = self._read_counter_kwh(sensor_id)
+            if value is None:
                 return None
-            try:
-                value = float(state.state)
-            except (ValueError, TypeError):
-                return None
-            unit = str(state.attributes.get("unit_of_measurement") or "kWh")
-            if unit == "Wh":
-                value /= 1000.0
-            elif unit == "MWh":
-                value *= 1000.0
-            elif unit != "kWh":
-                self._warn_unit_once(sensor_id, unit, "treating value as kWh")
             total += value
         return total
 
-    def _read_energy_totals(self) -> dict[str, float | None]:
-        """Read both cumulative throughput counters at one instant."""
+    def _read_energy_totals(self) -> dict[str, dict[str, float | None]]:
+        """Read every battery's throughput counters at one instant.
+
+        Keyed by subentry, because a fleet sum cannot say which pack moved the
+        energy — and with the dispatcher concentrating on one battery at a time,
+        that is exactly the question the calibration asks.
+        """
         return {
-            "charged": self._read_energy_total_kwh(CONF_BATTERY_ENERGY_CHARGED_SENSOR),
-            "discharged": self._read_energy_total_kwh(
-                CONF_BATTERY_ENERGY_DISCHARGED_SENSOR
-            ),
+            sid: {
+                "charged": self._read_counter_kwh(
+                    data.get(CONF_BATTERY_ENERGY_CHARGED_SENSOR) or ""
+                )
+                if data.get(CONF_BATTERY_ENERGY_CHARGED_SENSOR)
+                else None,
+                "discharged": self._read_counter_kwh(
+                    data.get(CONF_BATTERY_ENERGY_DISCHARGED_SENSOR) or ""
+                )
+                if data.get(CONF_BATTERY_ENERGY_DISCHARGED_SENSOR)
+                else None,
+            }
+            for sid, data in self._battery_subentries
         }
+
+    def _battery_soc_quantum_kwh(
+        self, data: dict[str, Any], cfg: BatteryConfig
+    ) -> float:
+        """Resolution of one battery's SoC measurement, in kWh.
+
+        Derived from the decimals the SoC sensor actually reports: a state of
+        "47" is whole-percent, "47.3" is ten times finer. Returns 0.0 when
+        nothing can be determined, which leaves the caller on its fixed floor.
+        """
+        sensor_id = data.get(CONF_BATTERY_SOC_SENSOR)
+        if not sensor_id:
+            return 0.0
+        state = usable_state(self.hass, sensor_id)
+        if state is None:
+            return 0.0
+        raw = state.state.strip()
+        decimals = len(raw.split(".", 1)[1]) if "." in raw else 0
+        step = 10.0**-decimals
+        unit = str(state.attributes.get("unit_of_measurement") or "%")
+        if unit == "kWh":
+            return step
+        if unit == "Wh":
+            return step / 1000.0
+        # percent (or unitless, which is treated as percent elsewhere)
+        return step / 100.0 * cfg.capacity_kwh
 
     def _soc_quantum_kwh(self) -> float:
         """Estimate the resolution of the aggregated SoC measurement, in kWh.
 
-        Derived from the decimals each SoC sensor actually reports: a state of
-        "47" is whole-percent, "47.3" is ten times finer. Summed across packs
-        because the aggregate SoC is a sum and the individual quantisation
-        errors can align. Returns 0.0 when nothing can be determined, which
-        leaves the caller on its fixed floor.
+        Summed across packs because the aggregate SoC is a sum and the
+        individual quantisation errors can align.
         """
-        total = 0.0
-        for (_sid, cfg), (_sid2, data) in zip(
-            self._individual_battery_configs, self._battery_subentries
-        ):
-            sensor_id = data.get(CONF_BATTERY_SOC_SENSOR)
-            if not sensor_id:
-                continue
-            state = usable_state(self.hass, sensor_id)
-            if state is None:
-                continue
-            raw = state.state.strip()
-            decimals = len(raw.split(".", 1)[1]) if "." in raw else 0
-            step = 10.0**-decimals
-            unit = str(state.attributes.get("unit_of_measurement") or "%")
-            if unit == "kWh":
-                total += step
-            elif unit == "Wh":
-                total += step / 1000.0
-            else:  # percent (or unitless, which is treated as percent elsewhere)
-                total += step / 100.0 * cfg.capacity_kwh
-        return total
+        return sum(
+            self._battery_soc_quantum_kwh(data, cfg)
+            for (_sid, cfg), (_sid2, data) in zip(
+                self._individual_battery_configs, self._battery_subentries
+            )
+        )
 
     def _previous_step_complete(self) -> bool:
         """Return whether the previously planned first step has elapsed.
@@ -1624,112 +1745,208 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         tolerance_kw = max(0.05, 0.1 * abs(planned_kw))
         return abs(executed_kw - planned_kw) <= tolerance_kw
 
+    def _fleet_calibration_block(self, action: str) -> str | None:
+        """Why no battery can be sampled for ``action`` this run, if any.
+
+        These conditions are properties of the plan and of the system as a
+        whole, so they are answered once rather than per battery.
+        """
+        result = self._last_result
+        if result is None:
+            return CALIBRATION_NO_RESULT
+        if len(result.mode_schedule) < 1 or len(result.soc_schedule_kwh) < 2:
+            return CALIBRATION_NO_RESULT
+        if result.mode_schedule[0] != action:
+            return CALIBRATION_NO_PLAN
+        # Only sample when the plan was actually commanded; mode resolution
+        # (hybrid → zero_grid, commitment filter, zero_grid/manual control)
+        # would otherwise drag the correction towards the 0.5 clip floor.
+        if not self._planned_first_step_was_executed(action):
+            return CALIBRATION_PLAN_NOT_EXECUTED
+        if not self._previous_step_complete():
+            return CALIBRATION_STEP_INCOMPLETE
+        if self.config.get(CONF_PV_DC_COUPLED, False):
+            return CALIBRATION_DC_COUPLED
+        return None
+
+    def _previous_step_hours(self) -> float:
+        """Length of the step being scored, in hours.
+
+        Falls back to the coordinator's own interval when the plan carried no
+        timing metadata — the same fallback _previous_step_complete makes.
+        """
+        if isinstance(self.data, dict):
+            durations = self.data.get("step_durations_hours")
+            if durations:
+                try:
+                    return float(durations[0])
+                except (TypeError, ValueError, IndexError):
+                    pass
+        return (
+            float(self.config.get(CONF_TIME_STEP_MINUTES, DEFAULT_TIME_STEP_MINUTES))
+            / 60.0
+        )
+
+    def _planned_battery_delta_kwh(
+        self, spec: CalibrationSpec, setpoint_kw: float, cfg: BatteryConfig
+    ) -> float:
+        """SoC change this battery was expected to make over the step, in kWh.
+
+        Derived from the setpoint the dispatcher actually gave this pack and
+        this pack's own efficiency curve at that power — not from the fleet SoC
+        schedule. The dispatcher concentrates a setpoint on one battery at a
+        time, so the fleet plan says nothing about what any single pack was
+        asked to do, and the curves are power-dependent, so a battery running at
+        1.2 kW is not modelled by the fleet's 2.4 kW point.
+        """
+        energy_kwh = abs(setpoint_kw) * self._previous_step_hours()
+        curve = (
+            cfg.charge_efficiency_curve_parsed
+            if spec.action == ACTION_CHARGING
+            else cfg.discharge_efficiency_curve_parsed
+        )
+        scalar = (
+            cfg.charge_efficiency
+            if spec.action == ACTION_CHARGING
+            else cfg.discharge_efficiency
+        )
+        efficiency = (
+            interpolate_efficiency(curve, abs(setpoint_kw)) if curve else float(scalar)
+        )
+        if efficiency <= 0:
+            return 0.0
+        # Charging puts less into the pack than it draws; discharging takes more
+        # out of the pack than it delivers.
+        return (
+            energy_kwh * efficiency
+            if spec.action == ACTION_CHARGING
+            else energy_kwh / efficiency
+        )
+
     def _update_eff_calibration(
         self,
-        calibration: DirectionCalibration,
-        battery_state: BatteryState,
-        energy_totals_now: dict[str, float | None] | None,
+        spec: CalibrationSpec,
+        energy_totals_now: dict[str, dict[str, float | None]] | None,
     ) -> None:
-        """Score the previous plan against reality and fold it in.
+        """Score the previous plan against reality, per battery, and fold it in.
 
-        This method decides *eligibility* and records why on the calibration;
-        DirectionCalibration.record does the arithmetic and the persistence.
+        This method decides *eligibility* and records why on each battery's
+        calibration; DirectionCalibration.record does the arithmetic and the
+        persistence.
 
-        Both directions ask the same question: did the battery move as much
-        energy within the step as the DP assumed? A sample is only taken when:
+        Both directions ask the same question: did this battery move as much
+        energy within the step as the plan assumed? A sample is only taken when:
         - The previous optimizer step planned this direction actively
         - The planned step was actually commanded unchanged (no hybrid/zero_grid
           override, no commitment-filter power lock)
         - The full planned step has elapsed
-        - The planned delta is large enough to be measurable at the resolution
-          of whatever measured it (energy counter or SoC sensor)
         - DC-coupled PV is not active: passive PV charging inflates the measured
           charge delta and offsets the measured discharge delta
-        - The step does not cross the inverter's derating threshold. The DP
-          plans full power for the whole step while the inverter throttles once
+        - The dispatcher gave *this* battery a setpoint in this direction. A
+          pack that sat idle while its sibling did the work has nothing to say
+          about its own efficiency, and attributing the sibling's throughput to
+          it is what a single fleet-wide ratio used to do.
+        - The planned delta is large enough to be measurable at the resolution
+          of whatever measured it (energy counter or SoC sensor)
+        - The step does not cross that battery's derating threshold. The plan
+          holds full power for the whole step while the inverter throttles once
           the threshold is passed mid-step, so the ratio would reflect the
           derating rather than an efficiency loss.
 
-        The correction is the mean of the last CALIBRATION_WINDOW ratios
-        (actual/planned), clamped for use. It is applied as a multiplier on the
-        DP's SoC transition for this direction only; the economic cost model is
-        untouched.
+        Each battery's correction is the mean of its last CALIBRATION_WINDOW
+        ratios, clamped for use; the DP is handed their capacity-weighted
+        aggregate. It scales the SoC transition for this direction only; the
+        economic cost model is untouched.
 
-        When no sample is taken, ``calibration.last_result`` names the reason.
-        Several of those reasons are permanent for a given setup (a DC-coupled
-        system never samples at all, and a control mode that does not execute
-        the DP plan never will either), so the reason is published rather than
-        leaving the user with a sample count stuck at zero.
+        When no sample is taken, ``last_result`` names the reason. Several of
+        those reasons are permanent for a given setup (a DC-coupled system never
+        samples at all, and a control mode that does not execute the DP plan
+        never will either), so the reason is published rather than leaving the
+        user with a sample count stuck at zero.
         """
-        result = self._last_result
-        if result is None:
-            calibration.last_result = CALIBRATION_NO_RESULT
-            return
-        if len(result.mode_schedule) < 1 or len(result.soc_schedule_kwh) < 2:
-            calibration.last_result = CALIBRATION_NO_RESULT
-            return
-        if result.mode_schedule[0] != calibration.spec.action:
-            calibration.last_result = CALIBRATION_NO_PLAN
+        blocked = self._fleet_calibration_block(spec.action)
+        if blocked is not None:
+            for calibration in self._direction_calibrations(spec.action):
+                calibration.last_result = blocked
             return
 
-        # Only sample when the plan was actually commanded; mode resolution
-        # (hybrid → zero_grid, commitment filter, zero_grid/manual control)
-        # would otherwise drag the correction towards the 0.5 clip floor.
-        if not self._planned_first_step_was_executed(calibration.spec.action):
-            calibration.last_result = CALIBRATION_PLAN_NOT_EXECUTED
-            return
-        if not self._previous_step_complete():
-            calibration.last_result = CALIBRATION_STEP_INCOMPLETE
-            return
-        if self.config.get(CONF_PV_DC_COUPLED, False):
-            calibration.last_result = CALIBRATION_DC_COUPLED
-            return
+        for (sid, cfg), (_sid, data) in zip(
+            self._individual_battery_configs, self._battery_subentries
+        ):
+            battery = self._battery_calibrations.get(sid)
+            if battery is None:
+                continue
+            self._update_battery_eff_calibration(
+                battery.for_action(spec.action),
+                sid,
+                cfg,
+                data,
+                (energy_totals_now or {}).get(sid),
+            )
 
-        prev_soc = result.soc_schedule_kwh[0]
-        planned_next_soc = result.soc_schedule_kwh[1]
-        # Positive in both directions: the magnitude of the planned SoC change.
-        planned_delta = (
-            planned_next_soc - prev_soc
-            if calibration.spec.action == ACTION_CHARGING
-            else prev_soc - planned_next_soc
+    def _update_battery_eff_calibration(
+        self,
+        calibration: DirectionCalibration,
+        subentry_id: str,
+        cfg: BatteryConfig,
+        data: dict[str, Any],
+        counters_now: dict[str, float | None] | None,
+    ) -> None:
+        """Fold one battery's outcome for one direction into its correction."""
+        spec = calibration.spec
+        setpoint_kw = self._last_battery_setpoints.get(subentry_id, 0.0)
+        # Setpoints are positive for charge, negative for discharge.
+        dispatched = (
+            setpoint_kw > 0 if spec.action == ACTION_CHARGING else setpoint_kw < 0
         )
+        if not dispatched:
+            calibration.last_result = CALIBRATION_NOT_DISPATCHED
+            return
+
+        planned_delta = self._planned_battery_delta_kwh(spec, setpoint_kw, cfg)
+        prev_soc = self._soc_snapshot_kwh.get(subentry_id)
+        planned_next_soc: float | None = None
+        if prev_soc is not None:
+            planned_next_soc = (
+                prev_soc + planned_delta
+                if spec.action == ACTION_CHARGING
+                else prev_soc - planned_delta
+            )
 
         # Prefer the cumulative throughput counter over the SoC delta. Both
-        # measure the same quantity — energy moved through the battery, which
+        # measure the same quantity — energy moved through this battery, which
         # is what the planned SoC change represents — but the counter is not
         # limited by the SoC sensor's step size.
+        snapshot = self._energy_counter_snapshot.get(subentry_id) or {}
         counter_delta = (
             counter_delta_kwh(
-                calibration.spec.counter_key,
-                self._energy_counter_snapshot.get(calibration.spec.counter_key),
-                energy_totals_now.get(calibration.spec.counter_key),
+                spec.counter_key,
+                snapshot.get(spec.counter_key),
+                counters_now.get(spec.counter_key),
             )
-            if energy_totals_now is not None
+            if counters_now is not None
             else None
         )
         if planned_delta < min_planned_delta_kwh(
-            counter_delta is not None, self._soc_quantum_kwh()
+            counter_delta is not None, self._battery_soc_quantum_kwh(data, cfg)
         ):
             # Too small to measure reliably at this resolution; skip.
             calibration.last_result = CALIBRATION_DELTA_TOO_SMALL
             return
 
-        bc = self.battery_config
-        if calibration.spec.derate_limit_kw(bc) > 0:
-            threshold_kwh = (
-                calibration.spec.derate_threshold_pct(bc) / 100 * bc.capacity_kwh
-            )
+        if spec.derate_limit_kw(cfg) > 0 and planned_next_soc is not None:
+            threshold_kwh = spec.derate_threshold_pct(cfg) / 100 * cfg.capacity_kwh
             if (
-                min(prev_soc, planned_next_soc)
+                min(prev_soc or 0.0, planned_next_soc)
                 < threshold_kwh
-                <= max(prev_soc, planned_next_soc)
+                <= max(prev_soc or 0.0, planned_next_soc)
             ):
                 _LOGGER.debug(
                     "%s efficiency calibration: skipping sample — step crosses "
                     "%s derating threshold (%.1f%% / %.2f kWh)",
-                    calibration.spec.name.capitalize(),
-                    calibration.spec.derate_label,
-                    calibration.spec.derate_threshold_pct(bc),
+                    calibration.who,
+                    spec.derate_label,
+                    spec.derate_threshold_pct(cfg),
                     threshold_kwh,
                 )
                 calibration.last_result = CALIBRATION_DERATING
@@ -1738,37 +1955,38 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         if counter_delta is not None:
             actual_delta = counter_delta
             source = "energy counter"
-        else:
+        elif prev_soc is not None:
+            state = self._per_battery_states.get(subentry_id)
+            if state is None:
+                calibration.last_result = CALIBRATION_NO_RESULT
+                return
             measured = (
-                battery_state.soc_kwh - prev_soc
-                if calibration.spec.action == ACTION_CHARGING
-                else prev_soc - battery_state.soc_kwh
+                state.soc_kwh - prev_soc
+                if spec.action == ACTION_CHARGING
+                else prev_soc - state.soc_kwh
             )
             actual_delta = max(0.0, measured)
             source = "SoC delta"
+        else:
+            calibration.last_result = CALIBRATION_NO_RESULT
+            return
 
         if calibration.record(planned_delta, actual_delta, source):
             self.hass.async_create_task(calibration.async_save())
 
     def _update_charge_eff_calibration(
         self,
-        battery_state: BatteryState,
-        energy_totals_now: dict[str, float | None] | None = None,
+        energy_totals_now: dict[str, dict[str, float | None]] | None = None,
     ) -> None:
-        """Fold the previous charging step's outcome into the charge correction."""
-        self._update_eff_calibration(
-            self._charge_calibration, battery_state, energy_totals_now
-        )
+        """Fold the previous charging step's outcome into the charge corrections."""
+        self._update_eff_calibration(CHARGE_CALIBRATION, energy_totals_now)
 
     def _update_discharge_eff_calibration(
         self,
-        battery_state: BatteryState,
-        energy_totals_now: dict[str, float | None] | None = None,
+        energy_totals_now: dict[str, dict[str, float | None]] | None = None,
     ) -> None:
-        """Fold the previous discharging step's outcome into the discharge correction."""
-        self._update_eff_calibration(
-            self._discharge_calibration, battery_state, energy_totals_now
-        )
+        """Fold the previous discharging step's outcome into the discharge corrections."""
+        self._update_eff_calibration(DISCHARGE_CALIBRATION, energy_totals_now)
 
     def _weather_hour_offset(self, weather: dict[str, Any], target: datetime) -> int:
         """Index into the weather series for the hour containing ``target``.
@@ -2507,11 +2725,11 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         energy_totals_now = self._read_energy_totals()
 
         # Charge efficiency calibration: compare the previous plan against what
-        # the battery actually moved, to detect systematic over-estimation of
+        # each battery actually moved, to detect systematic over-estimation of
         # charge efficiency (e.g. CV-phase).
-        self._update_charge_eff_calibration(battery_state, energy_totals_now)
+        self._update_charge_eff_calibration(energy_totals_now)
         # Discharge efficiency calibration: same principle for discharging steps.
-        self._update_discharge_eff_calibration(battery_state, energy_totals_now)
+        self._update_discharge_eff_calibration(energy_totals_now)
 
         battery_config = self.battery_config
 
@@ -2521,23 +2739,25 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         # or degradation. See efficiency_calibration.py for the two directions'
         # opposite arithmetic, and for the threshold below which a correction is
         # stored but not applied.
+        charge_eff_correction = self.charge_eff_correction
+        discharge_eff_correction = self.discharge_eff_correction
         charge_eff_curve_override = charge_curve_override(
             battery_config.charge_efficiency_curve_parsed,
-            self._charge_eff_correction,
+            charge_eff_correction,
         )
         discharge_eff_curve_override = discharge_curve_override(
             battery_config.discharge_efficiency_curve_parsed,
-            self._discharge_eff_correction,
+            discharge_eff_correction,
         )
         if charge_eff_curve_override is not None:
             _LOGGER.debug(
                 "Charge efficiency correction %.3f applied to curve",
-                self._charge_eff_correction,
+                charge_eff_correction,
             )
         if discharge_eff_curve_override is not None:
             _LOGGER.debug(
                 "Discharge efficiency correction %.3f applied to curve",
-                self._discharge_eff_correction,
+                discharge_eff_correction,
             )
 
         _LOGGER.debug("OptimizationCoordinator: Calling optimize_battery_schedule.")
@@ -2577,9 +2797,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         )
 
         self._last_result = result
-        # Snapshot the counters alongside the plan they belong to, so the next
-        # run can measure the throughput of exactly this step.
+        # Snapshot the counters and each pack's SoC alongside the plan they
+        # belong to, so the next run can measure the throughput of exactly this
+        # step, per battery. The setpoints themselves are snapshotted further
+        # down, once the split is known.
         self._energy_counter_snapshot = energy_totals_now
+        self._soc_snapshot_kwh = {
+            sid: state.soc_kwh for sid, state in self._per_battery_states.items()
+        }
 
         # Get current grid power: prefer real sensor, fall back to estimate
         realtime_grid_w = self._get_realtime_grid_w()
@@ -2690,12 +2915,12 @@ class OptimizationCoordinator(DataUpdateCoordinator):
                 "grid_kw": round(current_grid / 1000, 3),
                 "commitment_locked": commitment_locked,
                 "commitment_reason": commitment_reason,
-                "charge_eff_correction": round(self._charge_eff_correction, 4),
-                "charge_eff_samples": len(self._charge_eff_samples),
-                "charge_eff_last_result": self._charge_eff_last_result,
-                "discharge_eff_correction": round(self._discharge_eff_correction, 4),
-                "discharge_eff_samples": len(self._discharge_eff_samples),
-                "discharge_eff_last_result": self._discharge_eff_last_result,
+                "charge_eff_correction": round(self.charge_eff_correction, 4),
+                "charge_eff_samples": self.charge_eff_sample_count,
+                "charge_eff_last_result": self.charge_eff_last_result,
+                "discharge_eff_correction": round(self.discharge_eff_correction, 4),
+                "discharge_eff_samples": self.discharge_eff_sample_count,
+                "discharge_eff_last_result": self.discharge_eff_last_result,
             }
         )
         self._optimization_trigger_source = "unknown"
@@ -2705,6 +2930,10 @@ class OptimizationCoordinator(DataUpdateCoordinator):
         battery_setpoints = self._split_setpoint(
             combined_setpoint_kw, self._control_mode
         )
+        # Which pack was asked to do what, for the calibration that scores this
+        # step on the next run. The dispatcher concentrates on one battery at a
+        # time, so without this the fleet plan would be credited to every pack.
+        self._last_battery_setpoints = dict(battery_setpoints)
 
         return {
             "optimization_result": result,
@@ -2735,13 +2964,14 @@ class OptimizationCoordinator(DataUpdateCoordinator):
             "feed_in_price_forecast_model": feed_in_price_forecast_model,
             "feed_in_price_forecast": resampled_feed_in,
             "price_interval": price_interval,
-            "charge_eff_correction": round(self._charge_eff_correction, 4),
-            "charge_eff_samples": len(self._charge_eff_samples),
+            "charge_eff_correction": round(self.charge_eff_correction, 4),
+            "charge_eff_samples": self.charge_eff_sample_count,
             "charge_eff_applied": self.charge_eff_applied,
-            "charge_eff_last_result": self._charge_eff_last_result,
-            "discharge_eff_correction": round(self._discharge_eff_correction, 4),
-            "discharge_eff_samples": len(self._discharge_eff_samples),
+            "charge_eff_last_result": self.charge_eff_last_result,
+            "discharge_eff_correction": round(self.discharge_eff_correction, 4),
+            "discharge_eff_samples": self.discharge_eff_sample_count,
             "discharge_eff_applied": self.discharge_eff_applied,
-            "discharge_eff_last_result": self._discharge_eff_last_result,
+            "discharge_eff_last_result": self.discharge_eff_last_result,
+            "battery_calibration": self.battery_calibration_report(),
             "timestamp": dt_util.utcnow(),
         }

--- a/custom_components/battery_controller/diagnostics.py
+++ b/custom_components/battery_controller/diagnostics.py
@@ -231,6 +231,12 @@ async def async_get_config_entry_diagnostics(
             "discharge_eff_samples": data.get("discharge_eff_samples"),
             "discharge_eff_applied": data.get("discharge_eff_applied"),
             "discharge_eff_last_result": data.get("discharge_eff_last_result"),
+            # The fleet figures above are the capacity-weighted aggregate the DP
+            # plans with. This is where each pack's own measurement lives —
+            # which is the only place a single derated battery is visible.
+            "battery_calibration": _remap_keys(
+                data.get("battery_calibration") or {}, name_map
+            ),
             "timestamp": str(data.get("timestamp")),
         }
 

--- a/custom_components/battery_controller/efficiency_calibration.py
+++ b/custom_components/battery_controller/efficiency_calibration.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -66,6 +66,7 @@ CALIBRATION_APPLY_THRESHOLD = 0.995
 CALIBRATION_SAMPLED = "sampled"
 CALIBRATION_NO_RESULT = "no_previous_run"
 CALIBRATION_NO_PLAN = "direction_not_planned"
+CALIBRATION_NOT_DISPATCHED = "battery_not_dispatched"
 CALIBRATION_PLAN_NOT_EXECUTED = "plan_not_executed"
 CALIBRATION_STEP_INCOMPLETE = "step_not_finished"
 CALIBRATION_DC_COUPLED = "dc_coupled_pv"
@@ -184,6 +185,12 @@ class DirectionCalibration:
 
     spec: CalibrationSpec
     store: storage.Store[dict[str, Any]]
+    # Human-readable owner of this calibration ("Marstek"), used in log
+    # messages so a multi-battery system says which pack it is talking about.
+    label: str = ""
+    # Where to look when this calibration has never been persisted; see
+    # async_load. None for a calibration that has no predecessor.
+    legacy_store: storage.Store[dict[str, Any]] | None = None
     samples: deque[float] = field(
         default_factory=lambda: deque(maxlen=CALIBRATION_WINDOW)
     )
@@ -209,9 +216,33 @@ class DirectionCalibration:
         """Number of observations behind the current correction."""
         return len(self.samples)
 
+    @property
+    def who(self) -> str:
+        """ "Charge" / "Charge (Marstek 2)" — the subject of a log line."""
+        return f"{self.spec.name.capitalize()}" + (
+            f" ({self.label})" if self.label else ""
+        )
+
     async def async_load(self) -> None:
-        """Restore the persisted samples and correction, if any."""
+        """Restore the persisted samples and correction, if any.
+
+        A battery with nothing of its own falls back to ``legacy_store``, the
+        fleet-wide store this calibration used to share with every other pack.
+        That value was measured on whichever battery the dispatcher happened to
+        pick, so it is no longer the answer — but it is a far better prior than
+        nominal, and it is replaced sample by sample as the pack measures
+        itself.
+        """
         stored = await self.store.async_load()
+        if stored is None and self.legacy_store is not None:
+            stored = await self.legacy_store.async_load()
+            if stored is not None:
+                _LOGGER.info(
+                    "Seeding %s efficiency calibration for %s from the previous "
+                    "fleet-wide correction",
+                    self.spec.name,
+                    self.label or "battery",
+                )
         if stored is None:
             return
         self.samples = deque(stored.get("samples", []), maxlen=CALIBRATION_WINDOW)
@@ -261,7 +292,7 @@ class DirectionCalibration:
             _LOGGER.debug(
                 "%s efficiency calibration: dropping implausible sample "
                 "(ratio=%.3f from %s, planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
-                self.spec.name.capitalize(),
+                self.who,
                 ratio,
                 source,
                 planned_delta,
@@ -272,6 +303,9 @@ class DirectionCalibration:
 
         previous = self.correction
         self.samples.append(ratio)
+        # A ratio is only meaningful next to the ratios of the same battery, so
+        # the mean below is per battery; the fleet number the DP uses is
+        # assembled from these by aggregate_correction().
         mean = sum(self.samples) / len(self.samples)
         self.correction = max(CALIBRATION_APPLY_MIN, min(CALIBRATION_APPLY_MAX, mean))
         self.last_result = CALIBRATION_SAMPLED
@@ -281,7 +315,7 @@ class DirectionCalibration:
                 "%s efficiency correction updated: %.3f → %.3f "
                 "(latest ratio=%.3f from %s, n=%d samples, "
                 "planned Δ=%.2f kWh, actual Δ=%.2f kWh)",
-                self.spec.name.capitalize(),
+                self.who,
                 previous,
                 self.correction,
                 ratio,
@@ -291,3 +325,64 @@ class DirectionCalibration:
                 actual_delta,
             )
         return moved
+
+
+@dataclass
+class BatteryCalibration:
+    """Both directions' calibration for one battery.
+
+    Every pack gets its own, because the dispatcher does not spread a setpoint
+    evenly: it concentrates on one battery at a time, so a single fleet-wide
+    ratio describes whichever pack happened to be dispatched and then attributes
+    it to all of them. A pack that is losing capacity is invisible that way — it
+    only drags the shared number down and has its healthy sibling planned
+    pessimistically.
+    """
+
+    subentry_id: str
+    charge: DirectionCalibration
+    discharge: DirectionCalibration
+
+    def for_action(self, action: str) -> DirectionCalibration:
+        """The direction whose plan is ``action``."""
+        return self.charge if action == ACTION_CHARGING else self.discharge
+
+    def both(self) -> tuple[DirectionCalibration, DirectionCalibration]:
+        """Both directions, for the operations that treat them alike."""
+        return (self.charge, self.discharge)
+
+
+def aggregate_correction(weighted: Iterable[tuple[float, float]]) -> float:
+    """Combine per-battery corrections into the one the DP plans with.
+
+    The DP has a single SoC state for the whole fleet, so it needs a single
+    factor. Weighting is by usable capacity over the batteries that have
+    actually measured something: a pack the dispatcher has never used carries no
+    evidence, and letting its nominal 1.0 dilute a measured sibling would report
+    half the derating that was observed. An unmeasured pack is therefore assumed
+    to behave like the measured ones rather than like the datasheet.
+
+    Returns 1.0 when nothing has been measured at all.
+    """
+    total = 0.0
+    total_weight = 0.0
+    for correction, weight in weighted:
+        if weight <= 0:
+            continue
+        total += correction * weight
+        total_weight += weight
+    return total / total_weight if total_weight > 0 else 1.0
+
+
+def aggregate_last_result(results: Iterable[str]) -> str:
+    """The fleet's headline calibration outcome.
+
+    A sample taken on any battery is the informative answer for the fleet —
+    the reasons the others skipped are visible on their own sensors.
+    """
+    reasons = list(results)
+    if not reasons:
+        return CALIBRATION_NO_RESULT
+    if CALIBRATION_SAMPLED in reasons:
+        return CALIBRATION_SAMPLED
+    return reasons[0]

--- a/custom_components/battery_controller/sensor.py
+++ b/custom_components/battery_controller/sensor.py
@@ -102,6 +102,22 @@ async def async_setup_entry(
                         subentry.subentry_id,
                         subentry.title,
                     ),
+                    # Per-battery calibration: the fleet sensors average the
+                    # packs together, which describes neither when they differ.
+                    BatterySubentryChargeCalibrationSensor(
+                        optimization_coordinator,
+                        batt_device,
+                        entry,
+                        subentry.subentry_id,
+                        subentry.title,
+                    ),
+                    BatterySubentryDischargeCalibrationSensor(
+                        optimization_coordinator,
+                        batt_device,
+                        entry,
+                        subentry.subentry_id,
+                        subentry.title,
+                    ),
                 ],
                 config_subentry_id=subentry.subentry_id,
             )
@@ -919,7 +935,12 @@ class BatteryEfficiencyCalibrationSensor(BatteryControllerSensor):
 
 
 class ChargeEfficiencyCalibrationSensor(BatteryEfficiencyCalibrationSensor):
-    """Learned correction on the charge-side SoC transition."""
+    """Learned correction on the charge-side SoC transition, fleet-wide.
+
+    The capacity-weighted aggregate of the per-battery corrections — what the
+    DP is actually handed, since it plans one SoC for the whole fleet. The
+    per-battery sensors say which pack the number came from.
+    """
 
     _attr_translation_key = "charge_eff_correction"
     _attr_name = "Charge Efficiency Correction"
@@ -935,7 +956,7 @@ class ChargeEfficiencyCalibrationSensor(BatteryEfficiencyCalibrationSensor):
 
 
 class DischargeEfficiencyCalibrationSensor(BatteryEfficiencyCalibrationSensor):
-    """Learned correction on the discharge-side SoC transition."""
+    """Learned correction on the discharge-side SoC transition, fleet-wide."""
 
     _attr_translation_key = "discharge_eff_correction"
     _attr_name = "Discharge Efficiency Correction"
@@ -948,6 +969,61 @@ class DischargeEfficiencyCalibrationSensor(BatteryEfficiencyCalibrationSensor):
             self.coordinator.discharge_eff_applied,
             self.coordinator.discharge_eff_last_result,
         )
+
+
+class BatterySubentryCalibrationSensor(BatteryEfficiencyCalibrationSensor):
+    """One battery's own learned efficiency correction.
+
+    Reported per battery because the causes are per battery: the dispatcher
+    concentrates a setpoint on one pack at a time, so a single fleet number
+    describes whichever machine happened to be picked. A pack that is losing
+    capacity shows up here as a correction below 100% while its sibling stays
+    at nominal — on the fleet sensor the two are averaged into something that
+    describes neither.
+
+    ``last_result`` says why a pack is not learning; ``battery_not_dispatched``
+    is the common one and is not a fault — it means the other battery has been
+    doing the work.
+    """
+
+    _action: str = ACTION_CHARGING
+
+    def __init__(
+        self,
+        coordinator: OptimizationCoordinator,
+        device: DeviceInfo,
+        entry: ConfigEntry,
+        subentry_id: str,
+        battery_title: str,
+    ):
+        super().__init__(coordinator, device, entry, f"{self._key}_{subentry_id}")
+        self._subentry_id = subentry_id
+        self._attr_name = f"{self._title} {battery_title}"
+
+    _title = ""
+
+    def _calibration(self) -> tuple[float, int, bool, str]:
+        return self.coordinator.battery_calibration_state(
+            self._subentry_id, self._action
+        )
+
+
+class BatterySubentryChargeCalibrationSensor(BatterySubentryCalibrationSensor):
+    """One battery's learned charge-side correction."""
+
+    _attr_translation_key = "battery_charge_eff_correction"
+    _action = ACTION_CHARGING
+    _key = "charge_eff_correction"
+    _title = "Charge Efficiency Correction"
+
+
+class BatterySubentryDischargeCalibrationSensor(BatterySubentryCalibrationSensor):
+    """One battery's learned discharge-side correction."""
+
+    _attr_translation_key = "battery_discharge_eff_correction"
+    _action = ACTION_DISCHARGING
+    _key = "discharge_eff_correction"
+    _title = "Discharge Efficiency Correction"
 
 
 class PVArrayCalibrationSensor(BatteryForecastSensor):

--- a/custom_components/battery_controller/strings.json
+++ b/custom_components/battery_controller/strings.json
@@ -377,6 +377,12 @@
       },
       "discharge_eff_correction": {
         "name": "Discharge Efficiency Correction"
+      },
+      "battery_charge_eff_correction": {
+        "name": "Charge Efficiency Correction"
+      },
+      "battery_discharge_eff_correction": {
+        "name": "Discharge Efficiency Correction"
       }
     },
     "number": {

--- a/custom_components/battery_controller/translations/en.json
+++ b/custom_components/battery_controller/translations/en.json
@@ -377,6 +377,12 @@
       },
       "discharge_eff_correction": {
         "name": "Discharge Efficiency Correction"
+      },
+      "battery_charge_eff_correction": {
+        "name": "Charge Efficiency Correction"
+      },
+      "battery_discharge_eff_correction": {
+        "name": "Discharge Efficiency Correction"
       }
     },
     "number": {

--- a/custom_components/battery_controller/translations/nl.json
+++ b/custom_components/battery_controller/translations/nl.json
@@ -302,6 +302,12 @@
       },
       "discharge_eff_correction": {
         "name": "Ontlaadefficiëntie-correctie"
+      },
+      "battery_charge_eff_correction": {
+        "name": "Laadefficiëntie-correctie"
+      },
+      "battery_discharge_eff_correction": {
+        "name": "Ontlaadefficiëntie-correctie"
       }
     },
     "number": {

--- a/docs/__tests__/calibration_card.test.js
+++ b/docs/__tests__/calibration_card.test.js
@@ -52,6 +52,20 @@ const DIAGNOSTICS = {
     // Can never learn: DC-coupled PV makes the SoC delta unusable.
     discharge_eff_correction: 1.0, discharge_eff_samples: 0,
     discharge_eff_applied: false, discharge_eff_last_result: 'dc_coupled_pv',
+    // The fleet figures above average the packs together. Only these rows can
+    // show that one battery has derated while the other is fine.
+    battery_calibration: {
+      Marstek: {
+        name: 'Marstek',
+        charge: { correction: 0.88, samples: 12, applied: true, last_result: 'sampled' },
+        discharge: { correction: 1.0, samples: 0, applied: false, last_result: 'battery_not_dispatched' },
+      },
+      'Marstek 2': {
+        name: 'Marstek 2',
+        charge: { correction: 1.0, samples: 0, applied: false, last_result: 'battery_not_dispatched' },
+        discharge: { correction: 1.0, samples: 0, applied: false, last_result: 'battery_not_dispatched' },
+      },
+    },
     battery_state: { soc_kwh: 5, soc_percent: 50, power_kw: 0, mode: 'idle' },
     schedule: {
       price_forecast: [0.2, 0.3], power_schedule_kw: [0, 0],
@@ -103,6 +117,20 @@ describe('analyzer learned-calibration card', () => {
     expect(card).toContain('87.0%');
     // An array left out of the report is exactly what hides the problem.
     expect(card).toContain('East Array');
+  });
+
+  test('breaks the fleet number down per battery', () => {
+    // The fleet charge correction is 94%; the pack that did the work measured
+    // 88%. Only the per-battery row can tell you which machine to look at.
+    expect(card).toContain('Marstek · charge');
+    expect(card).toContain('88.0%');
+    expect(card).toContain('Marstek 2 · discharge');
+  });
+
+  test('says why a battery is not learning instead of showing a bare 100%', () => {
+    // A pack the dispatcher never picked has nothing to report — that is not
+    // the same as a pack that measured itself and came out at nominal.
+    expect(card).toContain('battery not dispatched');
   });
 
   test('the efficiency card no longer claims 100% for an unmeasured correction', () => {

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -533,6 +533,12 @@ Charge-speed correction: when runtime calibration detects that the battery gains
 
 The observation is taken from the per-battery cumulative kWh counters when they are configured, and from the SoC delta otherwise. Both measure the same energy, but a SoC sensor reporting whole percent quantises at `capacity / 100` — 0.1 kWh on a 10 kWh pack — so on that path the minimum planned change worth sampling scales with the observed sensor resolution rather than a fixed 0.1 kWh. Samples outside `[0.5, 1.5]` are dropped rather than folded into the mean: an asymmetric clip (capped at 1.05, allowed down to 0.5) let symmetric measurement noise bias the correction below 1.0 for a healthy battery. Only the resulting mean is clamped, to `[0.5, 1.05]`, before it is applied.
 
+**One calibration per battery.** Each pack keeps its own window, its own storage key and its own pair of diagnostic sensors, and is scored against the setpoint *it* was given (`battery_setpoints`) rather than against the fleet plan. The dispatcher concentrates a setpoint on one battery at a time (see [Section 12](#12-multi-battery-dispatch)), so a single fleet-wide ratio measures whichever pack happened to be picked and then attributes it to all of them: a pack that is losing capacity is invisible, dragging the shared number down and having its healthy sibling planned pessimistically. A pack that was not dispatched in this direction reports `battery_not_dispatched` and takes no sample.
+
+The planned SoC change per pack is `|setpoint| × step_hours × charge_eff(|setpoint|)` for charging and `|setpoint| × step_hours / discharge_eff(|setpoint|)` for discharging, using that battery's own curve at its own power — the curves are power-dependent, so a pack running at 1.2 kW is not described by the fleet's 2.4 kW point. The derating guard likewise uses the pack's own threshold and its own SoC.
+
+The DP plans one SoC for the whole fleet, so it is handed the **capacity-weighted aggregate** of the per-battery corrections, taken over the packs that have actually measured something. A pack the dispatcher has never used carries no evidence, and averaging its nominal 1.0 in would report half the derating that was observed — an unmeasured pack is therefore assumed to behave like the measured ones rather than like the datasheet. The fleet sensors publish that aggregate; the per-battery sensors publish the individual measurements. On upgrade, a battery with nothing of its own seeds from the old fleet-wide store: that value is no longer the answer, but it is a better prior than nominal and each new sample replaces more of it.
+
 The shadow price is always the raw DP value — there is no separate "post-processed" shadow price. Post-processing filters affect `total_cost` and `savings` (where the difference between raw and processed values shows the impact of filtered actions), but the shadow price is a DP concept that is not modified by post-processing.
 
 **Use by hybrid mode**: λ is used by the coordinator as the charge/discharge switching threshold in hybrid mode. It is deliberately not fed back into the next run's terminal condition (see [Section 5](#5-terminal-condition)).
@@ -716,13 +722,31 @@ A quarter hour under cloud has a large relative error on a tiny amount of
 energy, and weighting by energy stops those steps dominating an estimate that
 is meant to describe a gain error.
 
-Samples are only taken in the middle of the array's rating (10–80 % of kWp):
+Samples are only taken in the middle of the array's rating (10–90 % of kWp):
 below the floor the signal is smaller than the noise, above the ceiling
-inverter clipping and thermal derating dominate and are not forecast errors.
+inverter clipping dominates and is not a forecast error. The ceiling has to sit
+above what an array genuinely reaches — a well-oriented array peaks near 85 %
+of its rating on a clear summer day, and a lower ceiling excludes exactly the
+steps with the best signal-to-noise ratio, leaving a south array learning only
+from its oblique, diffuse-dominated hours and then applying that error all day.
+Typical DC/AC ratios of 1.1–1.2 put real clipping at 83–91 %.
+
 Steps are skipped entirely while PV curtailment is active, when the elapsed
 window is not the window the forecast described, and when the counter jumps
-backwards. The applied factor is clamped and only used once enough samples
-exist.
+backwards. Within the accepted window the planned energy is stretched to the
+time that actually elapsed: this coordinator also refreshes when new weather
+arrives, so a meter delta covering 20 minutes is regularly scored against a
+snapshot describing 15, and a late run alone would read as a 33 % better array.
+
+The applied factor is clamped and only used once `PV_CALIBRATION_MIN_SAMPLES`
+observations exist. That floor is what separates a gain error from the weather:
+an array only ever samples in its own part of the day, so it picks up the
+radiation forecast's bias for those hours, and at a couple of dozen samples —
+one afternoon of production — that bias *is* the correction. A correction is
+reported as applied only when it has been derived *and* differs from nominal by
+more than `PV_CALIBRATION_APPLY_EPSILON`, the same gate the forecast itself
+uses, so "being corrected" cannot mean something different on the sensor than
+it does in the model.
 
 **What it can and cannot fix.** A wrong tilt or orientation entry, soiling and
 a string that is down are gain errors: the array produces a roughly constant

--- a/docs/analyzer/index.html
+++ b/docs/analyzer/index.html
@@ -848,6 +848,15 @@ function renderDiagnostics(raw) {
     return kv(label, `${pct} <span class="text-gray-400">(n=${n})</span> ${state}${why}`);
   };
   const pvCal = fc.pv_calibration || {};
+  // The two battery rows above are the fleet aggregate the DP plans with. With
+  // more than one pack that average describes neither of them — the dispatcher
+  // concentrates on one battery at a time — so each pack's own measurement is
+  // listed underneath it.
+  const batCal = opt.battery_calibration || {};
+  const batteryRows = Object.entries(batCal).flatMap(([name, e]) => [
+    calRow(`&nbsp;&nbsp;↳ ${name} · charge`, e.charge),
+    calRow(`&nbsp;&nbsp;↳ ${name} · discharge`, e.discharge),
+  ]).join('');
   document.getElementById('cfg-calibration').innerHTML =
     calRow('Battery charge efficiency', {
       correction: chgEffCorr, samples: chgEffSamples,
@@ -857,6 +866,7 @@ function renderDiagnostics(raw) {
       correction: disEffCorr, samples: disEffSamples,
       applied: opt.discharge_eff_applied, last_result: opt.discharge_eff_last_result,
     }) +
+    batteryRows +
     (Object.keys(pvCal).length
       ? Object.entries(pvCal).map(([name, e]) => calRow(`PV forecast · ${name}`, e)).join('')
       : kv('PV forecast', '<span class="text-gray-400">no PV arrays reported</span>'));

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -157,16 +157,26 @@ the more stable the resulting schedule.
 
 ### Checking what has actually been learned
 
-Three corrections are learned from your own installation, and each one is published as a
+The corrections are learned from your own installation, and each one is published as a
 diagnostic sensor so you can see where it stands without downloading anything:
 
-| Sensor | What it measures |
-|---|---|
-| *Charge Efficiency Correction* | How much SoC the battery really gains within a step, against what the model assumed |
-| *Discharge Efficiency Correction* | The same for discharging |
-| *PV Forecast Correction &lt;array&gt;* | What each PV array really produces, against its forecast |
+| Sensor | Where | What it measures |
+|---|---|---|
+| *Charge Efficiency Correction* | main device | How much SoC the fleet really gains within a step, against what the model assumed |
+| *Discharge Efficiency Correction* | main device | The same for discharging |
+| *Charge / Discharge Efficiency Correction &lt;battery&gt;* | each battery | The same, measured on that pack alone |
+| *PV Forecast Correction &lt;array&gt;* | each PV array | What each array really produces, against its forecast |
 
-All three read **100%** when reality matches the model. That is also the value they start
+The two sensors on the main device are the **fleet** figures — the capacity-weighted
+average of the individual batteries, and what the optimizer actually plans with, since it
+plans one state of charge for all of them together. With more than one battery that
+average describes neither pack when they differ: the controller runs one battery at a
+time rather than splitting every setpoint, so the per-battery sensors are where a single
+ageing pack becomes visible. A battery that was not asked to do anything reports
+`battery_not_dispatched` — that is not a fault, it means the other battery has been
+doing the work.
+
+They all read **100%** when reality matches the model. That is also the value they start
 at, so the number alone cannot tell you whether anything has been measured — the
 attributes say which:
 
@@ -186,7 +196,8 @@ and they are the usual explanation for a sample count that never moves:
 | `plan_not_executed` | The battery is not following the DP schedule verbatim, so the SoC change does not measure efficiency. Normal in [Zero Grid](control-modes.md#zero-grid) and [Manual](control-modes.md#manual) mode, and common in [Hybrid](control-modes.md#hybrid-recommended). |
 | `direction_not_planned` | The optimizer has not planned this direction recently. Simply waiting is the fix. |
 | `no_measured_production_sensor` | The PV array has no production counter configured, so there is nothing to compare its forecast against. |
-| `production_outside_usable_band` | The array is producing below 10% or above 80% of its rating — too little signal, or close enough to clipping that the shortfall is not a forecast error. |
+| `production_outside_usable_band` | The array is producing below 10% or above 90% of its rating — too little signal, or close enough to clipping that the shortfall is not a forecast error. |
+| `battery_not_dispatched` | This battery was not given a setpoint in this direction, so it has nothing to report. The controller concentrates on one pack at a time, so this alternates between batteries. |
 
 To reset a correction that has gone wrong, call the
 `battery_controller.reset_charge_efficiency_calibration`,

--- a/simulate/simulate_diagnostics.py
+++ b/simulate/simulate_diagnostics.py
@@ -1549,6 +1549,29 @@ def main():
             f"  discharge_eff_correction: {_discharge_eff_correction:.4f}{samples_str}{flag}"
         )
 
+    # The two figures above are the fleet aggregate the DP plans with. Each pack
+    # also measures itself, and with more than one battery the average describes
+    # neither of them — that breakdown is where a single derated pack shows up.
+    for _name, _entry in (opt_top.get("battery_calibration") or {}).items():
+        for _direction in ("charge", "discharge"):
+            _cal = (_entry or {}).get(_direction) or {}
+            _correction = _cal.get("correction")
+            if _correction is None:
+                continue
+            _n = _cal.get("samples", 0)
+            _why = _cal.get("last_result", "")
+            _state = (
+                "never measured"
+                if not _n
+                else "applied"
+                if _cal.get("applied")
+                else "stored, not applied"
+            )
+            print(
+                f"    {_name} {_direction}: {_correction:.4f}, n={_n} "
+                f"({_state}; last: {_why})"
+            )
+
     # Run DP
     (
         V,

--- a/tests/test_coordinator_forecast.py
+++ b/tests/test_coordinator_forecast.py
@@ -12,6 +12,7 @@ import pytest
 from custom_components.battery_controller.const import (
     CONF_BATTERY_ENERGY_CHARGED_SENSOR,
     CONF_PV_MEASURED_PRODUCTION_SENSOR,
+    PV_CALIBRATION_MIN_SAMPLES,
 )
 from custom_components.battery_controller.coordinator_forecast import (
     PV_CAL_CURTAILED,
@@ -1338,8 +1339,8 @@ async def test_pv_calibration_learns_an_energy_weighted_gain(hass):
     step_h = 0.25
     meter = 100.0
 
-    # 30 quarter-hours where the array delivers 80 % of the forecast.
-    for i in range(30):
+    # Enough quarter-hours to clear the floor, each delivering 80 % of forecast.
+    for i in range(PV_CALIBRATION_MIN_SAMPLES + 10):
         forecast_kw = 2.0  # 50 % of the 4 kWp rating: inside the sampling band
         coord._pv_cal_snapshot = {
             "taken_at": now,
@@ -1464,12 +1465,60 @@ async def test_pv_snapshot_only_inside_the_sampling_band(hass):
 
 
 @pytest.mark.asyncio
+async def test_pv_snapshot_covers_a_clear_midday_peak(hass):
+    """A well-oriented array peaks near 85 % of its rating, and must sample there.
+
+    Those are the steps with the best signal-to-noise ratio. Excluding them left
+    a south array learning only from its oblique hours — where the transposition
+    model is weakest — and applying that error all day.
+    """
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    hass.states.async_set("sensor.pv1_energy", "100.0", {"unit_of_measurement": "kWh"})
+
+    coord._snapshot_pv_calibration(now, {"pv1": 3.4}, {"pv1": 4.0})
+
+    assert coord._pv_cal_snapshot["forecast_kwh"]["pv1"] == pytest.approx(0.85)
+
+
+@pytest.mark.asyncio
+async def test_pv_sample_is_scaled_to_the_window_that_elapsed(hass):
+    """A late run measures more minutes than the snapshot describes.
+
+    A weather update refreshes this coordinator off its own cadence, so the
+    meter delta regularly covers a longer window than one step. Scoring it
+    against a fixed quarter-hour of forecast energy read as a 33 % better array.
+    """
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    meter = 100.0
+
+    # 2 kW forecast, an array performing exactly on target, sampled 20 minutes
+    # later each time: the meter moves 2 kW x 20 min, the snapshot says 15.
+    for _ in range(PV_CALIBRATION_MIN_SAMPLES + 5):
+        coord._pv_cal_snapshot = {
+            "taken_at": now,
+            "forecast_kwh": {"pv1": 2.0 * 0.25},
+            "meter_kwh": {"pv1": meter},
+        }
+        meter += 2.0 * (20 / 60)
+        hass.states.async_set(
+            "sensor.pv1_energy", f"{meter}", {"unit_of_measurement": "kWh"}
+        )
+        now += timedelta(minutes=20)
+        coord._update_pv_calibration(now)
+
+    assert coord.pv_correction("pv1") == pytest.approx(1.0, abs=1e-6)
+    assert coord.pv_correction_applied("pv1") is False
+
+
+@pytest.mark.asyncio
 async def test_pv_correction_is_clamped(hass):
     """However bad the ratio, the applied factor stays inside its bounds."""
     coord = _make_cal_coordinator(hass)
     now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
     meter = 100.0
-    for _ in range(25):
+    for _ in range(PV_CALIBRATION_MIN_SAMPLES + 5):
         coord._pv_cal_snapshot = {
             "taken_at": now,
             "forecast_kwh": {"pv1": 1.0},
@@ -1562,6 +1611,53 @@ async def test_pv_report_distinguishes_learning_from_applied(hass):
     assert coord.pv_sample_count("pv1") == 3
     assert coord.pv_correction_applied("pv1") is False
     assert coord.pv_last_result("pv1") == PV_CAL_SAMPLED
+
+
+@pytest.mark.asyncio
+async def test_pv_correction_below_the_floor_survives_a_reload_unapplied(hass):
+    """An array still filling its window must not come back as corrected.
+
+    Every array with samples is persisted, including the ones below the floor.
+    Reading those back unconditionally handed each a correction of 1.0, and
+    membership of that mapping was what ``applied`` reported — so a restart
+    turned "never measured anything" into "being corrected".
+    """
+    coord = _make_cal_coordinator(hass)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    meter = 100.0
+    for _ in range(3):
+        coord._pv_cal_snapshot = {
+            "taken_at": now,
+            "forecast_kwh": {"pv1": 0.5},
+            "meter_kwh": {"pv1": meter},
+        }
+        meter += 0.4
+        hass.states.async_set(
+            "sensor.pv1_energy", f"{meter}", {"unit_of_measurement": "kWh"}
+        )
+        now += timedelta(minutes=15)
+        coord._update_pv_calibration(now)
+    await coord._async_save_pv_calibration()
+
+    reloaded = _make_cal_coordinator(hass)
+    await reloaded._async_load_pv_calibration()
+
+    assert reloaded.pv_sample_count("pv1") == 3
+    assert reloaded.pv_correction("pv1") == pytest.approx(1.0)
+    assert reloaded.pv_correction_applied("pv1") is False
+
+
+@pytest.mark.asyncio
+async def test_pv_array_on_target_is_not_reported_as_corrected(hass):
+    """A derived correction of exactly nominal changes nothing, and says so."""
+    coord = _make_cal_coordinator(hass)
+    coord._pv_cal_correction["pv1"] = 1.002
+
+    assert coord.pv_correction_applied("pv1") is False
+
+    coord._pv_cal_correction["pv1"] = 0.9
+
+    assert coord.pv_correction_applied("pv1") is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_optimization.py
+++ b/tests/test_coordinator_optimization.py
@@ -16,7 +16,10 @@ from custom_components.battery_controller.battery_model import (
     BatteryState,
 )
 from custom_components.battery_controller.const import (
+    ACTION_CHARGING,
+    ACTION_DISCHARGING,
     CONF_BATTERY_ENERGY_CHARGED_SENSOR,
+    CONF_CAPACITY_KWH,
     CONF_BATTERY_ENERGY_DISCHARGED_SENSOR,
     CONF_BATTERY_SOC_SENSOR,
     CONF_CHARGE_EFFICIENCY_CURVE,
@@ -30,6 +33,7 @@ from custom_components.battery_controller.const import (
     CONF_MAX_GRID_POWER_KW,
     CONF_MAX_SOC_PERCENT,
     CONF_MIN_SOC_PERCENT,
+    CONF_NAME,
     CONF_OPTIMIZATION_INTERVAL_MINUTES,
     CONF_POWER_CONSUMPTION_SENSORS,
     CONF_POWER_PRODUCTION_SENSORS,
@@ -53,6 +57,7 @@ from custom_components.battery_controller.efficiency_calibration import (
     CALIBRATION_DC_COUPLED,
     CALIBRATION_NO_PLAN,
     CALIBRATION_NO_RESULT,
+    CALIBRATION_NOT_DISPATCHED,
     CALIBRATION_PLAN_NOT_EXECUTED,
     CALIBRATION_SAMPLED,
 )
@@ -2453,15 +2458,74 @@ def _mark_plan_executed(coord) -> None:
     coord._controller_schedule_w = coord._last_result.power_schedule_kw[0] * 1000
 
 
+def _calibration(coord, action=ACTION_CHARGING, index=0):
+    """One battery's calibration for one direction."""
+    sid, _data = coord._battery_subentries[index]
+    return coord.battery_calibrations[sid].for_action(action)
+
+
+def _plan_battery_step(
+    coord,
+    *,
+    planned_delta_kwh: float,
+    actual_delta_kwh: float | None = None,
+    action: str = ACTION_CHARGING,
+    index: int = 0,
+    step_hours: float = 1.0,
+    prev_soc_kwh: float = 5.0,
+    executed: bool = True,
+):
+    """Give one battery a previous step: what it was told, and what it did.
+
+    Calibration scores each pack against the setpoint the dispatcher gave *it*,
+    so a test states the SoC change that was planned and this works back to the
+    setpoint producing it at that battery's own efficiency. ``actual_delta_kwh``
+    of None leaves the pack's SoC unmeasured, for the counter-driven cases.
+    """
+    sid, _data = coord._battery_subentries[index]
+    cfg = dict(coord._individual_battery_configs)[sid]
+    charging = action == ACTION_CHARGING
+    efficiency = cfg.charge_efficiency if charging else cfg.discharge_efficiency
+    power_kw = (
+        planned_delta_kwh / (step_hours * efficiency)
+        if charging
+        else planned_delta_kwh * efficiency / step_hours
+    )
+    signed_kw = power_kw if charging else -power_kw
+
+    coord._last_result = _make_fake_result(
+        mode_schedule=[action],
+        soc_schedule_kwh=[prev_soc_kwh, prev_soc_kwh + planned_delta_kwh],
+        power_schedule_kw=[signed_kw],
+    )
+    if coord.data is None:
+        coord.data = {}
+    coord.data = {**coord.data, "step_durations_hours": [step_hours]}
+    coord._last_battery_setpoints[sid] = signed_kw
+    coord._soc_snapshot_kwh[sid] = prev_soc_kwh
+    if actual_delta_kwh is not None:
+        reached = (
+            prev_soc_kwh + actual_delta_kwh
+            if charging
+            else prev_soc_kwh - actual_delta_kwh
+        )
+        coord._per_battery_states[sid] = BatteryState(
+            soc_kwh=reached,
+            soc_percent=reached / max(cfg.capacity_kwh, 1e-9) * 100,
+            power_kw=signed_kw,
+            mode=action,
+        )
+    if executed:
+        _mark_plan_executed(coord)
+    return sid
+
+
 def test_calibration_no_sample_without_previous_result(hass):
     """No calibration sample when _last_result is None."""
     coord = _make_coordinator(hass)
     assert coord.charge_eff_correction == 1.0
 
-    battery_state = BatteryState(
-        soc_kwh=5.0, soc_percent=50.0, power_kw=0.0, mode="idle"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_correction == 1.0
     assert coord.charge_eff_sample_count == 0
@@ -2475,27 +2539,42 @@ def test_calibration_no_sample_for_idle_step(hass):
         soc_schedule_kwh=[5.0, 5.0, 6.2],
     )
 
-    battery_state = BatteryState(
-        soc_kwh=5.0, soc_percent=50.0, power_kw=0.0, mode="idle"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
     assert coord.charge_eff_correction == 1.0
 
 
+def test_calibration_no_sample_for_a_battery_that_was_not_dispatched(hass):
+    """A pack that sat idle while its sibling worked has nothing to report.
+
+    The dispatcher concentrates a setpoint on one battery at a time, so
+    crediting the fleet plan to every pack would attribute one machine's
+    throughput to another.
+    """
+    coord = _make_coordinator(
+        hass,
+        battery_subentries=[
+            ("bat1", {CONF_MAX_CHARGE_POWER_KW: 1.2, CONF_MAX_DISCHARGE_POWER_KW: 1.2}),
+            ("bat2", {CONF_MAX_CHARGE_POWER_KW: 1.2, CONF_MAX_DISCHARGE_POWER_KW: 1.2}),
+        ],
+    )
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=0.8, index=0)
+    coord._last_battery_setpoints["bat2"] = 0.0
+
+    coord._update_charge_eff_calibration()
+
+    assert _calibration(coord, index=0).sample_count == 1
+    assert _calibration(coord, index=1).sample_count == 0
+    assert _calibration(coord, index=1).last_result == CALIBRATION_NOT_DISPATCHED
+
+
 def test_calibration_no_sample_when_planned_delta_too_small(hass):
     """No sample when planned charge delta is below 0.1 kWh threshold."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 5.05],  # only 0.05 kWh planned
-    )
+    _plan_battery_step(coord, planned_delta_kwh=0.05, actual_delta_kwh=0.03)
 
-    battery_state = BatteryState(
-        soc_kwh=5.03, soc_percent=50.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
 
@@ -2503,45 +2582,30 @@ def test_calibration_no_sample_when_planned_delta_too_small(hass):
 def test_calibration_perfect_efficiency_no_correction(hass):
     """When actual delta equals planned delta, correction stays at 1.0."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
-    )
-    _mark_plan_executed(coord)
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=1.0)
 
-    # Actual SoC reached exactly the planned value
-    battery_state = BatteryState(
-        soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 1
-    assert coord._charge_eff_samples[0] == pytest.approx(1.0)
+    assert _calibration(coord).samples[0] == pytest.approx(1.0)
     assert coord.charge_eff_correction == pytest.approx(1.0)
 
 
 def test_calibration_waits_until_previous_step_has_elapsed(hass, monkeypatch):
     """Do not sample halfway through the previously planned charging step."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],
-    )
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=0.25)
     coord.data = {
+        **coord.data,
         "step_start_times_iso": ["2026-04-15T10:00:00+00:00"],
-        "step_durations_hours": [1.0],
     }
 
     monkeypatch.setattr(
         "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
         lambda: datetime(2026, 4, 15, 10, 15, tzinfo=timezone.utc),
     )
-    _mark_plan_executed(coord)
 
-    battery_state = BatteryState(
-        soc_kwh=5.25, soc_percent=52.5, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
     assert coord.charge_eff_correction == 1.0
@@ -2550,48 +2614,33 @@ def test_calibration_waits_until_previous_step_has_elapsed(hass, monkeypatch):
 def test_calibration_samples_after_previous_step_has_elapsed(hass, monkeypatch):
     """Collect a sample once the previous planned charging step has finished."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],
-    )
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=1.0)
     coord.data = {
+        **coord.data,
         "step_start_times_iso": ["2026-04-15T10:00:00+00:00"],
-        "step_durations_hours": [1.0],
     }
 
     monkeypatch.setattr(
         "custom_components.battery_controller.coordinator_optimization.dt_util.utcnow",
         lambda: datetime(2026, 4, 15, 11, 0, tzinfo=timezone.utc),
     )
-    _mark_plan_executed(coord)
 
-    battery_state = BatteryState(
-        soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 1
-    assert coord._charge_eff_samples[0] == pytest.approx(1.0)
+    assert _calibration(coord).samples[0] == pytest.approx(1.0)
     assert coord.charge_eff_correction == pytest.approx(1.0)
 
 
 def test_calibration_low_efficiency_updates_correction(hass):
     """When battery only charged to 80% of plan, correction moves below 1."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[4.0, 6.0],  # planned delta = 2.0 kWh
-    )
-    _mark_plan_executed(coord)
+    _plan_battery_step(coord, planned_delta_kwh=2.0, actual_delta_kwh=1.6)
 
-    # Actual delta = 1.6 kWh → ratio = 0.8
-    battery_state = BatteryState(
-        soc_kwh=5.6, soc_percent=56.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 1
-    assert coord._charge_eff_samples[0] == pytest.approx(0.8)
+    assert _calibration(coord).samples[0] == pytest.approx(0.8)
     assert coord.charge_eff_correction == pytest.approx(0.8)
 
 
@@ -2600,21 +2649,8 @@ def test_calibration_rolling_average_converges(hass):
     coord = _make_coordinator(hass)
 
     for _ in range(4):
-        coord._last_result = _make_fake_result(
-            mode_schedule=["charging"],
-            soc_schedule_kwh=[0.0, 1.0],
-        )
-        _mark_plan_executed(coord)
-        # actual delta = 0.85 kWh → ratio = 0.85
-        battery_state = BatteryState(
-            soc_kwh=0.85, soc_percent=8.5, power_kw=1.0, mode="charging"
-        )
-        coord._update_charge_eff_calibration(battery_state)
-        # Reset prev_soc for next iteration
-        coord._last_result = _make_fake_result(
-            mode_schedule=["charging"],
-            soc_schedule_kwh=[0.0, 1.0],
-        )
+        _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=0.85)
+        coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_correction == pytest.approx(0.85, abs=1e-9)
 
@@ -2627,17 +2663,10 @@ def test_calibration_drops_implausibly_low_ratio(hass):
     something else happened.
     """
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 7.0],  # planned delta = 2.0 kWh
-    )
-    _mark_plan_executed(coord)
+    # Actual delta 0.5 of a planned 2.0 → ratio 0.25, below the 0.5 floor.
+    _plan_battery_step(coord, planned_delta_kwh=2.0, actual_delta_kwh=0.5)
 
-    # Actual delta = 0.5 kWh → ratio 0.25, below the 0.5 acceptance floor
-    battery_state = BatteryState(
-        soc_kwh=5.5, soc_percent=55.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
     assert coord.charge_eff_correction == pytest.approx(1.0)
@@ -2646,17 +2675,10 @@ def test_calibration_drops_implausibly_low_ratio(hass):
 def test_calibration_drops_implausibly_high_ratio(hass):
     """A ratio above the acceptance window is dropped as well."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
-    )
-    _mark_plan_executed(coord)
+    # Ratio 2.0, above the 1.5 acceptance ceiling.
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=2.0)
 
-    # Actual delta = 2.0 kWh → ratio 2.0, above the 1.5 acceptance ceiling
-    battery_state = BatteryState(
-        soc_kwh=7.0, soc_percent=70.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
 
@@ -2668,19 +2690,12 @@ def test_calibration_correction_is_clamped_for_use(hass):
     the bound on what the optimizer is handed is applied to the mean instead.
     """
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
-    )
-    _mark_plan_executed(coord)
+    # Ratio 1.4, inside the acceptance window but above the apply ceiling.
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=1.4)
 
-    # Actual delta = 1.4 kWh → ratio 1.4, inside the window
-    battery_state = BatteryState(
-        soc_kwh=6.4, soc_percent=64.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
-    assert coord._charge_eff_samples[0] == pytest.approx(1.4)
+    assert _calibration(coord).samples[0] == pytest.approx(1.4)
     assert coord.charge_eff_correction == pytest.approx(1.05)
 
 
@@ -2730,10 +2745,7 @@ def test_calibration_not_applied_for_dc_coupled(hass):
     )
     _mark_plan_executed(coord)
 
-    battery_state = BatteryState(
-        soc_kwh=5.5, soc_percent=55.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     # No sample should have been added for DC-coupled system
     assert coord.charge_eff_sample_count == 0
@@ -3098,10 +3110,7 @@ def test_calibration_no_sample_when_plan_overridden_by_zero_grid(hass):
     coord._effective_mode = "zero_grid"
     coord._controller_schedule_w = 0.0
 
-    battery_state = BatteryState(
-        soc_kwh=4.1, soc_percent=41.0, power_kw=0.0, mode="idle"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
     assert coord.charge_eff_correction == 1.0
@@ -3118,10 +3127,7 @@ def test_calibration_no_sample_when_commitment_locked_other_power(hass):
     coord._effective_mode = "charging"
     coord._controller_schedule_w = 400.0
 
-    battery_state = BatteryState(
-        soc_kwh=4.4, soc_percent=44.0, power_kw=0.4, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state)
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
     assert coord.charge_eff_correction == 1.0
@@ -3137,10 +3143,7 @@ def test_discharge_calibration_no_sample_when_plan_overridden(hass):
     coord._effective_mode = "zero_grid"
     coord._controller_schedule_w = 0.0
 
-    battery_state = BatteryState(
-        soc_kwh=5.9, soc_percent=59.0, power_kw=0.0, mode="idle"
-    )
-    coord._update_discharge_eff_calibration(battery_state)
+    coord._update_discharge_eff_calibration()
 
     assert coord.discharge_eff_sample_count == 0
     assert coord.discharge_eff_correction == 1.0
@@ -3149,20 +3152,18 @@ def test_discharge_calibration_no_sample_when_plan_overridden(hass):
 def test_discharge_calibration_samples_when_plan_executed(hass):
     """Discharge calibration samples normally when the plan was executed."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["discharging"],
-        soc_schedule_kwh=[6.0, 4.0],  # planned delta = 2.0 kWh down
+    _plan_battery_step(
+        coord,
+        action=ACTION_DISCHARGING,
+        planned_delta_kwh=2.0,
+        actual_delta_kwh=1.6,
+        prev_soc_kwh=6.0,
     )
-    _mark_plan_executed(coord)
 
-    # Actual delta = 1.6 kWh down → ratio = 0.8
-    battery_state = BatteryState(
-        soc_kwh=4.4, soc_percent=44.0, power_kw=-1.0, mode="discharging"
-    )
-    coord._update_discharge_eff_calibration(battery_state)
+    coord._update_discharge_eff_calibration()
 
     assert coord.discharge_eff_sample_count == 1
-    assert coord._discharge_eff_samples[0] == pytest.approx(0.8)
+    assert _calibration(coord, ACTION_DISCHARGING).samples[0] == pytest.approx(0.8)
     assert coord.discharge_eff_correction == pytest.approx(0.8)
 
 
@@ -3174,20 +3175,20 @@ def test_discharge_calibration_skips_when_crossing_low_soc_derating(hass):
     corrupt the persisted calibration (mirror of the high-SoC charge guard).
     """
     coord = _make_coordinator(hass)
-    coord.battery_config.low_soc_discharge_threshold_pct = 50.0
-    coord.battery_config.low_soc_max_discharge_kw = 0.5
+    cfg = coord._individual_battery_configs[0][1]
+    cfg.low_soc_discharge_threshold_pct = 50.0
+    cfg.low_soc_max_discharge_kw = 0.5
 
     # capacity 10 kWh → threshold at 5.0 kWh; plan 6.0 → 4.0 crosses it
-    coord._last_result = _make_fake_result(
-        mode_schedule=["discharging"],
-        soc_schedule_kwh=[6.0, 4.0],
+    _plan_battery_step(
+        coord,
+        action=ACTION_DISCHARGING,
+        planned_delta_kwh=2.0,
+        actual_delta_kwh=0.8,
+        prev_soc_kwh=6.0,
     )
-    _mark_plan_executed(coord)
 
-    battery_state = BatteryState(
-        soc_kwh=5.2, soc_percent=52.0, power_kw=-1.0, mode="discharging"
-    )
-    coord._update_discharge_eff_calibration(battery_state)
+    coord._update_discharge_eff_calibration()
 
     assert coord.discharge_eff_sample_count == 0
     assert coord.discharge_eff_correction == pytest.approx(1.0)
@@ -3196,23 +3197,23 @@ def test_discharge_calibration_skips_when_crossing_low_soc_derating(hass):
 def test_discharge_calibration_samples_above_low_soc_derating(hass):
     """Sampling continues when derating is configured but the step stays above it."""
     coord = _make_coordinator(hass)
-    coord.battery_config.low_soc_discharge_threshold_pct = 20.0
-    coord.battery_config.low_soc_max_discharge_kw = 0.5
+    cfg = coord._individual_battery_configs[0][1]
+    cfg.low_soc_discharge_threshold_pct = 20.0
+    cfg.low_soc_max_discharge_kw = 0.5
 
     # threshold at 2.0 kWh; plan 6.0 → 4.0 stays well above it
-    coord._last_result = _make_fake_result(
-        mode_schedule=["discharging"],
-        soc_schedule_kwh=[6.0, 4.0],
+    _plan_battery_step(
+        coord,
+        action=ACTION_DISCHARGING,
+        planned_delta_kwh=2.0,
+        actual_delta_kwh=1.6,
+        prev_soc_kwh=6.0,
     )
-    _mark_plan_executed(coord)
 
-    battery_state = BatteryState(
-        soc_kwh=4.4, soc_percent=44.0, power_kw=-1.0, mode="discharging"
-    )
-    coord._update_discharge_eff_calibration(battery_state)
+    coord._update_discharge_eff_calibration()
 
     assert coord.discharge_eff_sample_count == 1
-    assert coord._discharge_eff_samples[0] == pytest.approx(0.8)
+    assert _calibration(coord, ACTION_DISCHARGING).samples[0] == pytest.approx(0.8)
 
 
 # Feed-in interval handling
@@ -4114,96 +4115,108 @@ def _coordinator_with_counters(hass, capacity_kwh=10.0, soc_state="50"):
 def test_calibration_prefers_the_energy_counter_over_the_soc_delta(hass):
     """The counter measures the same energy without the SoC sensor's step size."""
     coord = _coordinator_with_counters(hass)
-    hass.states.async_set("sensor.bat_charged", "100.0", {"unit_of_measurement": "kWh"})
-    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
+    coord._energy_counter_snapshot = {"bat1": {"charged": 100.0, "discharged": 50.0}}
     hass.states.async_set("sensor.bat_charged", "100.9", {"unit_of_measurement": "kWh"})
     hass.states.async_set(
         "sensor.bat_discharged", "50.0", {"unit_of_measurement": "kWh"}
     )
 
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
-    )
-    _mark_plan_executed(coord)
+    # SoC sensor still reads its starting value — a SoC-based sample would be 0.
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=0.0)
+    coord._energy_counter_snapshot = {"bat1": {"charged": 100.0, "discharged": 50.0}}
 
-    # SoC sensor still reads 50 % (5.0 kWh) — a SoC-based sample would be 0.0.
-    battery_state = BatteryState(
-        soc_kwh=5.0, soc_percent=50.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+    coord._update_charge_eff_calibration(coord._read_energy_totals())
 
     # 0.9 kWh counted against 1.0 kWh planned
-    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+    assert _calibration(coord).samples[0] == pytest.approx(0.9)
 
 
 def test_calibration_uses_the_discharge_counter(hass):
     coord = _coordinator_with_counters(hass)
-    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
     hass.states.async_set("sensor.bat_charged", "100.0", {"unit_of_measurement": "kWh"})
     hass.states.async_set(
         "sensor.bat_discharged", "51.8", {"unit_of_measurement": "kWh"}
     )
 
-    coord._last_result = _make_fake_result(
-        mode_schedule=["discharging"],
-        soc_schedule_kwh=[6.0, 4.0],  # planned drop = 2.0 kWh
+    _plan_battery_step(
+        coord,
+        action=ACTION_DISCHARGING,
+        planned_delta_kwh=2.0,
+        actual_delta_kwh=0.0,
+        prev_soc_kwh=6.0,
     )
-    _mark_plan_executed(coord)
+    coord._energy_counter_snapshot = {"bat1": {"charged": 100.0, "discharged": 50.0}}
 
-    battery_state = BatteryState(
-        soc_kwh=6.0, soc_percent=60.0, power_kw=-1.0, mode="discharging"
-    )
-    coord._update_discharge_eff_calibration(battery_state, coord._read_energy_totals())
+    coord._update_discharge_eff_calibration(coord._read_energy_totals())
 
-    assert coord._discharge_eff_samples[0] == pytest.approx(0.9)
+    assert _calibration(coord, ACTION_DISCHARGING).samples[0] == pytest.approx(0.9)
 
 
 def test_calibration_falls_back_to_soc_when_counters_absent(hass):
     """No counters configured: the SoC delta still drives the calibration."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],
-    )
-    _mark_plan_executed(coord)
-    battery_state = BatteryState(
-        soc_kwh=5.9, soc_percent=59.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=0.9)
 
-    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+    coord._update_charge_eff_calibration(coord._read_energy_totals())
+
+    assert _calibration(coord).samples[0] == pytest.approx(0.9)
 
 
 def test_calibration_ignores_a_counter_reset(hass):
     """A total_increasing counter that jumped backwards must not be used."""
     coord = _coordinator_with_counters(hass)
-    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
     # Meter replaced: the total restarted from zero.
     hass.states.async_set("sensor.bat_charged", "0.4", {"unit_of_measurement": "kWh"})
     hass.states.async_set(
         "sensor.bat_discharged", "50.0", {"unit_of_measurement": "kWh"}
     )
 
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],
-    )
-    _mark_plan_executed(coord)
     # SoC says the step went fine, so the fallback path produces the sample.
-    battery_state = BatteryState(
-        soc_kwh=5.9, soc_percent=59.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=0.9)
+    coord._energy_counter_snapshot = {"bat1": {"charged": 100.0, "discharged": 50.0}}
 
-    assert coord._charge_eff_samples[0] == pytest.approx(0.9)
+    coord._update_charge_eff_calibration(coord._read_energy_totals())
+
+    assert _calibration(coord).samples[0] == pytest.approx(0.9)
 
 
 def test_calibration_ignores_an_unavailable_counter(hass):
     coord = _coordinator_with_counters(hass)
-    coord._energy_counter_snapshot = {"charged": 100.0, "discharged": 50.0}
     hass.states.async_set("sensor.bat_charged", "unavailable")
-    assert coord._read_energy_totals()["charged"] is None
+    assert coord._read_energy_totals()["bat1"]["charged"] is None
+
+
+def test_counters_are_read_per_battery(hass):
+    """Each pack's throughput is kept apart; a fleet sum cannot say who moved it."""
+    coord = _make_coordinator(
+        hass,
+        battery_subentries=[
+            (
+                "bat1",
+                {
+                    CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.a_charged",
+                    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR: "sensor.a_discharged",
+                },
+            ),
+            (
+                "bat2",
+                {
+                    CONF_BATTERY_ENERGY_CHARGED_SENSOR: "sensor.b_charged",
+                    CONF_BATTERY_ENERGY_DISCHARGED_SENSOR: "sensor.b_discharged",
+                },
+            ),
+        ],
+    )
+    hass.states.async_set("sensor.a_charged", "10.0", {"unit_of_measurement": "kWh"})
+    hass.states.async_set("sensor.a_discharged", "4.0", {"unit_of_measurement": "kWh"})
+    hass.states.async_set("sensor.b_charged", "7000", {"unit_of_measurement": "Wh"})
+    hass.states.async_set("sensor.b_discharged", "1.0", {"unit_of_measurement": "kWh"})
+
+    totals = coord._read_energy_totals()
+
+    assert totals["bat1"]["charged"] == pytest.approx(10.0)
+    assert totals["bat2"]["charged"] == pytest.approx(7.0)
+    assert totals["bat2"]["discharged"] == pytest.approx(1.0)
 
 
 def test_soc_quantum_raises_the_sampling_threshold(hass):
@@ -4233,15 +4246,10 @@ def test_small_step_is_skipped_on_a_coarse_soc_sensor(hass):
     coord._battery_subentries = [("bat1", {CONF_BATTERY_SOC_SENSOR: "sensor.test_soc"})]
     hass.states.async_set("sensor.test_soc", "50", {"unit_of_measurement": "%"})
 
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 5.2],  # planned delta = 0.2 kWh < 0.4 kWh floor
-    )
-    _mark_plan_executed(coord)
-    battery_state = BatteryState(
-        soc_kwh=5.1, soc_percent=51.0, power_kw=1.0, mode="charging"
-    )
-    coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+    # planned delta = 0.2 kWh, below the 0.4 kWh floor this sensor implies
+    _plan_battery_step(coord, planned_delta_kwh=0.2, actual_delta_kwh=0.1)
+
+    coord._update_charge_eff_calibration(coord._read_energy_totals())
 
     assert coord.charge_eff_sample_count == 0
 
@@ -4254,18 +4262,13 @@ def test_symmetric_noise_does_not_bias_the_correction(hass):
     battery.
     """
     coord = _coordinator_with_counters(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"],
-        soc_schedule_kwh=[5.0, 6.0],  # planned delta = 1.0 kWh
-    )
-    _mark_plan_executed(coord)
-    battery_state = BatteryState(
-        soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging"
-    )
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=1.0)
 
     charged = 100.0
     for actual in (0.8, 1.2, 0.9, 1.1, 1.3, 0.7):
-        coord._energy_counter_snapshot = {"charged": charged, "discharged": 0.0}
+        coord._energy_counter_snapshot = {
+            "bat1": {"charged": charged, "discharged": 0.0}
+        }
         charged += actual
         hass.states.async_set(
             "sensor.bat_charged", f"{charged}", {"unit_of_measurement": "kWh"}
@@ -4273,7 +4276,7 @@ def test_symmetric_noise_does_not_bias_the_correction(hass):
         hass.states.async_set(
             "sensor.bat_discharged", "0.0", {"unit_of_measurement": "kWh"}
         )
-        coord._update_charge_eff_calibration(battery_state, coord._read_energy_totals())
+        coord._update_charge_eff_calibration(coord._read_energy_totals())
 
     assert coord.charge_eff_sample_count == 6
     assert coord.charge_eff_correction == pytest.approx(1.0, abs=1e-6)
@@ -4291,14 +4294,9 @@ def test_symmetric_noise_does_not_bias_the_correction(hass):
 def test_calibration_reports_a_taken_sample(hass):
     """The happy path names itself, so 'no reason given' is never ambiguous."""
     coord = _make_coordinator(hass)
-    coord._last_result = _make_fake_result(
-        mode_schedule=["charging"], soc_schedule_kwh=[5.0, 6.0]
-    )
-    _mark_plan_executed(coord)
+    _plan_battery_step(coord, planned_delta_kwh=1.0, actual_delta_kwh=1.0)
 
-    coord._update_charge_eff_calibration(
-        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
-    )
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_last_result == CALIBRATION_SAMPLED
 
@@ -4312,9 +4310,7 @@ def test_calibration_reports_dc_coupling_as_the_blocker(hass):
     )
     _mark_plan_executed(coord)
 
-    coord._update_charge_eff_calibration(
-        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
-    )
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
     assert coord.charge_eff_last_result == CALIBRATION_DC_COUPLED
@@ -4330,9 +4326,7 @@ def test_calibration_reports_a_plan_that_was_never_executed(hass):
     coord._effective_mode = "zero_grid"
     coord._controller_schedule_w = 0.0
 
-    coord._update_charge_eff_calibration(
-        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
-    )
+    coord._update_charge_eff_calibration()
 
     assert coord.charge_eff_sample_count == 0
     assert coord.charge_eff_last_result == CALIBRATION_PLAN_NOT_EXECUTED
@@ -4346,9 +4340,7 @@ def test_calibration_reports_that_the_direction_was_not_planned(hass):
     )
     _mark_plan_executed(coord)
 
-    coord._update_discharge_eff_calibration(
-        BatteryState(soc_kwh=6.0, soc_percent=60.0, power_kw=1.0, mode="charging")
-    )
+    coord._update_discharge_eff_calibration()
 
     assert coord.discharge_eff_last_result == CALIBRATION_NO_PLAN
 
@@ -4366,9 +4358,111 @@ def test_calibration_starts_out_admitting_it_knows_nothing(hass):
 def test_a_correction_within_noise_of_nominal_is_reported_as_not_applied(hass):
     """1.0 is stored but never handed to the optimizer; applied must reflect that."""
     coord = _make_coordinator(hass)
+    calibration = _calibration(coord)
+    calibration.samples.append(1.0)
 
-    coord._charge_eff_correction = 0.999
+    calibration.correction = 0.999
     assert coord.charge_eff_applied is False
 
-    coord._charge_eff_correction = 0.94
+    calibration.correction = 0.94
     assert coord.charge_eff_applied is True
+
+
+def test_the_fleet_correction_is_capacity_weighted_across_batteries(hass):
+    """The DP gets one number, and it has to reflect how much pack it describes."""
+    coord = _make_coordinator(
+        hass,
+        battery_subentries=[
+            ("small", {CONF_MAX_CHARGE_POWER_KW: 1.0, CONF_CAPACITY_KWH: 5.0}),
+            ("large", {CONF_MAX_CHARGE_POWER_KW: 1.0, CONF_CAPACITY_KWH: 15.0}),
+        ],
+    )
+    for sid, correction in (("small", 0.80), ("large", 0.90)):
+        direction = coord.battery_calibrations[sid].charge
+        direction.samples.append(correction)
+        direction.correction = correction
+
+    # (0.80 x 5 + 0.90 x 15) / 20
+    assert coord.charge_eff_correction == pytest.approx(0.875)
+
+
+def test_the_calibration_report_names_every_battery_and_direction(hass):
+    """Diagnostics has to carry the breakdown, or the fleet average is all there is."""
+    coord = _make_coordinator(
+        hass,
+        battery_subentries=[
+            ("bat1", {CONF_NAME: "Marstek", CONF_MAX_CHARGE_POWER_KW: 1.2}),
+            ("bat2", {CONF_MAX_CHARGE_POWER_KW: 1.2}),
+        ],
+    )
+    charge = coord.battery_calibrations["bat1"].charge
+    charge.samples.append(0.88)
+    charge.correction = 0.88
+
+    report = coord.battery_calibration_report()
+
+    assert report["bat1"]["name"] == "Marstek"
+    assert report["bat1"]["charge"]["correction"] == pytest.approx(0.88)
+    assert report["bat1"]["charge"]["samples"] == 1
+    assert report["bat1"]["discharge"]["samples"] == 0
+    # A battery without a configured name still has to appear.
+    assert report["bat2"]["name"] == "bat2"
+
+
+def test_calibration_state_reports_the_battery_the_sensor_asked_for(hass):
+    """The per-battery sensors read through this, one pack and one direction."""
+    coord = _make_coordinator(hass)
+    charge = _calibration(coord, ACTION_CHARGING)
+    charge.samples.append(0.9)
+    charge.correction = 0.9
+
+    assert coord.battery_calibration_state("bat1", ACTION_CHARGING) == (
+        pytest.approx(0.9),
+        1,
+        True,
+        CALIBRATION_NO_RESULT,
+    )
+    correction, samples, applied, _ = coord.battery_calibration_state(
+        "bat1", ACTION_DISCHARGING
+    )
+    assert (correction, samples, applied) == (1.0, 0, False)
+
+
+def test_calibration_state_of_an_unknown_battery_admits_it_knows_nothing(hass):
+    """A subentry the coordinator has never seen must not report a clean 100%."""
+    coord = _make_coordinator(hass)
+
+    correction, samples, applied, last_result = coord.battery_calibration_state(
+        "not-a-battery", ACTION_CHARGING
+    )
+
+    assert (correction, samples, applied) == (1.0, 0, False)
+    assert last_result == CALIBRATION_NO_RESULT
+
+
+def test_the_fleet_reason_is_nothing_when_there_are_no_batteries(hass):
+    """With no packs configured there is no evidence and no reason to invent one."""
+    coord = _make_coordinator(hass, battery_subentries=[])
+
+    assert coord.charge_eff_last_result == CALIBRATION_NO_RESULT
+    assert coord.charge_eff_correction == 1.0
+
+
+def test_an_unmeasured_battery_does_not_dilute_a_measured_one(hass):
+    """A pack the dispatcher never used carries no evidence, so it carries no weight.
+
+    Averaging its nominal 1.0 in would report half the derating that was
+    actually observed on the pack that did the work.
+    """
+    coord = _make_coordinator(
+        hass,
+        battery_subentries=[
+            ("worked", {CONF_MAX_CHARGE_POWER_KW: 1.0, CONF_CAPACITY_KWH: 10.0}),
+            ("idle", {CONF_MAX_CHARGE_POWER_KW: 1.0, CONF_CAPACITY_KWH: 10.0}),
+        ],
+    )
+    measured = coord.battery_calibrations["worked"].charge
+    measured.samples.append(0.80)
+    measured.correction = 0.80
+
+    assert coord.charge_eff_correction == pytest.approx(0.80)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -236,7 +236,8 @@ async def test_diagnostics_carries_the_calibration_report(
     anything about this installation, or why it has not.
     """
     mock_config_entry.subentries = {
-        "pv1": MagicMock(title="South Array", subentry_type="pv", data={})
+        "pv1": MagicMock(title="South Array", subentry_type="pv", data={}),
+        "bat1": MagicMock(title="Marstek", subentry_type="battery", data={}),
     }
 
     weather_coord = MagicMock()
@@ -267,6 +268,23 @@ async def test_diagnostics_carries_the_calibration_report(
         "discharge_eff_samples": 0,
         "discharge_eff_applied": False,
         "discharge_eff_last_result": "dc_coupled_pv",
+        "battery_calibration": {
+            "bat1": {
+                "name": "Marstek",
+                "charge": {
+                    "correction": 0.88,
+                    "samples": 12,
+                    "applied": True,
+                    "last_result": "sampled",
+                },
+                "discharge": {
+                    "correction": 1.0,
+                    "samples": 0,
+                    "applied": False,
+                    "last_result": "battery_not_dispatched",
+                },
+            }
+        },
         "timestamp": "2024-01-01T00:00:00",
     }
     optimization_coord.last_update_success = True
@@ -304,3 +322,11 @@ async def test_diagnostics_carries_the_calibration_report(
     pv_cal = diagnostics["forecast"]["pv_calibration"]
     assert pv_cal["South Array"]["correction"] == 0.87
     assert pv_cal["South Array"]["samples"] == 64
+
+    # The fleet figures above are an average; only the per-battery report can
+    # show that this pack is the one that has derated.
+    battery_cal = opt["battery_calibration"]
+    assert battery_cal["Marstek"]["charge"]["correction"] == 0.88
+    assert (
+        battery_cal["Marstek"]["discharge"]["last_result"] == "battery_not_dispatched"
+    )

--- a/tests/test_efficiency_calibration_storage.py
+++ b/tests/test_efficiency_calibration_storage.py
@@ -8,6 +8,9 @@ writing it out, and resetting it.
 A fault here is quiet and durable. A correction that fails to load silently
 throws away weeks of calibration; one that fails to save comes back after
 every restart; one that resets without persisting reappears on the next load.
+
+Each battery keeps its own store, so these all address one pack's calibration
+rather than a fleet-wide one.
 """
 
 from __future__ import annotations
@@ -17,15 +20,28 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from custom_components.battery_controller.const import ACTION_CHARGING
+
 
 @pytest.fixture
 def coord_with_fake_stores(optimization_coordinator):
     """Coordinator whose calibration stores are in-memory doubles."""
     coord = optimization_coordinator
-    for calibration in (coord._charge_calibration, coord._discharge_calibration):
-        calibration.store.async_load = AsyncMock(return_value=None)
-        calibration.store.async_save = AsyncMock()
+    for battery in coord.battery_calibrations.values():
+        for calibration in battery.both():
+            calibration.store.async_load = AsyncMock(return_value=None)
+            calibration.store.async_save = AsyncMock()
+            calibration.legacy_store.async_load = AsyncMock(return_value=None)
     return coord
+
+
+def _charge(coord):
+    """The single fixture battery's charge-side calibration."""
+    return coord.battery_calibrations["bat1"].charge
+
+
+def _discharge(coord):
+    return coord.battery_calibrations["bat1"].discharge
 
 
 # --------------------------------------------------------------------------
@@ -40,48 +56,48 @@ async def test_load_without_stored_data_leaves_nominal_state(coord_with_fake_sto
     await coord._async_load_charge_eff_calibration()
 
     assert coord.charge_eff_correction == 1.0
-    assert list(coord._charge_eff_samples) == []
+    assert list(_charge(coord).samples) == []
 
 
 async def test_load_restores_samples_and_correction(coord_with_fake_stores):
     """The whole point: learning survives a restart."""
     coord = coord_with_fake_stores
-    coord._charge_calibration.store.async_load = AsyncMock(
+    _charge(coord).store.async_load = AsyncMock(
         return_value={"samples": [0.93, 0.94, 0.92], "correction": 0.935}
     )
 
     await coord._async_load_charge_eff_calibration()
 
     assert coord.charge_eff_correction == pytest.approx(0.935)
-    assert list(coord._charge_eff_samples) == [0.93, 0.94, 0.92]
+    assert list(_charge(coord).samples) == [0.93, 0.94, 0.92]
 
 
 async def test_load_keeps_only_the_most_recent_samples(coord_with_fake_stores):
     """The window is bounded, so an oversized file must not grow it."""
     coord = coord_with_fake_stores
     stored = [0.90 + i / 1000 for i in range(30)]
-    coord._charge_calibration.store.async_load = AsyncMock(
+    _charge(coord).store.async_load = AsyncMock(
         return_value={"samples": stored, "correction": 0.95}
     )
 
     await coord._async_load_charge_eff_calibration()
 
-    assert coord._charge_eff_samples.maxlen == 20
+    assert _charge(coord).samples.maxlen == 20
     assert coord.charge_eff_sample_count == 20
-    assert list(coord._charge_eff_samples) == stored[-20:]
+    assert list(_charge(coord).samples) == stored[-20:]
 
 
 async def test_load_coerces_a_string_correction(coord_with_fake_stores):
     """JSON round-trips can hand back a string; it must not poison the maths."""
     coord = coord_with_fake_stores
-    coord._charge_calibration.store.async_load = AsyncMock(
+    _charge(coord).store.async_load = AsyncMock(
         return_value={"samples": [], "correction": "0.97"}
     )
 
     await coord._async_load_charge_eff_calibration()
 
-    assert isinstance(coord._charge_eff_correction, float)
-    assert coord.charge_eff_correction == pytest.approx(0.97)
+    assert isinstance(_charge(coord).correction, float)
+    assert _charge(coord).correction == pytest.approx(0.97)
 
 
 async def test_load_falls_back_to_nominal_when_correction_is_absent(
@@ -89,13 +105,47 @@ async def test_load_falls_back_to_nominal_when_correction_is_absent(
 ):
     """A partial file must not leave the correction undefined."""
     coord = coord_with_fake_stores
-    coord._charge_calibration.store.async_load = AsyncMock(
-        return_value={"samples": [0.9]}
-    )
+    _charge(coord).store.async_load = AsyncMock(return_value={"samples": [0.9]})
 
     await coord._async_load_charge_eff_calibration()
 
     assert coord.charge_eff_correction == 1.0
+
+
+async def test_load_seeds_a_battery_from_the_old_fleet_wide_store(
+    coord_with_fake_stores,
+):
+    """Learning from before the split is a prior, not something to throw away.
+
+    The fleet value was measured on whichever pack the dispatcher happened to
+    pick, so it is no longer the answer — but it beats starting from nominal,
+    and each sample the pack takes replaces more of it.
+    """
+    coord = coord_with_fake_stores
+    _charge(coord).store.async_load = AsyncMock(return_value=None)
+    _charge(coord).legacy_store.async_load = AsyncMock(
+        return_value={"samples": [0.90, 0.92], "correction": 0.91}
+    )
+
+    await coord._async_load_charge_eff_calibration()
+
+    assert coord.charge_eff_correction == pytest.approx(0.91)
+    assert list(_charge(coord).samples) == [0.90, 0.92]
+
+
+async def test_a_batterys_own_store_wins_over_the_legacy_one(coord_with_fake_stores):
+    """Once a pack has measured itself, the shared history is no longer used."""
+    coord = coord_with_fake_stores
+    _charge(coord).store.async_load = AsyncMock(
+        return_value={"samples": [0.80], "correction": 0.80}
+    )
+    _charge(coord).legacy_store.async_load = AsyncMock(
+        return_value={"samples": [0.99], "correction": 0.99}
+    )
+
+    await coord._async_load_charge_eff_calibration()
+
+    assert coord.charge_eff_correction == pytest.approx(0.80)
 
 
 # --------------------------------------------------------------------------
@@ -105,12 +155,12 @@ async def test_load_falls_back_to_nominal_when_correction_is_absent(
 
 async def test_save_writes_samples_and_correction(coord_with_fake_stores):
     coord = coord_with_fake_stores
-    coord._charge_eff_samples = deque([0.91, 0.93], maxlen=20)
-    coord._charge_eff_correction = 0.92
+    _charge(coord).samples = deque([0.91, 0.93], maxlen=20)
+    _charge(coord).correction = 0.92
 
     await coord._async_save_charge_eff_calibration()
 
-    coord._charge_calibration.store.async_save.assert_awaited_once_with(
+    _charge(coord).store.async_save.assert_awaited_once_with(
         {"samples": [0.91, 0.93], "correction": 0.92}
     )
 
@@ -118,30 +168,48 @@ async def test_save_writes_samples_and_correction(coord_with_fake_stores):
 async def test_save_serialises_the_deque_as_a_list(coord_with_fake_stores):
     """A deque is not JSON-serialisable, so the payload must be a plain list."""
     coord = coord_with_fake_stores
-    coord._discharge_eff_samples = deque([0.88], maxlen=20)
+    _discharge(coord).samples = deque([0.88], maxlen=20)
 
     await coord._async_save_discharge_eff_calibration()
 
-    payload = coord._discharge_calibration.store.async_save.await_args.args[0]
+    payload = _discharge(coord).store.async_save.await_args.args[0]
     assert isinstance(payload["samples"], list)
 
 
 async def test_save_then_load_round_trips(coord_with_fake_stores):
     """What is written back must be exactly what comes out again."""
     coord = coord_with_fake_stores
-    coord._charge_eff_samples = deque([0.94, 0.95], maxlen=20)
-    coord._charge_eff_correction = 0.945
+    _charge(coord).samples = deque([0.94, 0.95], maxlen=20)
+    _charge(coord).correction = 0.945
 
     await coord._async_save_charge_eff_calibration()
-    written = coord._charge_calibration.store.async_save.await_args.args[0]
+    written = _charge(coord).store.async_save.await_args.args[0]
 
-    coord._charge_eff_samples = deque(maxlen=20)
-    coord._charge_eff_correction = 1.0
-    coord._charge_calibration.store.async_load = AsyncMock(return_value=written)
+    _charge(coord).samples = deque(maxlen=20)
+    _charge(coord).correction = 1.0
+    _charge(coord).store.async_load = AsyncMock(return_value=written)
     await coord._async_load_charge_eff_calibration()
 
-    assert list(coord._charge_eff_samples) == [0.94, 0.95]
+    assert list(_charge(coord).samples) == [0.94, 0.95]
     assert coord.charge_eff_correction == pytest.approx(0.945)
+
+
+async def test_each_battery_persists_to_its_own_key(optimization_coordinator, hass):
+    """Two packs must not share a store, or one overwrites the other's history."""
+    from tests.conftest import make_optimization_coordinator
+
+    coord = make_optimization_coordinator(
+        hass,
+        battery_subentries=[("bat1", {}), ("bat2", {})],
+    )
+
+    keys = {
+        sid: coord.battery_calibrations[sid].for_action(ACTION_CHARGING).store.key
+        for sid in ("bat1", "bat2")
+    }
+
+    assert keys["bat1"] != keys["bat2"]
+    assert "bat1" in keys["bat1"] and "bat2" in keys["bat2"]
 
 
 # --------------------------------------------------------------------------
@@ -152,28 +220,28 @@ async def test_save_then_load_round_trips(coord_with_fake_stores):
 async def test_reset_charge_clears_state_and_persists(coord_with_fake_stores):
     """Resetting must reach storage, or it comes back on the next load."""
     coord = coord_with_fake_stores
-    coord._charge_eff_samples = deque([0.90, 0.91], maxlen=20)
-    coord._charge_eff_correction = 0.905
+    _charge(coord).samples = deque([0.90, 0.91], maxlen=20)
+    _charge(coord).correction = 0.905
 
     await coord.async_reset_charge_eff_calibration()
 
-    assert list(coord._charge_eff_samples) == []
+    assert list(_charge(coord).samples) == []
     assert coord.charge_eff_correction == 1.0
-    coord._charge_calibration.store.async_save.assert_awaited_once_with(
+    _charge(coord).store.async_save.assert_awaited_once_with(
         {"samples": [], "correction": 1.0}
     )
 
 
 async def test_reset_discharge_clears_state_and_persists(coord_with_fake_stores):
     coord = coord_with_fake_stores
-    coord._discharge_eff_samples = deque([0.87], maxlen=20)
-    coord._discharge_eff_correction = 0.87
+    _discharge(coord).samples = deque([0.87], maxlen=20)
+    _discharge(coord).correction = 0.87
 
     await coord.async_reset_discharge_eff_calibration()
 
-    assert list(coord._discharge_eff_samples) == []
+    assert list(_discharge(coord).samples) == []
     assert coord.discharge_eff_correction == 1.0
-    coord._discharge_calibration.store.async_save.assert_awaited_once_with(
+    _discharge(coord).store.async_save.assert_awaited_once_with(
         {"samples": [], "correction": 1.0}
     )
 
@@ -185,7 +253,7 @@ async def test_reset_of_untouched_calibration_still_persists(coord_with_fake_sto
     await coord.async_reset_charge_eff_calibration()
 
     assert coord.charge_eff_correction == 1.0
-    coord._charge_calibration.store.async_save.assert_awaited_once()
+    _charge(coord).store.async_save.assert_awaited_once()
 
 
 async def test_charge_and_discharge_calibrations_are_independent(
@@ -193,11 +261,11 @@ async def test_charge_and_discharge_calibrations_are_independent(
 ):
     """Resetting one direction must not disturb the other."""
     coord = coord_with_fake_stores
-    coord._discharge_eff_samples = deque([0.88, 0.89], maxlen=20)
-    coord._discharge_eff_correction = 0.885
+    _discharge(coord).samples = deque([0.88, 0.89], maxlen=20)
+    _discharge(coord).correction = 0.885
 
     await coord.async_reset_charge_eff_calibration()
 
-    assert list(coord._discharge_eff_samples) == [0.88, 0.89]
+    assert list(_discharge(coord).samples) == [0.88, 0.89]
     assert coord.discharge_eff_correction == pytest.approx(0.885)
-    coord._discharge_calibration.store.async_save.assert_not_awaited()
+    _discharge(coord).store.async_save.assert_not_awaited()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -30,6 +30,8 @@ from custom_components.battery_controller.sensor import (
     BatteryScheduleSensor,
     BatteryShadowPriceSensor,
     BatterySoCSensor,
+    BatterySubentryChargeCalibrationSensor,
+    BatterySubentryDischargeCalibrationSensor,
     BatterySubentrySetpointSensor,
     BatterySubentrySoCSensor,
     ChargeEfficiencyCalibrationSensor,
@@ -1152,12 +1154,12 @@ async def test_sensor_async_setup_entry_with_battery_subentry():
 
     # Main entities + battery subentry entities
     assert len(added_calls) >= 2
-    # Battery subentry adds 2 entities (setpoint + SoC)
+    # Battery subentry adds setpoint, SoC and both calibration sensors
     battery_call = next(
         (c for c in added_calls if c[1].get("config_subentry_id") == "sub1"), None
     )
     assert battery_call is not None
-    assert len(battery_call[0]) == 2
+    assert len(battery_call[0]) == 4
 
 
 @pytest.mark.asyncio
@@ -1365,6 +1367,53 @@ def test_efficiency_calibration_sensors_have_distinct_unique_ids():
     discharge = DischargeEfficiencyCalibrationSensor(coord, _make_device(), entry)
 
     assert charge.unique_id != discharge.unique_id
+
+
+def test_per_battery_calibration_reads_its_own_battery(hass):
+    """Each pack's sensor must report that pack, not the fleet average.
+
+    The fleet correction averages the batteries together; when they differ it
+    describes neither, and a single derated pack is invisible in it.
+    """
+    coord = _make_opt_coord()
+    coord.battery_calibration_state = MagicMock(
+        side_effect=lambda sid, action: {
+            ("bat1", ACTION_CHARGING): (0.82, 12, True, "sampled"),
+            ("bat2", ACTION_CHARGING): (1.0, 0, False, "battery_not_dispatched"),
+        }[(sid, action)]
+    )
+    entry = _make_entry()
+
+    worked = BatterySubentryChargeCalibrationSensor(
+        coord, _make_device(), entry, "bat1", "Marstek"
+    )
+    idle = BatterySubentryChargeCalibrationSensor(
+        coord, _make_device(), entry, "bat2", "Marstek 2"
+    )
+
+    assert worked.native_value == pytest.approx(82.0)
+    assert worked.extra_state_attributes["samples"] == 12
+    assert idle.native_value == pytest.approx(100.0)
+    assert idle.extra_state_attributes["last_result"] == "battery_not_dispatched"
+    assert worked.unique_id != idle.unique_id
+
+
+def test_per_battery_calibration_names_the_battery_and_direction():
+    """Two directions on two packs is four entities; each needs its own identity."""
+    coord = _make_opt_coord()
+    coord.battery_calibration_state = MagicMock(return_value=(1.0, 0, False, "sampled"))
+    entry = _make_entry()
+
+    charge = BatterySubentryChargeCalibrationSensor(
+        coord, _make_device(), entry, "bat1", "Marstek"
+    )
+    discharge = BatterySubentryDischargeCalibrationSensor(
+        coord, _make_device(), entry, "bat1", "Marstek"
+    )
+
+    assert charge.unique_id != discharge.unique_id
+    assert "Marstek" in charge.name
+    assert charge.name != discharge.name
 
 
 def _make_pv_calibration_coord(


### PR DESCRIPTION
## Description

Five defects in the learned calibration, found while working out why the PV corrections on a four-array system spread from 0.72 to 1.18 between panels with identical tilt.

**PV: `applied` was true for arrays that had never derived anything.** Every array with samples is persisted, including the ones still filling their window, and `_async_load_pv_calibration` read those back unconditionally — handing each a correction of 1.0, which is exactly what `pv_correction_applied` reported (membership of `_pv_cal_correction`). A restart turned "never measured anything" into "being corrected". A correction is now restored only when the sample floor backs it, and `applied` shares its significance gate with `_sum_arrays` through one constant, so the sensor and the model cannot disagree.

**PV: the sample ignored how much time actually elapsed.** `_update_pv_calibration` accepts a window between 0.5× and 1.5× of a step but scored the meter delta against a fixed quarter hour of forecast energy. The forecast coordinator also refreshes when new weather arrives, so a delta covering 20 minutes was regularly compared against a snapshot describing 15 — a late run alone read as a 33 % better array. The planned energy is now stretched to the window that was measured.

**PV: two constants made the gain describe the weather rather than the array.** The 0.80 usable ceiling excluded exactly the steps with the best signal-to-noise ratio — a well-oriented array peaks near 0.85 of its rating on a clear day — so a south array learned only from its oblique, diffuse-dominated hours, where the transposition model is weakest, and applied that error all day. Typical DC/AC ratios put real clipping at 0.83–0.91, so the ceiling moves to 0.90. And a floor of 20 samples is about one afternoon of production, where the radiation forecast's bias for those hours *is* the correction; it moves to 60, which spans several days so cloud timing averages out.

**Battery: one fleet-wide ratio for a fleet that is never dispatched evenly.** The dispatcher concentrates a setpoint on one pack at a time, so the shared ratio measured whichever battery happened to be picked and then attributed it to all of them. A pack losing capacity was invisible — it only dragged the shared number down and had its healthy sibling planned pessimistically. Each battery now keeps its own window, its own storage key and its own pair of diagnostic sensors, scored against the setpoint *it* was given and its own efficiency curve at its own power. A pack that was not dispatched reports `battery_not_dispatched` and takes no sample.

The DP still plans one fleet SoC, so it is handed the capacity-weighted aggregate over the packs that have actually measured something. A battery that has never been dispatched carries no weight rather than a nominal 1.0 — averaging that in would report half the derating that was observed. On upgrade, a battery with nothing of its own seeds from the old fleet-wide store: no longer the answer, but a better prior than the datasheet, and replaced sample by sample.

**Note for existing installs:** raising the PV sample floor drops corrections derived from fewer than 60 observations on the next start. The samples are kept; the correction is re-derived once the window is full. That is intended — those values were built on a couple of dozen quarter-hours.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [x] Documentation updated if needed
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

Verified locally: 631 pytest tests pass, 89 jest tests pass, `pre-commit run --all-files` clean, mypy clean, coverage 95.9 %. `docs/algorithm.md`, `docs/how-it-works.md`, the analyzer's calibration card and `simulate_diagnostics.py` are updated. The DP itself is untouched, so `analyzer.js` and the DP half of `simulate_diagnostics.py` stay in sync with `optimizer.py`.
